### PR TITLE
Fix check in give_install_roles_on_network

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -215,7 +215,7 @@ function give_install_roles_on_network() {
 		return;
 	}
 
-	if ( ! in_array( 'give_manager', $wp_roles->roles ) ) {
+	if ( ! array_key_exists( 'give_manager', $wp_roles->roles ) ) {
 
 		// Create Give shop roles
 		$roles = new Give_Roles;


### PR DESCRIPTION
The `$wp_roles->roles` array is multidimensional, so checking for the presence of the `give_manager` role by using `in_array()` will always return false, and the plugin will re-initialize roles and capabilities on every admin page load (including admin-ajax calls). It's slowing down one of my clients' sites by about a second per page load. Use `array_key_exists()` instead and get faster admin load times!

