### PR TITLE
Issue/1130

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -164,7 +164,7 @@ function give_send_to_success_page( $query_string = null ) {
  */
 function give_send_back_to_checkout( $args = array() ) {
 
-	$redirect = ( isset( $_POST['give-current-url'] ) ) ? $_POST['give-current-url'] : '';
+	$url = ( isset( $_POST['give-current-url'] ) ) ? $_POST['give-current-url'] : '';
 	$form_id  = isset( $_POST['give-form-id'] ) ? $_POST['give-form-id'] : 0;
 
 	$defaults = array(
@@ -178,7 +178,10 @@ function give_send_back_to_checkout( $args = array() ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
-	$redirect = add_query_arg( $args, $redirect ) . '#give-form-' . $form_id . '-wrap';
+	// Remove query string before adding new query args.
+	$url_parts = explode( '?', $url );
+
+	$redirect = add_query_arg( $args, $url_parts[0] ) . '#give-form-' . $form_id . '-wrap';
 
 	wp_redirect( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) );
 	give_die();


### PR DESCRIPTION
## Description

Previously query strings would compound in length with each successive error as described in #1130. By removing the query string before adding new args, we ensure the query string only reflects the most recent redirect.

## How Has This Been Tested?

- Submitted multiple forms with error-causing card numbers from https://stripe.com/docs/testing#cards.
- Confirmed query string is correct after multiple errors.

## Types of changes

Fixes #1130 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [ ] @ravinderk please test this against the errors you described in #1130.