### PR TITLE
a11y: use WordPress default screen-reader class

### DIFF
--- a/assets/scss/admin/settings.scss
+++ b/assets/scss/admin/settings.scss
@@ -57,11 +57,6 @@ Settings
 
 }
 
-// Section Titles
-.give-hide-heading {
-  display: none;
-}
-
 .cmb-type-give-title label {
   float: left;
   width: 220px;

--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -141,7 +141,7 @@ class Give_Plugin_Settings {
 
 		<div class="wrap give_settings_page cmb2_options_page <?php echo $this->key; ?>">
 
-			<h1 class="give-hide-heading"><?php esc_html_e( 'Give Settings', 'give' ); ?></h1>
+			<h1 class="screen-reader-text"><?php esc_html_e( 'Give Settings', 'give' ); ?></h1>
 
 			<h2 class="nav-tab-wrapper">
 				<?php

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -34,7 +34,7 @@ function give_reports_page() {
 	?>
 	<div class="wrap">
 
-		<h1 class="give-hide-heading"><?php esc_html_e( 'Give Reports', 'give' ); ?></h1>
+		<h1 class="screen-reader-text"><?php esc_html_e( 'Give Reports', 'give' ); ?></h1>
 
 		<h2 class="nav-tab-wrapper">
 			<a href="<?php echo esc_url( add_query_arg( array(


### PR DESCRIPTION
You added `give-hide-heading` to hide `<H1>` titles in the admin (#820). We should use the default WordPress class for screen readers.

For more info, read this: https://make.wordpress.org/accessibility/2015/02/09/hiding-text-for-screen-readers-with-wordpress-core/