### PR TITLE
Show the shortcode button/dropdown conditionally

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -15,6 +15,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Filter: Do not show the Give shortcut button on Give Forms or Campaign posts
+ *
+ * @return bool
+ */
+function give_shortcode_button_condition() {
+
+	global $typenow;
+
+	if ( $typenow != 'give_forms' && $typenow != 'give_campaigns' ) {
+		return true;
+	}
+
+	return false;
+}
+
+add_filter( 'give_shortcode_button_condition', 'give_shortcode_button_condition' );
+
+
+/**
  * Get the form ID from the form $args
  *
  * @param $args


### PR DESCRIPTION
Use the `give_shortcode_button_condition` hook to hide the Give shortcut button on Give Form editors, etc.