### PR TITLE
i18n Improvments

### DIFF
--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -599,7 +599,7 @@ class Give_Plugin_Settings {
 						array(
 							'id'      => 'donation_receipt',
 							'name'    => __( 'Donation Receipt', 'give' ),
-							'desc'    => __( 'Enter the email that is sent to users after completing a successful donation. HTML is accepted. Available template tags:', 'give' ) . '<br/>' . give_get_emails_tags_list(),
+							'desc'    => sprintf( __( 'Enter the email that is sent to users after completing a successful donation. HTML is accepted. Available template tags: %s', 'give' ), give_get_emails_tags_list() ) . '<br/>',
 							'type'    => 'wysiwyg',
 							'default' => give_get_default_donation_receipt_email()
 						),
@@ -619,7 +619,7 @@ class Give_Plugin_Settings {
 						array(
 							'id'      => 'donation_notification',
 							'name'    => __( 'Donation Notification', 'give' ),
-							'desc'    => __( 'Enter the email that is sent to donation notification emails after completion of a donation. HTML is accepted. Available template tags:', 'give' ) . '<br/>' . give_get_emails_tags_list(),
+							'desc'    => sprintf( __( 'Enter the email that is sent to donation notification emails after completion of a donation. HTML is accepted. Available template tags: %s', 'give' ), give_get_emails_tags_list() ) . '<br/>',
 							'type'    => 'wysiwyg',
 							'default' => give_get_default_donation_notification_email()
 						),

--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -248,7 +248,7 @@ abstract class Give_Shortcode_Generator {
 
 			// do not reindex array!
 			$field['options'] = array(
-				                    '' => ( $field['placeholder'] ? $field['placeholder'] : sprintf( '– %s –', __( 'Select', 'give' ) ) ),
+				                    '' => ( $field['placeholder'] ? $field['placeholder'] : __( '- Select -', 'give' ) ),
 			                    ) + $field['options'];
 
 			foreach ( $field['options'] as $value => $text ) {

--- a/includes/admin/shortcodes/shortcode-give-form.php
+++ b/includes/admin/shortcodes/shortcode-give-form.php
@@ -47,7 +47,7 @@ class Give_Shortcode_Donation_Form extends Give_Shortcode_Generator {
 				),
 				'name'        => 'id',
 				'tooltip'     => __( 'Select a Donation Form', 'give' ),
-				'placeholder' => sprintf( '– %s –', __( 'Select a Form', 'give' ) ),
+				'placeholder' => __( '- Select a Form -', 'give' ),
 				'required'    => array(
 					'alert' => __( 'You must first select a Form!', 'give' ),
 					'error' => sprintf( '<p class="strong">%s</p><p class="no-margin">%s</p>', __( 'No donation forms were found!', 'give' ), $create_form_link ),

--- a/includes/admin/shortcodes/shortcode-give-goal.php
+++ b/includes/admin/shortcodes/shortcode-give-goal.php
@@ -44,7 +44,7 @@ class Give_Shortcode_Donation_Form_Goal extends Give_Shortcode_Generator {
 				),
 				'name'        => 'id',
 				'tooltip'     => __( 'Select a Donation Form', 'give' ),
-				'placeholder' => sprintf( '– %s –', __( 'Select a Form', 'give' ) ),
+				'placeholder' => __( '- Select a Form -', 'give' ),
 				'required'    => array(
 					'alert' => __( 'You must first select a Form!', 'give' ),
 					'error' => sprintf( '<p class="strong">%s</p><p class="no-margin">%s</p>', __( 'No donation forms were found!', 'give' ), $create_form_link ),

--- a/includes/admin/system-info.php
+++ b/includes/admin/system-info.php
@@ -28,10 +28,10 @@ function give_system_info_callback() {
 		return;
 	}
 	?>
-	<textarea readonly="readonly" onclick="this.focus(); this.select()" id="system-info-textarea" name="give-sysinfo" title="To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac)."><?php echo give_tools_sysinfo_get(); ?></textarea>
+	<textarea readonly="readonly" onclick="this.focus(); this.select()" id="system-info-textarea" name="give-sysinfo" title="<?php echo esc_attr( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'give' ); ?>"><?php echo give_tools_sysinfo_get(); ?></textarea>
 	<p class="submit">
 		<input type="hidden" name="give-action" value="download_sysinfo"/>
-		<?php submit_button( 'Download System Info File', 'secondary', 'give-download-sysinfo', false ); ?>
+		<?php submit_button( __( 'Download System Info File', 'give' ), 'secondary', 'give-download-sysinfo', false ); ?>
 	</p>
 	<?php
 }

--- a/includes/class-give-gravatars.php
+++ b/includes/class-give-gravatars.php
@@ -385,7 +385,7 @@ class Give_Donators_Gravatars_Widget extends WP_Widget {
 		// widget settings
 		$widget_ops = array(
 			'classname'   => 'give-donators-gravatars',
-			'description' => sprintf( __( 'Displays gravatars of people who have donated using your your %s. Will only show on the single %s page.', 'give' ), $give_label_singular, $give_label_singular )
+			'description' => sprintf( __( 'Displays gravatars of people who have donated using your your %1$s. Will only show on the single %2$s page.', 'give' ), $give_label_singular, $give_label_singular )
 		);
 
 		// widget control settings

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -57,7 +57,7 @@ function give_offline_payment_cc_form( $form_id ) {
 	<fieldset id="give_offline_payment_info">
 		<?php
 		$settings_url         = admin_url( 'post.php?post=' . $form_id . '&action=edit&message=1' );
-		$offline_instructions = ! empty( $offline_instructions ) ? $offline_instructions : sprintf( esc_attr__( 'Please enter offline donation instructions in the %s.', 'give' ), '<a href="' . $settings_url . '">' . __( 'this form\'s settings', 'give' ) . '</a>' );
+		$offline_instructions = ! empty( $offline_instructions ) ? $offline_instructions : sprintf( esc_attr__( 'Please enter offline donation instructions in <a href="%s">this form\'s settings</a>.', 'give' ), $settings_url );
 		echo wpautop( stripslashes( $offline_instructions ) );
 		?>
 	</fieldset>

--- a/tests/unit-tests/tests-login-register.php
+++ b/tests/unit-tests/tests-login-register.php
@@ -37,7 +37,7 @@ class Tests_Login_Register extends Give_Unit_Test_Case {
 		) );
 
 		$this->assertArrayHasKey( 'username_incorrect', give_get_errors() );
-		$this->assertContains( 'The username you entered does not exist', give_get_errors() );
+		$this->assertContains( 'The username you entered does not exist.', give_get_errors() );
 
 		// Clear errors for other test
 		give_clear_errors();
@@ -58,7 +58,7 @@ class Tests_Login_Register extends Give_Unit_Test_Case {
 		) );
 
 		$this->assertArrayHasKey( 'password_incorrect', give_get_errors() );
-		$this->assertContains( 'The password you entered is incorrect', give_get_errors() );
+		$this->assertContains( 'The password you entered is incorrect.', give_get_errors() );
 
 		// Clear errors for other test
 		give_clear_errors();


### PR DESCRIPTION
More i18n Improvments:

1. Use `__()` in two more strings, making them translatable to other languages.
2. use sprintf() to show the `%s` placeholder. Not in all languages the tag-list is in the end. This why we should use placeholders. Translation editor will decide where to place the placeholder.