### PR TITLE
Test: remove unneeded test check

### DIFF
--- a/tests/unit-tests/tests-scripts.php
+++ b/tests/unit-tests/tests-scripts.php
@@ -101,9 +101,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 		$origin_pagenow = $pagenow;
 		$pagenow        = 'dashboard';
 
-		if ( ! function_exists( 'give_is_admin_page' ) ) {
-			include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
-		}
+		include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 
 		// Assert
 		$this->assertNull( give_load_admin_scripts( 'dashboard' ) );
@@ -120,9 +118,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 	 */
 	public function test_load_admin_scripts() {
 
-		if ( ! function_exists( 'give_is_admin_page' ) ) {
-			include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
-		}
+		include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 
 		give_load_admin_scripts( 'index.php' );
 

--- a/tests/unit-tests/tests-scripts.php
+++ b/tests/unit-tests/tests-scripts.php
@@ -101,7 +101,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 		$origin_pagenow = $pagenow;
 		$pagenow        = 'dashboard';
 
-		include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
+		require_once GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 
 		// Assert
 		$this->assertNull( give_load_admin_scripts( 'dashboard' ) );
@@ -118,7 +118,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 	 */
 	public function test_load_admin_scripts() {
 
-		include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
+		require_once GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 
 		give_load_admin_scripts( 'index.php' );
 

--- a/tests/unit-tests/tests-scripts.php
+++ b/tests/unit-tests/tests-scripts.php
@@ -84,6 +84,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 		give_update_option( 'disable_css', false );
 		give_register_styles();
 
+		// Assert
 		$this->assertTrue( wp_style_is( 'give-styles', 'enqueued' ) );
 
 	}


### PR DESCRIPTION
## Description

The test checks whether the `give_is_admin_page()` function exist, to include the `includes/admin/admin-pages.php` file.

> if ( ! function_exists( 'give_is_admin_page' ) ) {
> 	  include GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
> }

But this if statement will always return false because `give_is_admin_page()` function is in the `includes/admin/admin-pages.php` file.