### PR TITLE
Typo in German Translation

### DIFF
--- a/languages/give-de_DE.po
+++ b/languages/give-de_DE.po
@@ -3801,7 +3801,7 @@ msgstr "Kreditkarteninformation"
 
 #: includes/forms/template.php:530
 msgid "This is a secure SSL encrypted payment."
-msgstr "Die ist eine SSL-gesicherte Zahlung."
+msgstr "Dies ist eine SSL-gesicherte Zahlung."
 
 #: includes/forms/template.php:535
 msgid "Card Number"


### PR DESCRIPTION
The message for SSL encrypted should read "Dies" and not "Die".