### PR TITLE
Issue/1099 - STOP USING `global $wp_taxonomies`

### DIFF
--- a/tests/unit-tests/tests-logging.php
+++ b/tests/unit-tests/tests-logging.php
@@ -62,7 +62,7 @@ class Tests_Logging extends Give_Unit_Test_Case {
 	 * Test Taxonomy Exist
 	 */
 	public function test_taxonomy_exist() {
-		global $wp_taxonomies;
+		$wp_taxonomies = get_taxonomies( array(), 'names' );
 		$this->assertArrayHasKey( 'give_log_type', $wp_taxonomies );
 	}
 


### PR DESCRIPTION
## Description
Replace `global $wp_taxonomies;` with `$wp_taxonomies = get_taxonomies();`

## Motivation and Context
Issue #1099  

## Types of changes
Non-breaking change which fixes an issue.