### PR TITLE
Unit test fixes and resolved travis-ci issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 - bash tests/bin/install.sh wordpress_test root '' localhost $WP_VERSION
 - bash tests/bin/travis.sh before
 
-script: phpunit -c phpunit.xml.dist
+script: phpunit -c phpunit.xml
 
 after_script:
 - bash tests/bin/travis.sh after

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+- 5.2
 - 5.3
 - 5.4
 - 5.5
@@ -12,35 +13,23 @@ php:
 
 env:
 - WP_VERSION=latest WP_MULTISITE=0
+- WP_VERSION=4.5 WP_MULTISITE=0
 - WP_VERSION=4.4 WP_MULTISITE=0
 - WP_VERSION=4.3 WP_MULTISITE=0
-- WP_VERSION=4.2 WP_MULTISITE=0
-- WP_VERSION=4.1 WP_MULTISITE=0
-- WP_VERSION=4.0 WP_MULTISITE=0
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
-  exclude:
-    - php: hhvm
-      env: WP_VERSION=4.0 WP_MULTISITE=0
 
 before_script:
-- bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+- bash tests/bin/install.sh wordpress_test root '' localhost $WP_VERSION
+- bash tests/bin/travis.sh before
 
-script:
-- if [[ $TRAVIS_PHP_VERSION != 'hhvm' && ( $TRAVIS_PHP_VERSION != '5.5'|| $WP_VERSION != 'latest'
-  || $WP_MULTISITE != '0' ) ]]; then phpenv config-rm xdebug.ini; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'
-  ]]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi
+script: phpunit -c phpunit.xml.dist
 
 after_script:
-- if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'
-  ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-- if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'
-  ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover;
-  fi
+- bash tests/bin/travis.sh after
 
 notifications:
  slack: givewp:AgWxvdTjTkSjd8FHM5ndeSH5

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_script:
 script:
 - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && ( $TRAVIS_PHP_VERSION != '5.5'|| $WP_VERSION != 'latest'
   || $WP_MULTISITE != '0' ) ]]; then phpenv config-rm xdebug.ini; fi
+- if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'
+  ]]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi
 
 after_script:
 - if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'

--- a/includes/class-give-db.php
+++ b/includes/class-give-db.php
@@ -287,4 +287,14 @@ abstract class Give_DB {
 		return $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE '%s'", $table ) ) === $table;
 	}
 
