### PR TITLE
Issue/1141

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -564,9 +564,9 @@ function give_check_for_existing_payment( $payment_id ) {
  *
  * @since 1.0
  *
- * @param WP_Post $payment      Payment ID.
- * @param bool    $return_label Whether to return the donation status or not.
- *
+ * @param WP_Post $payment      Payment object.
+ * @param bool    $return_label Whether to return the translated status label
+ *                              instead of status value. Default false.
  * @return bool|mixed True if payment status exists, false otherwise.
  */
 function give_get_payment_status( $payment, $return_label = false ) {

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -585,13 +585,11 @@ function give_get_payment_status( $payment, $return_label = false ) {
 
 	if ( array_key_exists( $payment->status, $statuses ) ) {
 		if ( true === $return_label ) {
+			// Return translated status label.
 			return $statuses[ $payment->status ];
 		} else {
-			// Account that our 'publish' status is labeled 'Complete'.
-			$post_status = 'publish' == $payment->status ? 'Complete' : $payment->post_status;
-
-			// Make sure we're matching cases, since they matter.
-			return array_search( strtolower( $post_status ), array_map( 'strtolower', $statuses ) );
+			// Return status value.
+			return $payment->status;
 		}
 	}
 

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -174,7 +174,7 @@ do_action( 'give_donation_receipt_before_table', $payment, $give_receipt_args );
 		<?php if ( filter_var( $give_receipt_args['payment_status'], FILTER_VALIDATE_BOOLEAN ) ) : ?>
 			<tr>
 				<td scope="row" class="give_receipt_payment_status"> <strong><?php esc_html_e( 'Donation Status:', 'give' ); ?></strong> </td>
-				<td class="give_receipt_payment_status <?php echo esc_attr( $status ); ?>"><?php echo $status_label; ?></td>
+				<td class="give_receipt_payment_status <?php echo esc_attr( $status ); ?>"><?php echo esc_html( $status_label ); ?></td>
 			</tr>
 		<?php endif; ?>
 


### PR DESCRIPTION
## Description

- Corrected DocBlock parameter descriptions for `give_get_payment_status()`.
- Return payment status as described in #1141.
- Escape payment status label prior to output in receipt table.

## How Has This Been Tested?

- Tested `give_payement_status()` return values in multiple languages.
- Confirmed that `give_payment_status( $payment, false )` returns unmodified status value as it exists in database.
- Confirmed that `give_payment_status( $payment, true )` returns translated status label.

## Types of changes

Fixes #1141

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.