### PR TITLE
New i18n banner and Add-on activation banner improvements

### DIFF
--- a/give.php
+++ b/give.php
@@ -365,6 +365,7 @@ if ( ! class_exists( 'Give' ) ) :
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/class-admin-notices.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/class-api-keys-table.php';
+				require_once GIVE_PLUGIN_DIR . 'includes/admin/class-i18n-module.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/admin-actions.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/system-info.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/add-ons.php';

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -58,7 +58,6 @@ class Give_Addon_Activation_Banner {
 		add_action( 'current_screen', array( $this, 'give_addon_notice_ignore' ) );
 		add_action( 'admin_notices', array( $this, 'give_addon_activation_admin_notice' ) );
 
-
 	}
 
 
@@ -79,45 +78,42 @@ class Give_Addon_Activation_Banner {
 		// Output the activation banner
 		if ( ! get_user_meta( $this->user_id, $this->nag_meta_key ) ) { ?>
 
-			<!-- * I output inline styles here
-				 * because there's no reason to keep these
-				 * enqueued after the alert is dismissed. -->
 			<style>
 				div.give-addon-alert.updated {
-					padding: 1em 2em;
+					padding: 20px;
 					position: relative;
 					border-color: #66BB6A;
 				}
 
-				div.give-addon-alert img {
+				div.give-alert-message {
+					margin-left: 70px;
+				}
+
+				div.give-addon-alert img.give-logo {
 					max-width: 50px;
-					position: relative;
-					top: 1em;
+					float: left;
 				}
 
 				div.give-addon-alert h3 {
-					display: inline;
-					position: relative;
-					top: -20px;
-					left: 20px;
+					margin: -5px 0 10px;
 					font-size: 24px;
 					font-weight: 300;
+					line-height: 30px;
 				}
 
 				div.give-addon-alert h3 span {
-					font-weight: 900;
+					font-weight: 700;
 					color: #66BB6A;
 				}
 
 				div.give-addon-alert .alert-actions {
-					position: relative;
-					left: 70px;
-					top: -10px;
-
 				}
 
 				div.give-addon-alert a {
 					color: #66BB6A;
+				}
+
+				div.give-addon-alert .alert-actions a {
 					margin-right: 2em;
 				}
 
@@ -136,73 +132,71 @@ class Give_Addon_Activation_Banner {
 
 				div.give-addon-alert .dismiss {
 					position: absolute;
-					right: 0;
+					right: 20px;
 					height: 100%;
 					top: 50%;
 					margin-top: -10px;
 					outline: none;
 					box-shadow: none;
+					text-decoration: none;
+					color: #AAA;
+				}
+
+				div.give-addon-alert .dismiss:hover {
+					color: #333;
 				}
 			</style>
 
-			<!-- * Now we output the HTML
-				 * of the banner 			-->
-
 			<div class="updated give-addon-alert">
 
-				<!-- Your Logo -->
-				<img src="<?php echo GIVE_PLUGIN_URL; ?>assets/images/svg/give-icon-full-circle.svg" class="give-logo" />
+				<img src="<?php echo GIVE_PLUGIN_URL; ?>assets/images/svg/give-icon-full-circle.svg" class="give-logo"/>
 
-				<!-- Your Message -->
-				<h3><?php
-					printf(
+				<div class="give-alert-message">
+					<h3><?php
+						printf(
 						/* translators: %s: Add-on name */
-						esc_html__( "Thank you for installing Give's %s Add-on!", 'give' ),
-						'<span>' . $this->banner_details['name'] . '</span>'
-					);
-				?></h3>
+							esc_html__( "Thank you for installing Give's %s Add-on!", 'give' ),
+							'<span>' . $this->banner_details['name'] . '</span>'
+						);
+						?></h3>
 
-				<a href="<?php
-				//The Dismiss Button
-				$nag_admin_dismiss_url = 'plugins.php?' . $this->nag_meta_key . '=0';
-				echo admin_url( $nag_admin_dismiss_url ); ?>" class="dismiss"><span class="dashicons dashicons-dismiss"></span></a>
+					<a href="<?php
+					//The Dismiss Button.
+					$nag_admin_dismiss_url = 'plugins.php?' . $this->nag_meta_key . '=0';
+					echo admin_url( $nag_admin_dismiss_url ); ?>" class="dismiss"><span
+							class="dashicons dashicons-dismiss"></span></a>
 
-				<!-- * Now we output a few "actions"
-					 * that the user can take from here -->
+					<div class="alert-actions">
 
-				<div class="alert-actions">
+						<?php //Point them to your settings page.
+						if ( isset( $this->banner_details['settings_url'] ) ) { ?>
+							<a href="<?php echo $this->banner_details['settings_url']; ?>">
+								<span class="dashicons dashicons-admin-settings"></span><?php esc_html_e( 'Go to Settings', 'give' ); ?></a>
+						<?php } ?>
 
-					<?php //Point them to your settings page
-					if ( isset( $this->banner_details['settings_url'] ) ) { ?>
-						<a href="<?php echo $this->banner_details['settings_url']; ?>">
-							<span class="dashicons dashicons-admin-settings"></span><?php esc_html_e( 'Go to Settings', 'give' ); ?>
-						</a>
-					<?php } ?>
-
-					<?php
-					// Show them how to configure the Addon
-					if ( isset( $this->banner_details['documentation_url'] ) ) { ?>
-						<a href="<?php echo $this->banner_details['documentation_url'] ?>" target="_blank">
-							<span class="dashicons dashicons-media-text"></span>
-							<?php
+						<?php
+						// Show them how to configure the Addon.
+						if ( isset( $this->banner_details['documentation_url'] ) ) { ?>
+							<a href="<?php echo $this->banner_details['documentation_url'] ?>" target="_blank">
+								<span class="dashicons dashicons-media-text"></span><?php
 								printf(
-									/* translators: %s: Add-on name */
+								/* translators: %s: Add-on name */
 									esc_html__( 'Documentation: %s Add-on', 'give' ),
 									$this->banner_details['name']
 								);
-							?>
-						</a>
-					<?php } ?>
-					<?php
-					//Let them signup for plugin updates
-					if ( isset( $this->banner_details['support_url'] ) ) { ?>
+								?></a>
+						<?php } ?>
+						<?php
+						//Let them signup for plugin updates
+						if ( isset( $this->banner_details['support_url'] ) ) { ?>
 
-						<a href="<?php echo $this->banner_details['support_url'] ?>" target="_blank">
-							<span class="dashicons dashicons-sos"></span><?php esc_html_e( 'Get Support', 'give' ); ?>
-						</a>
+							<a href="<?php echo $this->banner_details['support_url'] ?>" target="_blank">
+								<span class="dashicons dashicons-sos"></span><?php esc_html_e( 'Get Support', 'give' ); ?>
+							</a>
 
-					<?php } ?>
+						<?php } ?>
 
+					</div>
 				</div>
 			</div>
 			<?php
@@ -211,13 +205,14 @@ class Give_Addon_Activation_Banner {
 
 
 	/**
-	 * Ignore Nag
+	 * Ignore Nag.
 	 *
 	 * This is the action that allows the user to dismiss the banner it basically sets a tag to their user meta data
 	 */
 	public function give_addon_notice_ignore() {
 
-		/* If user clicks to ignore the notice, add that to their user meta the banner then checks whether this tag exists already or not.
+		/**
+		 * If user clicks to ignore the notice, add that to their user meta the banner then checks whether this tag exists already or not.
 		 * See here: http://codex.wordpress.org/Function_Reference/add_user_meta
 		 */
 		if ( isset( $_GET[ $this->nag_meta_key ] ) && '0' == $_GET[ $this->nag_meta_key ] ) {

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -96,7 +96,7 @@ class Give_Addon_Activation_Banner {
 
 				div.give-addon-alert h3 {
 					margin: -5px 0 10px;
-					font-size: 24px;
+					font-size: 22px;
 					font-weight: 300;
 					line-height: 30px;
 				}

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -3,7 +3,7 @@
 /**
  * Class Give_i18n
  */
-class Give_i18n {
+class Give_i18n_Banner {
 
 	/**
 	 * Your translation site's URL.
@@ -307,7 +307,7 @@ class Give_i18n {
 	}
 }
 
-$give_i18n = new Give_i18n(
+$give_i18n = new Give_i18n_Banner(
 	array(
 		'hook'          => 'give_forms_page_give-settings',
 		'glotpress_url' => 'https://translate.wordpress.org/api/projects/wp-plugins/give/stable/',

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -61,9 +61,10 @@ class Give_i18n {
 	private $translation_loaded;
 
 	/**
-	 * Class constructor.
+	 * Give_i18n constructor.
 	 *
-	 * @param array $args Contains the settings for the class.
+	 * @param $args
+	 *
 	 */
 	public function __construct( $args ) {
 		if ( ! is_admin() ) {
@@ -153,17 +154,57 @@ class Give_i18n {
 
 			<style>
 				/* Banner specific styles */
+				div.give-addon-alert.updated {
+					padding: 10px 20px;
+					position: relative;
+					border-color: #66BB6A;
+				}
 
+				div.give-addon-alert a {
+					color: #66BB6A;
+				}
+
+				#give-i18n-notice > .give-i18n-icon {
+					overflow: hidden;
+				}
+
+				#give-i18n-notice > .give-i18n-icon .dashicons {
+					width: 110px;
+					height: 110px;
+				}
+
+				#give-i18n-notice > .give-i18n-icon:focus {
+					box-shadow: none;
+				}
+
+				.give-i18n-notice-content {
+					margin: 0 30px 0 125px;
+				}
+
+				div.give-addon-alert .dismiss {
+					position: absolute;
+					right: 20px;
+					height: 100%;
+					top: 50%;
+					margin-top: -10px;
+					outline: none;
+					box-shadow: none;
+					text-decoration: none;
+					color: #AAA;
+				}
+
+				div.give-addon-alert .dismiss:hover {
+					color: #333;
+				}
 			</style>
 			<div id="give-i18n-notice" class="give-addon-alert updated" style="">
 
-				<a href="https://wordpress.org/support/register.php" class="alignleft" style="margin:0" target="_blank"><span class="dashicons dashicons-translation" style="font-size: 110px; text-decoration: none;"></span></a>
+				<a href="https://wordpress.org/support/register.php" class="alignleft give-i18n-icon" style="margin:0" target="_blank"><span class="dashicons dashicons-translation" style="font-size: 110px; text-decoration: none;"></span></a>
 
-				<div style="margin: 0 0 0 132px;">
-					<a href="<?php echo esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ); ?>" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;padding:1px 4px;" class="alignright"><span class="dashicons dashicons-dismiss"></span></a>
+				<div class="give-i18n-notice-content">
+					<a href="<?php echo esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ); ?>" class="dismiss"><span class="dashicons dashicons-dismiss"></span></a>
 
-					<h2 style="margin: 10px 0;"><?php _e( 'Help Translate Give', 'give' ); ?></h2>
-
+					<h2 style="margin: 10px 0;"><?php printf( __( 'Help Translate Give to %s', 'give' ), $this->locale_name ); ?></h2>
 					<p><?php echo $message; ?></p>
 					<p>
 						<a href="https://wordpress.org/support/register.php" target="_blank"><?php _e( 'Register now &raquo;', 'give' ); ?></a>
@@ -182,6 +223,7 @@ class Give_i18n {
 	 * @return object|null
 	 */
 	private function find_or_initialize_translation_details() {
+
 		$set = get_transient( 'give_i18n_give_' . $this->locale );
 
 		if ( ! $set ) {
@@ -214,14 +256,25 @@ class Give_i18n {
 	 * @return object|null
 	 */
 	private function retrieve_translation_details() {
-		$api_url = trailingslashit( $this->glotpress_url ) . 'api/projects/give';
+
+		$api_url = trailingslashit( $this->glotpress_url );
 
 		$resp = wp_remote_get( $api_url );
+
+		if ( is_wp_error( $resp ) || wp_remote_retrieve_response_code( $resp ) === '404' ) {
+			return null;
+		}
+
 		$body = wp_remote_retrieve_body( $resp );
 		unset( $resp );
 
 		if ( $body ) {
 			$body = json_decode( $body );
+			echo '<pre>';
+			var_dump( $body->translation_sets );
+			var_dump( $body );
+			echo '</pre>';
+
 			foreach ( $body->translation_sets as $set ) {
 				if ( ! property_exists( $set, 'wp_locale' ) ) {
 					continue;
@@ -256,7 +309,7 @@ class Give_i18n {
 
 $give_i18n = new Give_i18n(
 	array(
-		'hook'          => 'admin_notices',
-		'glotpress_url' => 'https://translate.wordpress.org/projects/wp-plugins/give',
+		'hook'          => 'give_forms_page_give-settings',
+		'glotpress_url' => 'https://translate.wordpress.org/api/projects/wp-plugins/give/stable/',
 	)
 );

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * Class Give_i18n
+ */
+class Give_i18n {
+
+	/**
+	 * Your translation site's logo.
+	 *
+	 * @var string
+	 */
+	private $glotpress_logo;
+
+	/**
+	 * Your translation site's name.
+	 *
+	 * @var string
+	 */
+	private $glotpress_name;
+
+	/**
+	 * Your translation site's URL.
+	 *
+	 * @var string
+	 */
+	private $glotpress_url;
+
+	/**
+	 * Hook where you want to show the promo box.
+	 *
+	 * @var string
+	 */
+	private $hook;
+
+	/**
+	 * Will contain the site's locale.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $locale;
+
+	/**
+	 * Will contain the locale's name, obtained from your translation site.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $locale_name;
+
+	/**
+	 * Will contain the percentage translated for the plugin translation project in the locale.
+	 *
+	 * @access private
+	 * @var int
+	 */
+	private $percent_translated;
+
+	/**
+	 * Project slug for the project on your translation site.
+	 *
+	 * @var string
+	 */
+	private $project_slug;
+
+	/**
+	 * URL to point to for registration links.
+	 *
+	 * @var string
+	 */
+	private $register_url;
+
+	/**
+	 * Your plugins textdomain
+	 *
+	 * @var string
+	 */
+	private $textdomain;
+
+	/**
+	 * Indicates whether there's a translation available at all.
+	 *
+	 * @access private
+	 * @var bool
+	 */
+	private $translation_exists;
+
+	/**
+	 * Indicates whether the translation's loaded.
+	 *
+	 * @access private
+	 * @var bool
+	 */
+	private $translation_loaded;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param array $args Contains the settings for the class.
+	 */
+	public function __construct( $args ) {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		$this->locale = get_locale();
+		if ( 'en_US' === $this->locale ) {
+			return;
+		}
+
+		$this->init( $args );
+
+		if ( ! $this->hide_promo() ) {
+			add_action( $this->hook, array( $this, 'promo' ) );
+		}
+	}
+
+	/**
+	 * This is where you decide where to display the messages and where you set the plugin specific variables.
+	 *
+	 * @access private
+	 *
+	 * @param array $args
+	 */
+	private function init( $args ) {
+		foreach ( $args as $key => $arg ) {
+			$this->$key = $arg;
+		}
+	}
+
+	/**
+	 * Check whether the promo should be hidden or not.
+	 *
+	 * @access private
+	 *
+	 * @return bool
+	 */
+	private function hide_promo() {
+		$hide_promo = get_transient( 'give_i18n_' . $this->project_slug . '_promo_hide' );
+		if ( ! $hide_promo ) {
+			if ( filter_input( INPUT_GET, 'remove_i18n_promo', FILTER_VALIDATE_INT ) === 1 ) {
+				// No expiration time, so this would normally not expire, but it wouldn't be copied to other sites etc.
+				set_transient( 'give_i18n_' . $this->project_slug . '_promo_hide', true );
+				$hide_promo = true;
+			}
+		}
+
+		return $hide_promo;
+	}
+
+	/**
+	 * Generates a promo message.
+	 *
+	 * @access private
+	 *
+	 * @return bool|string $message
+	 */
+	private function promo_message() {
+		$message = false;
+
+		if ( $this->translation_exists && $this->translation_loaded && $this->percent_translated < 90 ) {
+			$message = __( 'As you can see, there is a translation of this plugin in %1$s. This translation is currently %3$d%% complete. We need your help to make it complete and to fix any errors. Please register at %4$s to help complete the translation to %1$s!', 'give' );
+		} else if ( ! $this->translation_loaded && $this->translation_exists ) {
+			$message = __( 'You\'re using WordPress in %1$s. While %2$s has been translated to %1$s for %3$d%%, it\'s not been shipped with the plugin yet. You can help! Register at %4$s to help complete the translation to %1$s!', 'give' );
+		} else if ( ! $this->translation_exists ) {
+			$message = __( 'You\'re using WordPress in a language we don\'t support yet. We\'d love for %2$s to be translated in that language too, but unfortunately, it isn\'t right now. You can change that! Register at %4$s to help translate it!', 'give' );
+		}
+
+		$registration_link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $this->register_url ), esc_html__( 'WordPress.org', 'give' ) );
+		$message           = sprintf( $message, esc_html( $this->locale_name ), esc_html( 'Give' ), $this->percent_translated, $registration_link );
+
+		return $message;
+	}
+
+	/**
+	 * Outputs a promo box
+	 */
+	public function promo() {
+		$this->translation_details();
+
+		$message = $this->promo_message();
+
+		if ( $message ) {
+			echo '<div id="give-i18n-notice" class="give-addon-alert updated" style="">';
+			//Logo linked to GlotPress.
+			if ( isset( $this->glotpress_logo ) && '' != $this->glotpress_logo ) {
+				echo '<a href="' . $this->register_url . '" class="alignleft" style="margin:0"><img style="margin: -6px 0 0;max-width: 180px;" src="' . $this->glotpress_logo . '" alt="' . __( 'WordPress.org', 'give' ) . '"/></a>';
+			}
+			//Container with Text.
+			echo '<div style="margin: 0 0 0 200px;">';
+			echo '<a href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;padding:1px 4px;" class="alignright"><span class="dashicons dashicons-dismiss"></span></a>';
+			echo '<h2 style="margin: 10px 0;">' . __( 'Help Translate Give', 'give' ) . '</h2>';
+
+			echo '<p>' . $message . '</p>';
+			echo '<p><a href="' . $this->register_url . '">' . __( 'Register now &raquo;', 'give' ) . '</a></p>';
+			echo '</div>';
+			echo '</div>';
+		}
+	}
+
+	/**
+	 * Try to find the transient for the translation set or retrieve them.
+	 *
+	 * @access private
+	 *
+	 * @return object|null
+	 */
+	private function find_or_initialize_translation_details() {
+		$set = get_transient( 'give_i18n_' . $this->project_slug . '_' . $this->locale );
+
+		if ( ! $set ) {
+			$set = $this->retrieve_translation_details();
+			set_transient( 'give_i18n_' . $this->project_slug . '_' . $this->locale, $set, DAY_IN_SECONDS );
+		}
+
+		return $set;
+	}
+
+	/**
+	 * Try to get translation details from cache, otherwise retrieve them, then parse them.
+	 *
+	 * @access private
+	 */
+	private function translation_details() {
+		$set = $this->find_or_initialize_translation_details();
+
+		$this->translation_exists = ! is_null( $set );
+		$this->translation_loaded = is_textdomain_loaded( 'give' );
+
+		$this->parse_translation_set( $set );
+	}
+
+	/**
+	 * Retrieve the translation details from Give Translate.
+	 *
+	 * @access private
+	 *
+	 * @return object|null
+	 */
+	private function retrieve_translation_details() {
+		$api_url = trailingslashit( $this->glotpress_url ) . 'api/projects/' . $this->project_slug;
+
+		$resp = wp_remote_get( $api_url );
+		$body = wp_remote_retrieve_body( $resp );
+		unset( $resp );
+
+		if ( $body ) {
+			$body = json_decode( $body );
+			foreach ( $body->translation_sets as $set ) {
+				if ( ! property_exists( $set, 'wp_locale' ) ) {
+					continue;
+				}
+
+				if ( $this->locale == $set->wp_locale ) {
+					return $set;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Set the needed private variables based on the results from Give Translate.
+	 *
+	 * @param object $set The translation set
+	 *
+	 * @access private
+	 */
+	private function parse_translation_set( $set ) {
+		if ( $this->translation_exists && is_object( $set ) ) {
+			$this->locale_name        = $set->name;
+			$this->percent_translated = $set->percent_translated;
+		} else {
+			$this->locale_name        = '';
+			$this->percent_translated = '';
+		}
+	}
+}
+
+$give_i18n = new Give_i18n(
+	array(
+		'project_slug'   => 'give',
+		'hook'           => 'admin_notices',
+		'glotpress_url'  => 'https://translate.wordpress.org/projects/wp-plugins/give',
+		'glotpress_name' => 'Translate Give',
+		'glotpress_logo' => GIVE_PLUGIN_URL . 'assets/images/give-logo-small.png',
+		'register_url '  => 'https://wordpress.org/support/register.php',
+	)
+);

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -270,10 +270,6 @@ class Give_i18n_Banner {
 
 		if ( $body ) {
 			$body = json_decode( $body );
-			echo '<pre>';
-			var_dump( $body->translation_sets );
-			var_dump( $body );
-			echo '</pre>';
 
 			foreach ( $body->translation_sets as $set ) {
 				if ( ! property_exists( $set, 'wp_locale' ) ) {

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -67,6 +67,8 @@ class Give_i18n_Banner {
 	 *
 	 */
 	public function __construct( $args ) {
+
+		//Only for admins.
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -128,18 +130,25 @@ class Give_i18n_Banner {
 	private function promo_message() {
 		$message = false;
 
+		//Using a translation less than 90% complete.
 		if ( $this->translation_exists && $this->translation_loaded && $this->percent_translated < 90 ) {
-			$message = __( 'As you can see, there is a translation of this plugin in %1$s. This translation is currently %3$d%% complete. We need your help to make it complete and to fix any errors. Please register at %4$s to help complete the translation to %1$s!', 'give' );
-		} else if ( ! $this->translation_loaded && $this->translation_exists ) {
+			$message = __( 'As you can see, there is a translation of this plugin in %1$s. This translation is currently %3$d%% complete. We need your help to make it complete and to fix any errors. Please register at %4$s to help %5$s to %1$s!', 'give' );
+		} elseif ( ! $this->translation_loaded && $this->translation_exists ) {
 			$message = __( 'You\'re using WordPress in %1$s. While %2$s has been translated to %1$s for %3$d%%, it\'s not been shipped with the plugin yet. You can help! Register at %4$s to help complete the translation to %1$s!', 'give' );
-		} else if ( ! $this->translation_exists ) {
+		} elseif ( ! $this->translation_exists ) {
 			$message = __( 'You\'re using WordPress in a language we don\'t support yet. We\'d love for %2$s to be translated in that language too, but unfortunately, it isn\'t right now. You can change that! Register at %4$s to help translate it!', 'give' );
 		}
 
-		$registration_link = sprintf( '<a href="%1$s">%2$s</a>', 'https://wordpress.org/support/register.php', esc_html__( 'WordPress.org', 'give' ) );
-		$message           = sprintf( $message, esc_html( $this->locale_name ), esc_html( 'Give' ), $this->percent_translated, $registration_link );
+		//Links.
+		$registration_link = sprintf( '<a href="%1$s" target="_blank">%2$s</a>', 'https://wordpress.org/support/register.php', esc_html__( 'WordPress.org', 'give' ) );
+		$translations_link = sprintf( '<a href="%1$s" target="_blank">%2$s</a>', 'https://translate.wordpress.org/projects/wp-plugins/give', esc_html__( 'complete the translation', 'give' ) );
+
+		//Message.
+		$message = sprintf( $message, esc_html( $this->locale_name ), esc_html( 'Give' ), $this->percent_translated, $registration_link, $translations_link );
+
 
 		return $message;
+
 	}
 
 	/**

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -6,20 +6,6 @@
 class Give_i18n {
 
 	/**
-	 * Your translation site's logo.
-	 *
-	 * @var string
-	 */
-	private $glotpress_logo;
-
-	/**
-	 * Your translation site's name.
-	 *
-	 * @var string
-	 */
-	private $glotpress_name;
-
-	/**
 	 * Your translation site's URL.
 	 *
 	 * @var string
@@ -57,26 +43,6 @@ class Give_i18n {
 	 */
 	private $percent_translated;
 
-	/**
-	 * Project slug for the project on your translation site.
-	 *
-	 * @var string
-	 */
-	private $project_slug;
-
-	/**
-	 * URL to point to for registration links.
-	 *
-	 * @var string
-	 */
-	private $register_url;
-
-	/**
-	 * Your plugins textdomain
-	 *
-	 * @var string
-	 */
-	private $textdomain;
 
 	/**
 	 * Indicates whether there's a translation available at all.
@@ -95,7 +61,7 @@ class Give_i18n {
 	private $translation_loaded;
 
 	/**
-	 * Class constructor
+	 * Class constructor.
 	 *
 	 * @param array $args Contains the settings for the class.
 	 */
@@ -104,6 +70,7 @@ class Give_i18n {
 			return;
 		}
 
+		//This plugin is en_US native.
 		$this->locale = get_locale();
 		if ( 'en_US' === $this->locale ) {
 			return;
@@ -127,6 +94,7 @@ class Give_i18n {
 		foreach ( $args as $key => $arg ) {
 			$this->$key = $arg;
 		}
+
 	}
 
 	/**
@@ -137,11 +105,11 @@ class Give_i18n {
 	 * @return bool
 	 */
 	private function hide_promo() {
-		$hide_promo = get_transient( 'give_i18n_' . $this->project_slug . '_promo_hide' );
+		$hide_promo = get_transient( 'give_i18n_give_promo_hide' );
 		if ( ! $hide_promo ) {
 			if ( filter_input( INPUT_GET, 'remove_i18n_promo', FILTER_VALIDATE_INT ) === 1 ) {
 				// No expiration time, so this would normally not expire, but it wouldn't be copied to other sites etc.
-				set_transient( 'give_i18n_' . $this->project_slug . '_promo_hide', true );
+				set_transient( 'give_i18n_give_promo_hide', true );
 				$hide_promo = true;
 			}
 		}
@@ -167,7 +135,7 @@ class Give_i18n {
 			$message = __( 'You\'re using WordPress in a language we don\'t support yet. We\'d love for %2$s to be translated in that language too, but unfortunately, it isn\'t right now. You can change that! Register at %4$s to help translate it!', 'give' );
 		}
 
-		$registration_link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $this->register_url ), esc_html__( 'WordPress.org', 'give' ) );
+		$registration_link = sprintf( '<a href="%1$s">%2$s</a>', 'https://wordpress.org/support/register.php', esc_html__( 'WordPress.org', 'give' ) );
 		$message           = sprintf( $message, esc_html( $this->locale_name ), esc_html( 'Give' ), $this->percent_translated, $registration_link );
 
 		return $message;
@@ -177,25 +145,32 @@ class Give_i18n {
 	 * Outputs a promo box
 	 */
 	public function promo() {
-		$this->translation_details();
 
+		$this->translation_details();
 		$message = $this->promo_message();
 
-		if ( $message ) {
-			echo '<div id="give-i18n-notice" class="give-addon-alert updated" style="">';
-			//Logo linked to GlotPress.
-			if ( isset( $this->glotpress_logo ) && '' != $this->glotpress_logo ) {
-				echo '<a href="' . $this->register_url . '" class="alignleft" style="margin:0"><img style="margin: -6px 0 0;max-width: 180px;" src="' . $this->glotpress_logo . '" alt="' . __( 'WordPress.org', 'give' ) . '"/></a>';
-			}
-			//Container with Text.
-			echo '<div style="margin: 0 0 0 200px;">';
-			echo '<a href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;padding:1px 4px;" class="alignright"><span class="dashicons dashicons-dismiss"></span></a>';
-			echo '<h2 style="margin: 10px 0;">' . __( 'Help Translate Give', 'give' ) . '</h2>';
+		if ( $message ) { ?>
 
-			echo '<p>' . $message . '</p>';
-			echo '<p><a href="' . $this->register_url . '">' . __( 'Register now &raquo;', 'give' ) . '</a></p>';
-			echo '</div>';
-			echo '</div>';
+			<style>
+				/* Banner specific styles */
+
+			</style>
+			<div id="give-i18n-notice" class="give-addon-alert updated" style="">
+
+				<a href="https://wordpress.org/support/register.php" class="alignleft" style="margin:0" target="_blank"><span class="dashicons dashicons-translation" style="font-size: 110px; text-decoration: none;"></span></a>
+
+				<div style="margin: 0 0 0 132px;">
+					<a href="<?php echo esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ); ?>" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;padding:1px 4px;" class="alignright"><span class="dashicons dashicons-dismiss"></span></a>
+
+					<h2 style="margin: 10px 0;"><?php _e( 'Help Translate Give', 'give' ); ?></h2>
+
+					<p><?php echo $message; ?></p>
+					<p>
+						<a href="https://wordpress.org/support/register.php" target="_blank"><?php _e( 'Register now &raquo;', 'give' ); ?></a>
+					</p>
+				</div>
+			</div>
+			<?php
 		}
 	}
 
@@ -207,11 +182,11 @@ class Give_i18n {
 	 * @return object|null
 	 */
 	private function find_or_initialize_translation_details() {
-		$set = get_transient( 'give_i18n_' . $this->project_slug . '_' . $this->locale );
+		$set = get_transient( 'give_i18n_give_' . $this->locale );
 
 		if ( ! $set ) {
 			$set = $this->retrieve_translation_details();
-			set_transient( 'give_i18n_' . $this->project_slug . '_' . $this->locale, $set, DAY_IN_SECONDS );
+			set_transient( 'give_i18n_give_' . $this->locale, $set, DAY_IN_SECONDS );
 		}
 
 		return $set;
@@ -239,7 +214,7 @@ class Give_i18n {
 	 * @return object|null
 	 */
 	private function retrieve_translation_details() {
-		$api_url = trailingslashit( $this->glotpress_url ) . 'api/projects/' . $this->project_slug;
+		$api_url = trailingslashit( $this->glotpress_url ) . 'api/projects/give';
 
 		$resp = wp_remote_get( $api_url );
 		$body = wp_remote_retrieve_body( $resp );
@@ -281,11 +256,7 @@ class Give_i18n {
 
 $give_i18n = new Give_i18n(
 	array(
-		'project_slug'   => 'give',
-		'hook'           => 'admin_notices',
-		'glotpress_url'  => 'https://translate.wordpress.org/projects/wp-plugins/give',
-		'glotpress_name' => 'Translate Give',
-		'glotpress_logo' => GIVE_PLUGIN_URL . 'assets/images/give-logo-small.png',
-		'register_url '  => 'https://wordpress.org/support/register.php',
+		'hook'          => 'admin_notices',
+		'glotpress_url' => 'https://translate.wordpress.org/projects/wp-plugins/give',
 	)
 );

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,7 @@ We also really like WooCommerce. It's hands-down the most robust eCommerce platf
 == Changelog ==
 
 = 1.6.2 =
+* New: Internationalization banner now promotes to admins translating Give in languages it doesn't yet support. The banner will only display under Donations > Settings and is dismissible. https://github.com/WordImpress/Give/issues/1021
 * Fix: Donation form names with an apostrophe in them were displaying a backslash in the name for the PayPal Standard gateway. https://github.com/WordImpress/Give/issues/1079
 
 = 1.6.1 =

--- a/tests/unit-tests/tests-give.php
+++ b/tests/unit-tests/tests-give.php
@@ -91,6 +91,7 @@ class Tests_Give extends Give_Unit_Test_Case {
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/welcome.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/class-admin-notices.php' );
+		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/class-i18n-module.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/admin-actions.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/system-info.php' );
 		$this->assertFileExists( GIVE_PLUGIN_DIR . 'includes/admin/add-ons.php' );


### PR DESCRIPTION
## Description
I added the new class `Give_i18n_Banner` with support for WP.org GlotPress #1021 

I also updated the styles for the Add-on activation banner #1081 

## How Has This Been Tested?
I switched to several different languages like Spanish and French and tested the banner. I also switched to an author user to ensure the banner did not display improperly.

## Screenshots (jpeg or gifs if applicable):

New i18n banner:
![screenshot at oct 04 14-05-45](https://cloud.githubusercontent.com/assets/1571635/19092870/a14e31e8-8a3d-11e6-98bf-ae0284d1dd7a.png)

Improved Add-on activation style:
![screenshot at oct 04 14-20-53](https://cloud.githubusercontent.com/assets/1571635/19092906/d073d3ec-8a3d-11e6-9f78-5f86a13c2c0c.png)

## Types of changes
- New feature (non-breaking change which adds functionality)
- UX improvements #1081 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.