### PR TITLE
Issue/1131

### DIFF
--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -50,15 +50,10 @@ function give_edit_customer( $args ) {
 
 	$defaults = array(
 		'name'    => '',
-		'email'   => '',
 		'user_id' => 0
 	);
 
 	$customer_info = wp_parse_args( $customer_info, $defaults );
-
-	if ( ! is_email( $customer_info['email'] ) ) {
-		give_set_error( 'give-invalid-email', esc_html__( 'Please enter a valid email address.', 'give' ) );
-	}
 
 	if ( (int) $customer_info['user_id'] != (int) $customer->user_id ) {
 

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -112,7 +112,6 @@ function give_edit_customer( $args ) {
 	// Sanitize the inputs
 	$customer_data            = array();
 	$customer_data['name']    = strip_tags( stripslashes( $customer_info['name'] ) );
-	$customer_data['email']   = $customer_info['email'];
 	$customer_data['user_id'] = $customer_info['user_id'];
 
 	$customer_data = apply_filters( 'give_edit_customer_info', $customer_data, $customer_id );
@@ -134,7 +133,6 @@ function give_edit_customer( $args ) {
 	do_action( 'give_pre_edit_customer', $customer_id, $customer_data, $address );
 
 	$output         = array();
-	$previous_email = $customer->email;
 
 	if ( $customer->update( $customer_data ) ) {
 
@@ -144,12 +142,6 @@ function give_edit_customer( $args ) {
 
 		// Update some donation meta if we need to
 		$payments_array = explode( ',', $customer->payment_ids );
-
-		if ( $customer->email != $previous_email ) {
-			foreach ( $payments_array as $payment_id ) {
-				give_update_payment_meta( $payment_id, 'email', $customer->email );
-			}
-		}
 
 		if ( $customer->user_id != $previous_user_id ) {
 			foreach ( $payments_array as $payment_id ) {


### PR DESCRIPTION
## Description

Attempting to update donor info was causing an email validation error described in #1131.

As of 1.7 donor email updates are handled in their own functions outside of `give_edit_customer()`. For that reason, references to the email field are removed from `give_edit_customer()`.

Donor info can now be updated without error.

## How Has This Been Tested?

- Updated donor name without error.
- Updated donor address without error.
- Connected donor to user ID without error.
- Confirmed email validation and editing still work in the Donor Emails section added in 1.7.

## Types of changes

Fixes #1131

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.