### PR TITLE
Issue/509

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -263,6 +263,21 @@ function give_listen_for_failed_payments() {
 
 add_action( 'template_redirect', 'give_listen_for_failed_payments' );
 
+/**
+ * Retrieve the Donation History page URI
+ *
+ * @access      public
+ * @since       1.7
+ *
+ * @return      string
+ */
+function give_get_history_page_uri() {
+	$give_options = give_get_settings();
+
+	$history_page = isset( $give_options['history_page'] ) ? get_permalink( absint( $give_options['history_page'] ) ) : get_bloginfo( 'url' );
+
+	return apply_filters( 'give_get_history_page_uri', $history_page );
+}
 
 /**
  * Check if a field is required

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -238,7 +238,7 @@ function give_receipt_shortcode( $atts ) {
 		'payment_method' => true,
 		'payment_id'     => true,
 		'payment_status' => false,
-		'notice'         => true,
+		'status_notice'  => true,
 	), $atts, 'give_receipt' );
 
 	//set $session var

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -25,6 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function give_donation_history() {
 
+	// If payment_key query arg exists, return receipt instead of donation history.
+	if ( isset( $_GET['payment_key'] ) ) {
+		return give_receipt_shortcode( array() );
+	}
+
 	$email_access = give_get_option( 'email_access' );
 
 	//Is user logged in? Does a session exist? Does an email-access token exist?

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -27,7 +27,11 @@ function give_donation_history() {
 
 	// If payment_key query arg exists, return receipt instead of donation history.
 	if ( isset( $_GET['payment_key'] ) ) {
-		return give_receipt_shortcode( array() );
+		ob_start();
+		echo give_receipt_shortcode( array() );
+		echo '<a href="' . esc_url( give_get_history_page_uri() ) . '">&laquo; ' . esc_html__( 'Return to All Donations', 'give' ) . '</a>';
+
+		return ob_get_clean();
 	}
 
 	$email_access = give_get_option( 'email_access' );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -236,7 +236,9 @@ function give_receipt_shortcode( $atts ) {
 		'date'           => true,
 		'payment_key'    => false,
 		'payment_method' => true,
-		'payment_id'     => true
+		'payment_id'     => true,
+		'payment_status' => false,
+		'notice'         => true,
 	), $atts, 'give_receipt' );
 
 	//set $session var

--- a/templates/history-donations.php
+++ b/templates/history-donations.php
@@ -68,9 +68,9 @@ if ( $donations ) : ?>
 				</td>
 				<td class="give_purchase_details">
 					<?php if ( $post->post_status != 'publish' && $post->post_status != 'subscription' ) : ?>
-						<a href="<?php echo esc_url( add_query_arg( 'payment_key', give_get_payment_key( $post->ID ), give_get_success_page_uri() ) ); ?>"><span class="give_purchase_status <?php echo $post->post_status; ?>"><?php echo give_get_payment_status( $post, true ); ?></span></a>
+						<a href="<?php echo esc_url( add_query_arg( 'payment_key', give_get_payment_key( $post->ID ), give_get_history_page_uri() ) ); ?>"><span class="give_purchase_status <?php echo $post->post_status; ?>"><?php echo give_get_payment_status( $post, true ); ?></span></a>
 					<?php else: ?>
-						<a href="<?php echo esc_url( add_query_arg( 'payment_key', give_get_payment_key( $post->ID ), give_get_success_page_uri() ) ); ?>"><?php esc_html_e( 'View Receipt', 'give' ); ?></a>
+						<a href="<?php echo esc_url( add_query_arg( 'payment_key', give_get_payment_key( $post->ID ), give_get_history_page_uri() ) ); ?>"><?php esc_html_e( 'View Receipt', 'give' ); ?></a>
 					<?php endif; ?>
 				</td>
 				<?php

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -24,7 +24,7 @@ $status         = $payment->post_status;
 $status_label   = give_get_payment_status( $payment, true );
 
 // Show payment status notice based on shortcode attribute.
-if ( true === $give_receipt_args['notice'] ) {
+if ( true === $give_receipt_args['status_notice'] ) {
 	$notice_message = '';
 	$notice_type    = 'warning';
 

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -16,12 +16,67 @@ if ( empty( $payment ) ) {
 	return;
 }
 
-$meta         = give_get_payment_meta( $payment->ID );
-$donation     = give_get_payment_form_title( $meta );
-$user         = give_get_payment_meta_user_info( $payment->ID );
-$email        = give_get_payment_user_email( $payment->ID );
-$status       = $payment->post_status;
-$status_label = give_get_payment_status( $payment, true );
+$meta           = give_get_payment_meta( $payment->ID );
+$donation       = give_get_payment_form_title( $meta );
+$user           = give_get_payment_meta_user_info( $payment->ID );
+$email          = give_get_payment_user_email( $payment->ID );
+$status         = $payment->post_status;
+$status_label   = give_get_payment_status( $payment, true );
+$notice_message = '';
+$notice_type    = 'warning';
+
+switch( $status ) {
+	case 'publish':
+		$notice_message = __( 'Payment Complete: Thank you for your donation.', 'give' );
+		$notice_type = 'success';
+		break;
+	case 'pending':
+		$notice_message = __( 'Payment Pending: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'warning';
+		break;
+	case 'refunded':
+		$notice_message = __( 'Payment Refunded: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'warning';
+		break;
+	case 'preapproval':
+		$notice_message = __( 'Payment Preapproved: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'warning';
+		break;
+	case 'failed':
+		$notice_message = __( 'Payment Failed: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'error';
+		break;
+	case 'cancelled':
+		$notice_message = __( 'Payment Cancelled: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'error';
+		break;
+	case 'abandoned':
+		$notice_message = __( 'Payment Abandoned: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'error';
+		break;
+	case 'revoked':
+		$notice_message = __( 'Payment Revoked: Please contact the site owner for assistance.', 'give' );
+		$notice_type = 'error';
+		break;
+}
+
+if ( ! empty( $notice_message ) ) {
+	/**
+	 * Filters payment status notice for receipts.
+	 *
+	 * By default, a success, warning, or error notice appears on the receipt
+	 * with payment status. This filter allows the HTML markup
+	 * and messaging for that notice to be customized.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $notice HTML markup for the default notice.
+	 * @param int    $id     Post ID where the notice is displayed.
+	 * @param string $status Payment status.
+	 * @param array  $meta   Array of meta data related to the payment.
+	 */
+	echo apply_filters( 'give_receipt_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
+}
 
 /**
  * Fires in the payment receipt shortcode, before the receipt main table.

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -167,10 +167,12 @@ do_action( 'give_donation_receipt_before_table', $payment, $give_receipt_args );
 			<td class="give_receipt_payment_status"><?php echo $donation; ?></td>
 		</tr>
 
-		<tr>
-			<td scope="row" class="give_receipt_payment_status"><strong><?php esc_html_e( 'Donation Status:', 'give' ); ?></strong></td>
-			<td class="give_receipt_payment_status <?php echo esc_attr( $status ); ?>"><?php echo $status_label; ?></td>
-		</tr>
+		<?php if ( filter_var( $give_receipt_args['payment_status'], FILTER_VALIDATE_BOOLEAN ) ) : ?>
+			<tr>
+				<td scope="row" class="give_receipt_payment_status"> <strong><?php esc_html_e( 'Donation Status:', 'give' ); ?></strong> </td>
+				<td class="give_receipt_payment_status <?php echo esc_attr( $status ); ?>"><?php echo $status_label; ?></td>
+			</tr>
+		<?php endif; ?>
 
 		<?php if ( filter_var( $give_receipt_args['payment_id'], FILTER_VALIDATE_BOOLEAN ) ) : ?>
 			<tr>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -16,11 +16,12 @@ if ( empty( $payment ) ) {
 	return;
 }
 
-$meta     = give_get_payment_meta( $payment->ID );
-$donation = give_get_payment_form_title( $meta );
-$user     = give_get_payment_meta_user_info( $payment->ID );
-$email    = give_get_payment_user_email( $payment->ID );
-$status   = give_get_payment_status( $payment, true );
+$meta         = give_get_payment_meta( $payment->ID );
+$donation     = give_get_payment_form_title( $meta );
+$user         = give_get_payment_meta_user_info( $payment->ID );
+$email        = give_get_payment_user_email( $payment->ID );
+$status       = $payment->post_status;
+$status_label = give_get_payment_status( $payment, true );
 
 /**
  * Fires in the payment receipt shortcode, before the receipt main table.

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -114,7 +114,7 @@ do_action( 'give_donation_receipt_before_table', $payment, $give_receipt_args );
 
 		<tr>
 			<td scope="row" class="give_receipt_payment_status"><strong><?php esc_html_e( 'Donation Status:', 'give' ); ?></strong></td>
-			<td class="give_receipt_payment_status <?php echo strtolower( $status ); ?>"><?php echo $status; ?></td>
+			<td class="give_receipt_payment_status <?php echo esc_attr( $status ); ?>"><?php echo $status_label; ?></td>
 		</tr>
 
 		<?php if ( filter_var( $give_receipt_args['payment_id'], FILTER_VALIDATE_BOOLEAN ) ) : ?>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -22,60 +22,64 @@ $user           = give_get_payment_meta_user_info( $payment->ID );
 $email          = give_get_payment_user_email( $payment->ID );
 $status         = $payment->post_status;
 $status_label   = give_get_payment_status( $payment, true );
-$notice_message = '';
-$notice_type    = 'warning';
 
-switch( $status ) {
-	case 'publish':
-		$notice_message = __( 'Payment Complete: Thank you for your donation.', 'give' );
-		$notice_type = 'success';
-		break;
-	case 'pending':
-		$notice_message = __( 'Payment Pending: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'warning';
-		break;
-	case 'refunded':
-		$notice_message = __( 'Payment Refunded: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'warning';
-		break;
-	case 'preapproval':
-		$notice_message = __( 'Payment Preapproved: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'warning';
-		break;
-	case 'failed':
-		$notice_message = __( 'Payment Failed: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'error';
-		break;
-	case 'cancelled':
-		$notice_message = __( 'Payment Cancelled: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'error';
-		break;
-	case 'abandoned':
-		$notice_message = __( 'Payment Abandoned: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'error';
-		break;
-	case 'revoked':
-		$notice_message = __( 'Payment Revoked: Please contact the site owner for assistance.', 'give' );
-		$notice_type = 'error';
-		break;
-}
+// Show payment status notice based on shortcode attribute.
+if ( true === $give_receipt_args['notice'] ) {
+	$notice_message = '';
+	$notice_type    = 'warning';
 
-if ( ! empty( $notice_message ) ) {
-	/**
-	 * Filters payment status notice for receipts.
-	 *
-	 * By default, a success, warning, or error notice appears on the receipt
-	 * with payment status. This filter allows the HTML markup
-	 * and messaging for that notice to be customized.
-	 *
-	 * @since 1.7.0
-	 *
-	 * @param string $notice HTML markup for the default notice.
-	 * @param int    $id     Post ID where the notice is displayed.
-	 * @param string $status Payment status.
-	 * @param array  $meta   Array of meta data related to the payment.
-	 */
-	echo apply_filters( 'give_receipt_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
+	switch ( $status ) {
+		case 'publish':
+			$notice_message = __( 'Payment Complete: Thank you for your donation.', 'give' );
+			$notice_type    = 'success';
+			break;
+		case 'pending':
+			$notice_message = __( 'Payment Pending: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'warning';
+			break;
+		case 'refunded':
+			$notice_message = __( 'Payment Refunded: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'warning';
+			break;
+		case 'preapproval':
+			$notice_message = __( 'Payment Preapproved: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'warning';
+			break;
+		case 'failed':
+			$notice_message = __( 'Payment Failed: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'error';
+			break;
+		case 'cancelled':
+			$notice_message = __( 'Payment Cancelled: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'error';
+			break;
+		case 'abandoned':
+			$notice_message = __( 'Payment Abandoned: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'error';
+			break;
+		case 'revoked':
+			$notice_message = __( 'Payment Revoked: Please contact the site owner for assistance.', 'give' );
+			$notice_type    = 'error';
+			break;
+	}
+
+	if ( ! empty( $notice_message ) ) {
+		/**
+		 * Filters payment status notice for receipts.
+		 *
+		 * By default, a success, warning, or error notice appears on the receipt
+		 * with payment status. This filter allows the HTML markup
+		 * and messaging for that notice to be customized.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param string $notice HTML markup for the default notice.
+		 * @param int    $id     Post ID where the notice is displayed.
+		 * @param string $status Payment status.
+		 * @param array  $meta   Array of meta data related to the payment.
+		 */
+		echo apply_filters( 'give_receipt_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
+	}
 }
 
 /**

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -78,7 +78,7 @@ if ( true === $give_receipt_args['status_notice'] ) {
 		 * @param string $status Payment status.
 		 * @param array  $meta   Array of meta data related to the payment.
 		 */
-		echo apply_filters( 'give_receipt_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
+		echo apply_filters( 'give_receipt_status_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
 	}
 }
 


### PR DESCRIPTION
## Description

Improves receipt-viewing experience discussed in #509 with the following changes:

- Receipts now display on Donation History page instead of Donation Confirmation page, allowing for a more predictable UI when clicking into an individual receipt.
- Whether user sees full donation history or individual receipt depends on presence of `payment_key` query arg in URL.
- Link back to all donations is provided below receipt.
- `[give_receipt]` shortcode has two new attributes:
    - `payment_status` determines whether status row within receipt is displayed. Default `false`.
    - `status_notice` determines whether notice above receipt is displayed. Default `true`.
- `give_receipt_status_notice` filter allows users to filter the notice.

## How Has This Been Tested?

- Created a donation with each possible status.
- Confirmed each status displays the relevant notice.
- Confirmed Donation Status row is hidden by default.
- Confirmed shortcode atts can override default behavior.
- Tested against non-English locales.

## Screenshots (jpeg or gifs if applicable):

![509-give-receipt-notice-low](https://cloud.githubusercontent.com/assets/1938671/19606804/34cb755e-9793-11e6-8bd0-74499da8d4e2.png)

## Types of changes

Resolves #509

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

## Documentation Updates

@mathetos We will need to update https://givewp.com/documentation/core/shortcodes/give_receipt/ with the following changes:

- [ ] Clarify when receipt appears on Donation Confirmation page vs. Donation History page.
- [ ] Document new `[give_receipt]` shortcode attributes.
- [ ] Document new `give_receipt_status_notice` filter with examples.

### New Filter: `give_receipt_status_notice`

```
/**
 * Filters payment status notice for receipts.
 *
 * By default, a success, warning, or error notice appears on the receipt
 * with payment status. This filter allows the HTML markup
 * and messaging for that notice to be customized.
 *
 * @since 1.7.0
 *
 * @param string $notice HTML markup for the default notice.
 * @param int    $id     Post ID where the notice is displayed.
 * @param string $status Payment status.
 * @param array  $meta   Array of meta data related to the payment.
 */
echo apply_filters( 'give_receipt_status_notice', give_output_error( $notice_message, false, $notice_type ), $id, $status, $meta );
```

### Basic Example

Customize an error notice based on donation status.

```
function prefix_custom_failed_notice( $notice, $id, $status, $meta ) {
	if ( 'failed' === $status ) {
		return give_output_error( __( 'Whoops! Something went wrong.' ), false, 'failed' );
	}

	return $notice;
}
add_filter( 'give_receipt_status_notice', 'prefix_custom_failed_notice', 10, 4 );
```

### Advanced Example

Personalize a success notice with the donor's first name. This is possible because we are passing `$meta` to the hooked function.

```
function prefix_personalized_success_notice( $notice, $id, $status, $meta ) {
	if ( 'publish' === $status ) {
		$first_name = $meta['user_info']['first_name'];
		$notice_message = sprintf( __( '%s, your generous donation is most appreciated!', 'text_domain' ), $first_name );

		return give_output_error( $notice_message, false, 'success' );
	}

	return $notice;
}
add_filter( 'give_receipt_status_notice', 'prefix_personalized_success_notice', 10, 4 );
```