### PR TITLE
Fix admin_url() function usage

### DIFF
--- a/includes/admin/class-admin-notices.php
+++ b/includes/admin/class-admin-notices.php
@@ -49,7 +49,7 @@ class Give_Notices {
 		//Add the main siteadmin menu item.
 		$wp_admin_bar->add_menu( array(
 			'id'     => 'give-test-notice',
-			'href'   => admin_url() . 'edit.php?post_type=give_forms&page=give-settings&tab=gateways',
+			'href'   => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways' ),
 			'parent' => 'top-secondary',
 			'title'  => esc_html__( 'Give Test Mode Active', 'give' ),
 			'meta'   => array( 'class' => 'give-test-mode-active' ),

--- a/includes/admin/customers/class-customer-table.php
+++ b/includes/admin/customers/class-customer-table.php
@@ -114,7 +114,7 @@ class Give_Customer_Reports_Table extends WP_List_Table {
 
 			case 'num_purchases' :
 				$value = '<a href="' .
-				         admin_url( '/edit.php?post_type=give_forms&page=give-payment-history&user=' . urlencode( $item['email'] )
+				         admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&user=' . urlencode( $item['email'] )
 				         ) . '">' . esc_html( $item['num_purchases'] ) . '</a>';
 				break;
 

--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -137,9 +137,16 @@ function give_dashboard_at_a_glance_widget( $items ) {
 		$text = sprintf( $text, number_format_i18n( $num_posts->publish ) );
 
 		if ( current_user_can( 'edit_give_forms', get_current_user_id() ) ) {
-			$text = sprintf( '<a class="give-forms-count" href="edit.php?post_type=give_forms">%1$s</a>', $text );
+			$text = sprintf(
+				'<a class="give-forms-count" href="%1$s">%2$s</a>',
+				admin_url( 'edit.php?post_type=give_forms' ),
+				$text
+			);
 		} else {
-			$text = sprintf( '<span class="give-forms-count">%1$s</span>', $text );
+			$text = sprintf(
+				'<span class="give-forms-count">%1$s</span>',
+				$text
+			);
 		}
 
 		$items[] = $text;

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -322,7 +322,7 @@ function give_trigger_purchase_delete( $data ) {
 		}
 
 		give_delete_purchase( $payment_id );
-		wp_redirect( admin_url( '/edit.php?post_type=give_forms&page=give-payment-history&give-message=payment_deleted' ) );
+		wp_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&give-message=payment_deleted' ) );
 		give_die();
 	}
 }

--- a/includes/admin/reporting/class-donor-reports-table.php
+++ b/includes/admin/reporting/class-donor-reports-table.php
@@ -173,7 +173,7 @@ class Give_Donor_Reports_Table extends WP_List_Table {
 
 			case 'num_purchases' :
 				$value = '<a href="' .
-				         admin_url( '/edit.php?post_type=give_forms&page=give-payment-history&user=' . urlencode( $item['email'] )
+				         admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&user=' . urlencode( $item['email'] )
 				         ) . '">' . esc_html( $item['num_purchases'] ) . '</a>';
 				break;
 

--- a/includes/admin/welcome.php
+++ b/includes/admin/welcome.php
@@ -198,7 +198,7 @@ class Give_Welcome {
 			<a class="nav-tab <?php echo $selected == 'give-credits' ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( admin_url( add_query_arg( array( 'page' => 'give-credits' ), 'index.php' ) ) ); ?>">
 				<?php esc_html_e( 'Credits', 'give' ); ?>
 			</a>
-			<a class="nav-tab <?php echo $selected == 'give-add-ons' ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( admin_url( null, 'index.php' ) ) . 'edit.php?post_type=give_forms&page=give-addons'; ?>">
+			<a class="nav-tab <?php echo $selected == 'give-add-ons' ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-addons' ) ); ?>">
 				<?php esc_html_e( 'Add-ons', 'give' ); ?>
 			</a>
 		</h2>


### PR DESCRIPTION
## Description

In some place the `admin_url()` function was used not as it should be, for example the `$path` parameter was outside of the function or has a leading `/` character. Or in one case we used only the path, without the `admin_url()` function.

Any way, this PR fixes those issues.