### PR TITLE
Extensibility improvements

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1064,7 +1064,7 @@ function give_checkout_button_purchase( $form_id ) {
 		<span class="give-loading-animation"></span>
 	</div>
 	<?php
-	return apply_filters( 'give_checkout_button_purchase', ob_get_clean() );
+	return apply_filters( 'give_checkout_button_purchase', ob_get_clean(), $form_id );
 }
 
 /**

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -903,7 +903,7 @@ function give_payment_mode_select( $form_id ) {
 	<fieldset id="give-payment-mode-select">
 		<?php do_action( 'give_payment_mode_before_gateways_wrap' ); ?>
 		<div id="give-payment-mode-wrap">
-			<legend class="give-payment-mode-label"><?php _e( 'Select Payment Method', 'give' ); ?></legend>
+			<legend class="give-payment-mode-label"><?php echo apply_filters( 'give_checkout_payment_method_text', __( 'Select Payment Method', 'give' ) ); ?></legend>
 			<?php
 
 			do_action( 'give_payment_mode_before_gateways' ) ?>


### PR DESCRIPTION
### Purpose
- - -
The purpose of this pull request is primarily to address some pain points I recently encountered while working with the Give plugin on a client project. They wanted to update the text in places, and I found that difficult to do in some cases.

### Solution
- - -
- Added a Wordpress filter to allow developers to modify the 'Select Payment Method' legend text.
- Modified existing Wordpress filter controlling submit button text so that it passes `$form_id` to hooks. This allows developers to access form options when generating submit button text. In my case this was necessary to output default donation amount, e.g. "Donate $5.00 Now".