### PR TITLE
The previous pull-request was a little unfinished/borked (sorry) This should do it.

### DIFF
--- a/includes/admin/shortcodes/shortcode-give-form.php
+++ b/includes/admin/shortcodes/shortcode-give-form.php
@@ -81,9 +81,9 @@ class Give_Shortcode_Donation_Form extends Give_Shortcode_Generator {
 				'label'   => __( 'Display Content:', 'give' ),
 				'tooltip' => __( 'Do you want to display the form content?', 'give' ),
 				'options' => array(
-					'none'           => __( 'No Content', 'give' ),
-					'give_pre_form'  => __( 'Display above the form fields', 'give' ),
-					'give_post_form' => __( 'Display below the form fields', 'give' ),
+					'none'  => __( 'No Content', 'give' ),
+					'above' => __( 'Display above the form fields', 'give' ),
+					'below' => __( 'Display below the form fields', 'give' ),
 				),
 			),
 			array(

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1120,7 +1120,7 @@ add_action( 'give_checkout_form_top', 'give_agree_to_terms_js', 10, 2 );
 function give_form_content( $form_id, $args ) {
 
 	$show_content = ( isset( $args['show_content'] ) && ! empty( $args['show_content'] ) )
-		? $args['display_style']
+		? $args['show_content']
 		: get_post_meta( $form_id, '_give_content_option', true );
 
 	if ( $show_content !== 'none' ) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -62,9 +62,20 @@ function give_form_shortcode( $atts, $content = null ) {
 		if ( $key == 'show_title' ) {
 			$atts[ $key ] = filter_var( $atts[ $key ], FILTER_VALIDATE_BOOLEAN );
 		}
+
 		//validate show_content value
-		if ( ( $key == 'show_content' && ! in_array( $value, array( 'none', 'above', 'below' ) ) )
-			|| ( $key == 'display_style' && ! in_array( $value, array( 'onpage', 'reveal', 'modal' ) ) )
+		if ( $key == 'show_content' ) {
+			if ( ! in_array( $value, array( 'none', 'above', 'below' ) ) ) {
+				$atts[ $key ] = '';
+			} else if ( $value == 'above' ) {
+				$atts[ $key ] = 'give_pre_form';
+			} else if ( $value == 'below' ) {
+				$atts[ $key ] = 'give_post_form';
+			}
+		}
+
+		//validate display_style and float_labels value
+		if ( ( $key == 'display_style' && ! in_array( $value, array( 'onpage', 'reveal', 'modal' ) ) )
 			|| ( $key == 'float_labels' && ! in_array( $value, array( 'enabled', 'disabled' ) ) ) ) {
 
 			$atts[ $key ] = '';


### PR DESCRIPTION
Ok, the shortcode "show_content" attribute now accepts three values:
- none
- above
- below