### PR TITLE
Issue/1017 - STOP USING `global $pagenow`

### DIFF
--- a/includes/admin/EDD_SL_Plugin_Updater.php
+++ b/includes/admin/EDD_SL_Plugin_Updater.php
@@ -62,20 +62,18 @@ class EDD_SL_Plugin_Updater {
      *
      * @uses api_request()
 	 *
-     * @global $pagenow
-     *
      * @param array   $_transient_data Update array build by WordPress.
      * @return array Modified update array with custom plugin data.
      */
     function check_update( $_transient_data ) {
 
-        global $pagenow;
+        $screen = get_current_screen();
 
         if( ! is_object( $_transient_data ) ) {
             $_transient_data = new stdClass;
         }
 
-        if( 'plugins.php' == $pagenow && is_multisite() ) {
+        if( 'plugins.php' == $screen->parent_file && is_multisite() ) {
             return $_transient_data;
         }
 

--- a/tests/unit-tests/tests-scripts.php
+++ b/tests/unit-tests/tests-scripts.php
@@ -98,9 +98,9 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 	public function test_load_admin_scripts_bail() {
 
 		// Prepare test
-		global $pagenow;
-		$origin_pagenow = $pagenow;
-		$pagenow        = 'dashboard';
+		$screen         = get_current_screen();
+		$origin_screen  = $screen->id;
+		$current_screen = 'dashboard';
 
 		require_once GIVE_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 
@@ -108,7 +108,7 @@ class Tests_Scripts extends Give_Unit_Test_Case {
 		$this->assertNull( give_load_admin_scripts( 'dashboard' ) );
 
 		// Reset to origin
-		$pagenow = $origin_pagenow;
+		$current_screen = $origin_screen;
 
 	}
 


### PR DESCRIPTION
## Description
Replace `global $pagenow` with `$screen = get_current_screen()`

## Motivation and Context
Issue #1017 

## Types of changes
Non-breaking change which fixes an issue.