### PR TITLE
i18n: Fix wrong use to translation string function

### DIFF
--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -278,9 +278,8 @@ class Give_Email_Access {
 
 		//Set error only if email access form isn't being submitted
 		if ( ! isset( $_POST['give_email'] ) && ! isset( $_POST['_wpnonce'] ) ) {
-			give_set_error( 'give_email_token_expired', apply_filters( 'give_email_token_expired_message', 'Your access token has expired. Please request a new one below:', 'give' ) );
+			give_set_error( 'give_email_token_expired', apply_filters( 'give_email_token_expired_message', esc_html__( 'Your access token has expired. Please request a new one below:', 'give' ) ) );
 		}
-
 
 		return false;
 


### PR DESCRIPTION
## Description

The filter did something wrong to the text... it's not translatable. This PR fixes the issue and makes the string translatable and filterable.