### PR TITLE
Issue/1097 - STOP USING `global $wp_post_types`

### DIFF
--- a/tests/unit-tests/tests-logging.php
+++ b/tests/unit-tests/tests-logging.php
@@ -29,7 +29,7 @@ class Tests_Logging extends Give_Unit_Test_Case {
 	 * Test Post Type
 	 */
 	public function test_post_type() {
-		$wp_post_types = get_post_types();
+		$wp_post_types = get_post_types( array(), 'names' );
 		$this->assertArrayHasKey( 'give_log', $wp_post_types );
 	}
 
@@ -37,7 +37,7 @@ class Tests_Logging extends Give_Unit_Test_Case {
 	 * Test Logs CPT Labels
 	 */
 	public function test_post_type_labels() {
-		$wp_post_types = get_post_types();
+		$wp_post_types = get_post_types( array(), 'objects' );
 		$this->assertEquals( 'Logs', $wp_post_types['give_log']->labels->name );
 		$this->assertEquals( 'Logs', $wp_post_types['give_log']->labels->singular_name );
 		$this->assertEquals( 'Add New', $wp_post_types['give_log']->labels->add_new );

--- a/tests/unit-tests/tests-logging.php
+++ b/tests/unit-tests/tests-logging.php
@@ -29,7 +29,7 @@ class Tests_Logging extends Give_Unit_Test_Case {
 	 * Test Post Type
 	 */
 	public function test_post_type() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types();
 		$this->assertArrayHasKey( 'give_log', $wp_post_types );
 	}
 
@@ -37,7 +37,7 @@ class Tests_Logging extends Give_Unit_Test_Case {
 	 * Test Logs CPT Labels
 	 */
 	public function test_post_type_labels() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types();
 		$this->assertEquals( 'Logs', $wp_post_types['give_log']->labels->name );
 		$this->assertEquals( 'Logs', $wp_post_types['give_log']->labels->singular_name );
 		$this->assertEquals( 'Add New', $wp_post_types['give_log']->labels->add_new );

--- a/tests/unit-tests/tests-post-types.php
+++ b/tests/unit-tests/tests-post-types.php
@@ -52,7 +52,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * Test Donation CPT Exists
 	 */
 	public function test_payment_post_type() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types( array(), 'names' );
 		$this->assertArrayHasKey( 'give_payment', $wp_post_types );
 	}
 
@@ -60,7 +60,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * Test Donation CPT Labels
 	 */
 	public function test_payment_post_type_labels() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types( array(), 'objects' );
 		$this->assertEquals( 'Donations', $wp_post_types['give_payment']->labels->name );
 		$this->assertEquals( 'Donation', $wp_post_types['give_payment']->labels->singular_name );
 		$this->assertEquals( 'Add New', $wp_post_types['give_payment']->labels->add_new );

--- a/tests/unit-tests/tests-post-types.php
+++ b/tests/unit-tests/tests-post-types.php
@@ -17,7 +17,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * @covers ::give_setup_post_types
 	 */
 	public function test_give_post_type() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types();
 		$this->assertArrayHasKey( 'give_forms', $wp_post_types );
 	}
 
@@ -25,7 +25,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * Test Post Type Labels
 	 */
 	public function test_give_post_type_labels() {
-		global $wp_post_types;
+		$wp_post_types = get_post_types();
 		$this->assertEquals( 'Donation Forms', $wp_post_types['give_forms']->labels->name );
 		$this->assertEquals( 'Form', $wp_post_types['give_forms']->labels->singular_name );
 		$this->assertEquals( 'Add Form', $wp_post_types['give_forms']->labels->add_new );

--- a/tests/unit-tests/tests-post-types.php
+++ b/tests/unit-tests/tests-post-types.php
@@ -17,7 +17,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * @covers ::give_setup_post_types
 	 */
 	public function test_give_post_type() {
-		$wp_post_types = get_post_types();
+		$wp_post_types = get_post_types( array(), 'names' );
 		$this->assertArrayHasKey( 'give_forms', $wp_post_types );
 	}
 
@@ -25,7 +25,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 	 * Test Post Type Labels
 	 */
 	public function test_give_post_type_labels() {
-		$wp_post_types = get_post_types();
+		$wp_post_types = get_post_types( array(), 'objects' );
 		$this->assertEquals( 'Donation Forms', $wp_post_types['give_forms']->labels->name );
 		$this->assertEquals( 'Form', $wp_post_types['give_forms']->labels->singular_name );
 		$this->assertEquals( 'Add Form', $wp_post_types['give_forms']->labels->add_new );


### PR DESCRIPTION
## Description
Replace `global $wp_post_types;` with `$wp_post_types = get_post_types();`

## Motivation and Context
Issue #1097 

## Types of changes
Non-breaking change which fixes an issue.