### PR TITLE
Issue/1130

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -188,12 +188,16 @@ function give_send_back_to_checkout( $args = array() ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
-	// Remove query string before adding new query args.
-	$url_parts = explode( '?', $url );
+	// Merge URL query with $args to maintain third-party URL parameters after redirect.
+	$url_data = wp_parse_url( $url );
+	parse_str( $url_data['query'], $query );
+	$new_query = array_merge( $args, $query );
+	$new_query_string = http_build_query( $new_query );
 
-	$redirect = add_query_arg( $args, $url_parts[0] ) . '#give-form-' . $form_id . '-wrap';
+	// Assemble URL parts.
+	$redirect = home_url( '/' . $url_data['path'] . '?' . $new_query_string . '#give-form-' . $form_id . '-wrap' );
 
-	wp_redirect( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) );
+	wp_safe_redirect( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) );
 	give_die();
 }
 

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -164,8 +164,18 @@ function give_send_to_success_page( $query_string = null ) {
  */
 function give_send_back_to_checkout( $args = array() ) {
 
-	$url = ( isset( $_POST['give-current-url'] ) ) ? $_POST['give-current-url'] : '';
-	$form_id  = isset( $_POST['give-form-id'] ) ? $_POST['give-form-id'] : 0;
+	if ( isset( $_POST['give-current-url'] ) ) {
+		$url = sanitize_text_field( $_POST['give-current-url']);
+	} else {
+		wp_safe_redirect( home_url() );
+		give_die();
+	}
+
+	if ( isset( $_POST['give-form-id'] ) ) {
+		$form_id = sanitize_text_field( $_POST['give-form-id']);
+	} else {
+		$form_id = 0;
+	}
 
 	$defaults = array(
 		'form-id' => (int) $form_id

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -48,11 +48,11 @@ function give_get_donation_form( $args = array() ) {
 
 	$payment_mode = give_get_chosen_gateway( $form->ID );
 
-	$form_action = esc_url( add_query_arg( apply_filters( 'give_form_action_args', array(
+	$form_action = add_query_arg( apply_filters( 'give_form_action_args', array(
 		'payment-mode' => $payment_mode,
 	) ),
 		give_get_current_page_url()
-	) );
+	);
 
 	//Sanity Check: Donation form not published or user doesn't have permission to view drafts
 	if ( 'publish' !== $form->post_status && ! current_user_can( 'edit_give_forms', $form->ID ) ) {
@@ -98,7 +98,7 @@ function give_get_donation_form( $args = array() ) {
 
 			do_action( 'give_pre_form', $form->ID, $args ); ?>
 
-			<form id="give-form-<?php echo $form_id; ?>" class="<?php echo $form_classes; ?>" action="<?php echo $form_action; ?>" method="post">
+			<form id="give-form-<?php echo $form_id; ?>" class="<?php echo $form_classes; ?>" action="<?php echo esc_url_raw( $form_action ); ?>" method="post">
 				<input type="hidden" name="give-form-id" value="<?php echo $form->ID; ?>"/>
 				<input type="hidden" name="give-form-title" value="<?php echo htmlentities( $form->post_title ); ?>"/>
 				<input type="hidden" name="give-current-url" value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -212,7 +212,9 @@ function give_get_current_page_url() {
 	if ( is_front_page() ) {
 		$current_url = home_url( '/' );
 	} else {
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . untrailingslashit( $_SERVER['REQUEST_URI'] ) );
+		$http_host = sanitize_text_field( $_SERVER['HTTP_HOST'] );
+		$request_uri = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+		$current_url = set_url_scheme( 'http://' . $http_host . untrailingslashit( $request_uri ) );
 	}
 
 	return apply_filters( 'give_get_current_page_url', $current_url );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -215,7 +215,7 @@ function give_get_current_page_url() {
 		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . untrailingslashit( $_SERVER['REQUEST_URI'] ) );
 	}
 
-	return apply_filters( 'give_get_current_page_url', esc_url( $current_url ) );
+	return apply_filters( 'give_get_current_page_url', $current_url );
 }
 
 


### PR DESCRIPTION
## Description

- Prevents query strings from compounding in length as described in #1130.
- Maintains all query parameters that were present before the error so they still exist after redirect.
- Sanitizes `$_POST` and `$_SERVER` values early.
- Escapes URL late as described in #1146.

## How Has This Been Tested?

- Added multiple custom query params to form URL.
- Submitted multiple forms with error-causing card numbers from https://stripe.com/docs/testing#cards.
- Confirmed query string is correct after multiple errors.

## Types of changes

Fixes #1130 
Fixes #1146

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.