### PR TITLE
Add select box to choose logo size on email tab in settings

### DIFF
--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -543,6 +543,19 @@ class Give_Plugin_Settings {
 							'type' => 'file'
 						),
 						array(
+						    'id'      => 'email_logo_size',
+						    'name'    => esc_html( 'Select Logo Size', 'give' ),
+						    'desc'    => esc_html( 'Choose which size to display logo', 'give' ),
+						    'type'    => 'select',
+						    'options' => array(
+						        'full' 		=> __( 'Full', 'give' ),
+						        'large'   	=> __( 'Large', 'give' ),
+						        'medium'    => __( 'Medium', 'give' ),
+						        'thumbnail' => __( 'Thumbnail', 'give' )
+						    ),
+						    'default' => 'full',
+						),
+						array(
 							'id'      => 'from_name',
 							'name'    => esc_html__( 'From Name', 'give' ),
 							'desc'    => esc_html__( 'The name donation receipts are said to come from. This is most likely the name of your organization or website.', 'give' ),

--- a/templates/emails/header-default.php
+++ b/templates/emails/header-default.php
@@ -58,7 +58,9 @@ $header_content_h1 = "
 	font-weight: 500;
 	line-height: 1.2;
 ";
-$header_img = give_get_option( 'email_logo', '' );
+$header_img_id = give_get_option( 'email_logo_id', '' );
+$logo_size = give_get_option( 'email_logo_size', '' );
+$header_img = $header_img_id == '' ? give_get_option( 'email_logo' ) : wp_get_attachment_image_src( $header_img_id, $logo_size )[0];
 ?>
 <!DOCTYPE html>
 <html>

--- a/templates/emails/header-default.php
+++ b/templates/emails/header-default.php
@@ -60,7 +60,8 @@ $header_content_h1 = "
 ";
 $header_img_id = give_get_option( 'email_logo_id', '' );
 $logo_size = give_get_option( 'email_logo_size', '' );
-$header_img = $header_img_id == '' ? give_get_option( 'email_logo' ) : wp_get_attachment_image_src( $header_img_id, $logo_size )[0];
+$header_img_array = wp_get_attachment_image_src( $header_img_id, $logo_size );
+$header_img = is_array( $header_img_array ) ? $header_img_array[0] : give_get_option( 'email_logo', '' );
 ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
When adding a logo image in the 'emails' settings tab you cannot select which size image you want to display.  I added a select box which uses the native WP image sizes to control the image size displayed in the email.  
   
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I used multiple images testing all sizes in the email preview view.  I also tested using a URL from an image hosted on another site.  

## Types of changes
<!--- What types of changes does your code introduce?  -->
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
