### PR TITLE
Permission Error Messages

### DIFF
--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -260,7 +260,7 @@ function give_customer_delete( $args ) {
 	$customer_edit_role = apply_filters( 'give_edit_customers_role', 'edit_give_payments' );
 
 	if ( ! is_admin() || ! current_user_can( $customer_edit_role ) ) {
-		wp_die( __( 'You do not have permission to delete this donor.', 'give' ) );
+		wp_die( __( 'You do not have permission to delete donors.', 'give' ) );
 	}
 
 	if ( empty( $args ) ) {

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function give_update_payment_details( $data ) {
 
 	if ( ! current_user_can( 'edit_give_payments', $data['give_payment_id'] ) ) {
-		wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	check_admin_referer( 'give_update_payment_details_nonce' );
@@ -223,7 +223,7 @@ function give_trigger_purchase_delete( $data ) {
 		$payment_id = absint( $data['purchase_id'] );
 
 		if ( ! current_user_can( 'edit_give_payments', $payment_id ) ) {
-			wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+			wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 		}
 
 		give_delete_purchase( $payment_id );
@@ -243,7 +243,7 @@ function give_ajax_store_payment_note() {
 	$note       = wp_kses( $_POST['note'], array() );
 
 	if ( ! current_user_can( 'edit_give_payments', $payment_id ) ) {
-		wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	if ( empty( $payment_id ) ) {
@@ -276,7 +276,7 @@ function give_trigger_payment_note_deletion( $data ) {
 	}
 
 	if ( ! current_user_can( 'edit_give_payments', $data['payment_id'] ) ) {
-		wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	$edit_order_url = admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&view=view-order-details&give-message=payment-note-deleted&id=' . absint( $data['payment_id'] ) );
@@ -300,7 +300,7 @@ add_action( 'give_delete_payment_note', 'give_trigger_payment_note_deletion' );
 function give_ajax_delete_payment_note() {
 
 	if ( ! current_user_can( 'edit_give_payments', $_POST['payment_id'] ) ) {
-		wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	if ( give_delete_payment_note( $_POST['note_id'], $_POST['payment_id'] ) ) {

--- a/includes/admin/reporting/pdf-reports.php
+++ b/includes/admin/reporting/pdf-reports.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function give_generate_pdf( $data ) {
 
 	if ( ! current_user_can( 'view_give_reports' ) ) {
-		wp_die( __( 'You do not have permission to generate PDF sales reports', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to generate PDF sales reports.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'give_generate_pdf' ) ) {

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -81,7 +81,7 @@ add_action( 'admin_notices', 'give_show_upgrade_notices' );
 function give_trigger_upgrades() {
 
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
-		wp_die( __( 'You do not have permission to do Give upgrades', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to do Give upgrades.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	$give_version = get_option( 'give_version' );
@@ -176,7 +176,7 @@ function give_get_completed_upgrades() {
 function give_v132_upgrade_give_payment_customer_id() {
 	global $wpdb;
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
-		wp_die( __( 'You do not have permission to do Give upgrades', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to do Give upgrades.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	ignore_user_abort( true );
@@ -213,7 +213,7 @@ function give_v134_upgrade_give_offline_status() {
 	global $wpdb;
 
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
-		wp_die( __( 'You do not have permission to do Give upgrades', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to do Give upgrades.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	ignore_user_abort( true );

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -53,7 +53,7 @@ function give_resend_donation_receipt( $data ) {
 	}
 
 	if ( ! current_user_can( 'edit_give_payments', $purchase_id ) ) {
-		wp_die( __( 'You do not have permission to edit this payment record', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'You do not have permission to edit payment records.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	give_email_donation_receipt( $purchase_id, false );


### PR DESCRIPTION
This pull request is unifying different permission error messages:

Source:
![perm](https://cloud.githubusercontent.com/assets/576623/16880390/b58f0fac-4abd-11e6-8c42-a145045454d4.png)

Note: permission error messages fired by current_user_can() when the user has no capability to do something.
