### PR TITLE
Fix typo: "login" is a noun or adjective. "log in" is the verb.

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1347,7 +1347,7 @@ function give_members_only_form( $final_output, $args ) {
 	//Logged in only and Register / Login set to none
 	if ( give_logged_in_only( $form_id ) && give_show_login_register_option( $form_id ) == 'none' ) {
 
-		$final_output = give_output_error( esc_html__( 'Please login in order to complete your donation.', 'give' ), false );
+		$final_output = give_output_error( esc_html__( 'Please log in in order to complete your donation.', 'give' ), false );
 
 		return apply_filters( 'give_members_only_output', $final_output, $form_id );
 


### PR DESCRIPTION
The irony is not lost on me that the commit text has a typo in it. 