### PR TITLE
Fix user lifetime donation stat 

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -158,12 +158,12 @@ function give_update_payment_details( $data ) {
 		$previous_customer->remove_payment( $payment_id, false );
 		$customer->attach_payment( $payment_id, false );
 
-		// If purchase was completed and not ever refunded, adjust stats of customers
+        // Reduce previous user donation count and amoount.
+        $previous_customer->decrease_purchase_count();
+        $previous_customer->decrease_value( $curr_total );
+
+		// If purchase was completed and not ever refunded, adjust stats of new customers.
 		if ( 'revoked' == $status || 'publish' == $status ) {
-
-			$previous_customer->decrease_purchase_count();
-			$previous_customer->decrease_value( $curr_total );
-
 			$customer->increase_purchase_count();
 			$customer->increase_value( $new_total );
 		}

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -66,17 +66,7 @@ function give_update_payment_details( $data ) {
 
 	$curr_total = give_sanitize_amount( $payment->total );
 	$new_total  = give_sanitize_amount( $_POST['give-payment-total'] );
-
-    /**
-     * Payment total difference value can be:
-     *  zero ( in case amount not change)
-     *  or -ve (in case amount decrease)
-     *  or +ve (in case amount increase)
-     */
-    $payment_total_diff = $new_total - $curr_total;
-
-
-    $date       = date( 'Y-m-d', strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
+	$date       = date( 'Y-m-d', strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
 
 	$curr_customer_id = sanitize_text_field( $data['give-current-customer'] );
 	$new_customer_id  = sanitize_text_field( $data['customer-id'] );
@@ -169,14 +159,9 @@ function give_update_payment_details( $data ) {
 		}
 
 		$payment->customer_id = $customer->id;
-	} elseif( $payment_total_diff ){
-
-        if( $payment_total_diff > 0 ) {
-            $customer->increase_value( $payment_total_diff );
-        }else{
-            // Pass payment total difference as +ve value to decrease amount from user lifetime stat.
-            $customer->decrease_value( -$payment_total_diff );
-        }
+	} else{
+		// Update user donation stat.
+		$customer->update_donation_value( $curr_total, $new_total );
     }
 
 	// Set new meta values

--- a/includes/class-give-customer.php
+++ b/includes/class-give-customer.php
@@ -512,6 +512,46 @@ class Give_Customer {
 	}
 
 	/**
+	 * Decrease/Increase a customer's lifetime value
+     *
+     * This function will update donation stat on basis of current amount and new amount donation difference.
+     * Difference value can positive or negative. Negative value will decrease user donation stat while positive value increase donation stat.
+     *
+     *
+     * @access public
+	 * @since  1.0
+	 *
+	 * @param  float $curr_amount Current Donation amount
+	 * @param  float $new_amount  New ( changed ) Donation amount
+	 *
+	 * @return mixed              If successful, the new donation stat value, otherwise false
+	 */
+	public function update_donation_value( $curr_amount, $new_amount ) {
+        /**
+         * Payment total difference value can be:
+         *  zero   (in case amount not change)
+         *  or -ve (in case amount decrease)
+         *  or +ve (in case amount increase)
+         */
+        $payment_total_diff = $new_amount - $curr_amount;
+
+        // We do not need to update donation stat if donation did not change.
+        if( ! $payment_total_diff ) {
+            return false;
+        }
+
+
+        if( $payment_total_diff > 0 ) {
+            $this->increase_value( $payment_total_diff );
+        }else{
+            // Pass payment total difference as +ve value to decrease amount from user lifetime stat.
+            $this->decrease_value( -$payment_total_diff );
+        }
+
+        return $this->purchase_value;
+	}
+
+	/**
 	 * Get the parsed notes for a customer as an array
 	 *
 	 * @since  1.0


### PR DESCRIPTION
Increase/decrease user lifetime donation stat when user increase/decrease donation amount from payment detail page in wp backend.

Releated to https://github.com/WordImpress/Give/issues/714