+	/**
+	 * Check if the table was ever installed
+	 *
+	 * @since  1.6
+	 * @return bool Returns if the customers table was installed and upgrade routine run
+	 */
+	public function installed() {
+		return $this->table_exists( $this->table_name );
+	}
+
 }

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -97,7 +97,7 @@ class Give_Donate_Form {
 	 *
 	 * @since 1.0
 	 *
-	 * @param bool $_id
+	 * @param bool  $_id
 	 * @param array $_args
 	 */
 	public function __construct( $_id = false, $_args = array() ) {
@@ -212,7 +212,7 @@ class Give_Donate_Form {
 		/**
 		 * Fired after a donation form is created
 		 *
-		 * @param int $id The post ID of the created item.
+		 * @param int   $id The post ID of the created item.
 		 * @param array $args The post object arguments used for creation.
 		 */
 		do_action( 'give_form_post_create', $id, $args );
@@ -272,7 +272,7 @@ class Give_Donate_Form {
 		 *
 		 * @since 1.0
 		 *
-		 * @param string $price The donation form price.
+		 * @param string     $price The donation form price.
 		 * @param string|int $id The form ID.
 		 */
 		return apply_filters( 'give_get_set_price', $this->price, $this->ID );
@@ -325,7 +325,7 @@ class Give_Donate_Form {
 		 *
 		 * @since 1.0
 		 *
-		 * @param array $prices The array of mulit-level prices.
+		 * @param array      $prices The array of mulit-level prices.
 		 * @param int|string The ID of the form.
 		 */
 		return apply_filters( 'give_get_donation_levels', $this->prices, $this->ID );
@@ -374,13 +374,13 @@ class Give_Donate_Form {
 		if ( empty( $option ) || $option === 'set' ) {
 			$ret = 1;
 		}
-		
+
 		/**
 		 * Override the price mode for a donation when checking if is in single price mode.
 		 *
 		 * @since 1.0
 		 *
-		 * @param bool $ret Is donation form in single price mode?
+		 * @param bool       $ret Is donation form in single price mode?
 		 * @param int|string The ID of the donation form.
 		 */
 		return (bool) apply_filters( 'give_single_price_option_mode', $ret, $this->ID );
@@ -407,7 +407,7 @@ class Give_Donate_Form {
 		 *
 		 * @since 1.6
 		 *
-		 * @param bool $ret Is donation form in custom price mode?
+		 * @param bool       $ret Is donation form in custom price mode?
 		 * @param int|string The ID of the donation form.
 		 */
 		return (bool) apply_filters( 'give_custom_price_option_mode', $ret, $this->ID );
@@ -434,7 +434,7 @@ class Give_Donate_Form {
 		/**
 		 * Filter: Override whether the donation form has variables prices.
 		 *
-		 * @param bool $ret Does donation form have variable prices?
+		 * @param bool       $ret Does donation form have variable prices?
 		 * @param int|string The ID of the donation form.
 		 */
 		return (bool) apply_filters( 'give_has_variable_prices', $ret, $this->ID );
@@ -463,31 +463,86 @@ class Give_Donate_Form {
 
 	}
 
-    /**
-     * Get if form type set or not.
-     *
-     * @since 1.6
-     * @return bool true if form type is 'multi' and false otherwise.
-     */
-    public function is_set_type_donation_form() {
-        $form_type = $this->get_type();
+	/**
+	 * Get form tag classes.
+	 *
+	 * Provides the classes for the donation <form> html tag and filters for customization.
+	 *
+	 * @since 1.6
+	 * @param $args
+	 *
+	 * @return string
+	 */
+	public function get_form_classes( $args ) {
 
-        return ( 'set' === $form_type ? true : false );
+		$float_labels_option = give_is_float_labels_enabled( $args )
+			? 'float-labels-enabled'
+			: '';
 
-    }
+		$form_classes_array = apply_filters( 'give_form_classes', array(
+			'give-form',
+			'give-form-' . $this->ID,
+			'give-form-type-' . $this->get_type(),
+			$float_labels_option
+		), $this->ID, $args );
 
-    /**
-     * Get if form type multi or not.
-     *
-     * @since 1.6
-     * @return bool true if form type is 'multi' and false otherwise.
-     */
-    public function is_multi_type_donation_form() {
-        $form_type = $this->get_type();
+		// Remove empty class names.
+		$form_classes_array = array_filter( $form_classes_array );
 
-        return ( 'multi' === $form_type ? true : false );
+		return implode( ' ', $form_classes_array );
 
-    }
+	}
+
+	/**
+	 * Get form wrap Classes.
+	 *
+	 * Provides the classes for the donation form div wrapper and filters for customization.
+	 *
+	 * @param $args
+	 *
+	 * @return string
+	 */
+	public function get_form_wrap_classes( $args ) {
+
+		$display_option = ( isset( $args['display_style'] ) && ! empty( $args['display_style'] ) )
+			? $args['display_style']
+			: get_post_meta( $this->ID, '_give_payment_display', true );
+
+		$form_wrap_classes_array = apply_filters( 'give_form_wrap_classes', array(
+			'give-form-wrap',
+			'give-display-' . $display_option
+		), $this->ID, $args );
+
+
+		return implode( ' ', $form_wrap_classes_array );
+
+	}
+
+	/**
+	 * Get if form type set or not.
+	 *
+	 * @since 1.6
+	 * @return bool true if form type is 'multi' and false otherwise.
+	 */
+	public function is_set_type_donation_form() {
+		$form_type = $this->get_type();
+
+		return ( 'set' === $form_type ? true : false );
+
+	}
+
+	/**
+	 * Get if form type multi or not.
+	 *
+	 * @since 1.6
+	 * @return bool true if form type is 'multi' and false otherwise.
+	 */
+	public function is_multi_type_donation_form() {
+		$form_type = $this->get_type();
+
+		return ( 'multi' === $form_type ? true : false );
+
+	}
 
 	/**
 	 * Retrieve the sale count for the donation form
@@ -606,9 +661,9 @@ class Give_Donate_Form {
 	 * Increase the earnings by the given amount
 	 *
 	 * @since 1.0
-	 * 
+	 *
 	 * @param int $amount Amount of donation
-	 * 
+	 *
 	 * @return float|false
 	 */
 	public function increase_earnings( $amount = 0 ) {
@@ -695,10 +750,10 @@ class Give_Donate_Form {
 	 */
 	public function is_close_donation_form() {
 		return (
-				'yes' === get_post_meta( $this->ID, '_give_goal_option', true ) )
-				&& ( 'yes' === get_post_meta( $this->ID, '_give_close_form_when_goal_achieved', true ) )
-				&& ( $this->get_goal() <= $this->get_earnings()
-		);
+			       'yes' === get_post_meta( $this->ID, '_give_goal_option', true ) )
+		       && ( 'yes' === get_post_meta( $this->ID, '_give_close_form_when_goal_achieved', true ) )
+		       && ( $this->get_goal() <= $this->get_earnings()
+		       );
 	}
 
 
@@ -708,8 +763,8 @@ class Give_Donate_Form {
 	 * @since  1.5
 	 * @access private
 	 *
-	 * @param  string               $meta_key   The meta_key to update
-	 * @param  string|array|object  $meta_value The value to put into the meta
+	 * @param  string              $meta_key The meta_key to update
+	 * @param  string|array|object $meta_value The value to put into the meta
 	 *
 	 * @return bool                             The result of the update query
 	 */

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -72,6 +72,8 @@ function give_get_donation_form( $args = array() ) {
 		'give-form-wrap',
 		'give-display-' . $display_option
 	), $form->ID, $args );
+
+
 	$form_wrap_classes       = implode( ' ', $form_wrap_classes_array );
 
 	//Form Classes

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -59,17 +59,11 @@ function give_get_donation_form( $args = array() ) {
 		return false;
 	}
 
-
-
-
 	//Get the form wrap CSS classes.
 	$form_wrap_classes       = $form->get_form_wrap_classes($args);
 
 	//Get the <form> tag wrap CSS classes.
 	$form_classes       = $form->get_form_classes($args);
-
-
-
 
 	ob_start();
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -59,40 +59,16 @@ function give_get_donation_form( $args = array() ) {
 		return false;
 	}
 
-	$display_option = ( isset( $args['display_style'] ) && ! empty( $args['display_style'] ) )
-		? $args['display_style']
-		: get_post_meta( $form->ID, '_give_payment_display', true );
-
-	$float_labels_option = give_is_float_labels_enabled( $args )
-		? 'float-labels-enabled'
-		: '';
-
-	//Form Wrap Classes
-	$form_wrap_classes_array = apply_filters( 'give_form_wrap_classes', array(
-		'give-form-wrap',
-		'give-display-' . $display_option
-	), $form->ID, $args );
 
 
-	$form_wrap_classes       = implode( ' ', $form_wrap_classes_array );
 
-	//Form Classes
-	$form_classes_array = apply_filters( 'give_form_classes', array(
-		'give-form',
-		'give-form-' . $form->ID,
-        'give-form-type-' . $form->get_type(),
-		$float_labels_option
-	), $form->ID, $args );
+	//Get the form wrap CSS classes.
+	$form_wrap_classes       = $form->get_form_wrap_classes($args);
 
-    // Remove empty class names.
-    $form_classes_array = array_filter(
-        $form_classes_array,
-        function( $class ){
-            return $class;
-        }
-    );
+	//Get the <form> tag wrap CSS classes.
+	$form_classes       = $form->get_form_classes($args);
 
-	$form_classes       = implode( ' ', $form_classes_array );
+
 
 
 	ob_start();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 	syntaxCheck="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="Give Test Suite">
 			<directory prefix="tests-" suffix=".php">./tests/unit-tests</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,6 +28,6 @@
 		</blacklist>
 	</filter>
 	<logging>
-		<log type="coverage-html" target="./tmp/coverage" charset="UTF-8" />
+		<log type="coverage-clover" target="./tmp/clover.xml" charset="UTF-8" />
 	</logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	verbose="true"
+	syntaxCheck="true"
 	>
 	<testsuites>
 		<testsuite>
@@ -18,6 +19,12 @@
 			<directory suffix=".php">./templates/</directory>
 			<directory suffix=".php">./tests/</directory>
 			<directory suffix=".php">./tmp/</directory>
+			<directory suffix=".php">./languages/</directory>
+			<directory suffix=".php">./tests/</directory>
+			<directory suffix=".php">./templates/</directory>
+			<directory suffix=".php">./includes/libraries/</directory>
+			<directory suffix=".php">./includes/admin/reporting/export</directory>
+			<directory suffix=".php">./includes/admin/reporting/tools/</directory>
 		</blacklist>
 	</filter>
 	<logging>

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -36,11 +36,6 @@ else
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
 
-if [[ $WP_TESTS_TAG == *"beta"* ]]
-then
-	WP_TESTS_TAG="trunk"
-fi
-
 set -ex
 
 install_wp() {

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# usage: travis.sh before|after
+
+if [ $1 == 'before' ]; then
+
+	# composer install fails in PHP 5.2
+	[ $TRAVIS_PHP_VERSION == '5.2' ] && exit;
+
+	composer self-update
+
+	# install php-coveralls to send coverage info
+	composer init --require=satooshi/php-coveralls:0.7.0 -n
+	composer install --no-interaction
+
+elif [ $1 == 'after' ]; then
+
+	# no Xdebug and therefore no coverage in PHP 5.2
+	[ $TRAVIS_PHP_VERSION == '5.2' ] && exit;
+
+	# send coverage data to coveralls
+	php vendor/bin/coveralls --verbose --exclude-no-stmt
+
+	# get scrutinizer ocular and run it
+	wget https://scrutinizer-ci.com/ocular.phar
+	ocular.phar code-coverage:upload --format=php-clover ./tmp/clover.xml
+
+fi

--- a/tests/unit-tests/tests-give.php
+++ b/tests/unit-tests/tests-give.php
@@ -52,6 +52,7 @@ class Tests_Give extends Give_Unit_Test_Case {
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-template-loader.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-donate-form.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-db.php' );
+		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-db-customer-meta.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-db-customers.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-customer.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/class-give-stats.php' );

--- a/tests/unit-tests/tests-install.php
+++ b/tests/unit-tests/tests-install.php
@@ -45,9 +45,7 @@ class Tests_Activation extends Give_Unit_Test_Case {
 		update_option( 'give_version', '2.0' );
 		$give_options = array();
 
-
 		give_install();
-
 
 		// Test the give_version_upgraded_from value
 		$this->assertEquals( get_option( 'give_version_upgraded_from' ), '2.0' );
@@ -82,7 +80,7 @@ class Tests_Activation extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the install doesn't redirect when activating multiple plugins.
+	 * Test that the install does not redirect when activating multiple plugins.
 	 *
 	 * @since 1.3.2
 	 */
@@ -101,7 +99,7 @@ class Tests_Activation extends Give_Unit_Test_Case {
 	 *
 	 * Since 1.3.2
 	 */
-	public function test_give_ater_install() {
+	public function test_give_after_install() {
 
 		// Prepare for test
 		set_transient( '_give_installed', $GLOBALS['give_options'], 30 );


### PR DESCRIPTION
In this PR I have refactored our `travis.yml` file so that it now tests PHP 5.2 

As well, we are now excluding directories that should not be tested in `phpunit.xml` 

The `install.sh` and `travis.sh` are now run from the tests directory

There are also doc block updates and a new `installed()` method (which was breaking the tests) is now added to `Give_DB`  