### PR TITLE
Checks to see if CMB2 plugin is installed first the uses included CMB…

### DIFF
--- a/includes/admin/register-settings.php
+++ b/includes/admin/register-settings.php
@@ -1017,7 +1017,7 @@ if ( ! function_exists( 'give_license_key_callback' ) ) {
 			$html .= '<input type="submit" class="button-secondary give-license-deactivate" name="' . $id . '_deactivate" value="' . __( 'Deactivate License', 'give' ) . '"/>';
 		} else {
 			//This license is not valid so delete it
-			give_delete_option($id);
+			give_delete_option( $id );
 		}
 
 		$html .= '<label for="give_settings[' . $id . ']"> ' . $field_description . '</label>';
@@ -1087,9 +1087,12 @@ function give_hook_callback( $args ) {
 /**
  * Get the CMB2 bootstrap!
  *
- * Super important!
+ * @description: Checks to see if CMB2 plugin is installed first the uses included CMB2; we can still use it even it it's not active. This prevents fatal error conflicts with other themes and users of the CMB2 WP.org plugin
+ *
  */
-if ( file_exists( GIVE_PLUGIN_DIR . '/includes/libraries/cmb2/init.php' ) ) {
+if ( file_exists( WP_PLUGIN_DIR . '/cmb2/init.php' ) ) {
+	require_once WP_PLUGIN_DIR . '/cmb2/init.php';
+} elseif ( file_exists( GIVE_PLUGIN_DIR . '/includes/libraries/cmb2/init.php' ) ) {
 	require_once GIVE_PLUGIN_DIR . '/includes/libraries/cmb2/init.php';
 } elseif ( file_exists( GIVE_PLUGIN_DIR . '/includes/libraries/CMB2/init.php' ) ) {
 	require_once GIVE_PLUGIN_DIR . '/includes/libraries/CMB2/init.php';

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,7 @@ We also really like WooCommerce. It's hands-down the most robust eCommerce platf
 * Fix: Multiple billing fields being output when multiple forms on a single page - https://github.com/WordImpress/Give/issues/310
 * Fix: Assume multiple give dropdown buttons - https://github.com/WordImpress/Give/issues/310
 * Fix: Give admin dashicon no longer lights up annoyingly on page load in wp-admin - https://github.com/WordImpress/Give/issues/315
+* Fix: Prevent fatal error if user has CMB2 plugin installed - https://github.com/WordImpress/Give/issues/321
 
 = 1.3.0.4 =
 * New: Added new filter for default form amount - https://github.com/WordImpress/Give/issues/301


### PR DESCRIPTION
…2; we can still use it even it it's not active. This prevents fatal error conflicts with other themes and users of the CMB2 WP.org plugin Fixes #321