### PR TITLE
Issues/1191

### DIFF
--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -334,7 +334,8 @@ class GIVE_CLI_COMMAND {
 	 * : The number of donor to retrieve
 	 *
 	 * [--create=<number>]
-	 * : The number of arbitrary donors to create. Leave as 1 or blank to create a donor with a specific email
+	 * : The number of arbitrary donors to create. Leave as 1 or blank to create a
+	 * donor with a specific email
 	 *
 	 * [--form-id=<donation_form_id>]
 	 * : Get list of donors of specific donation form

--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -342,6 +342,9 @@ class GIVE_CLI_COMMAND {
 	 * [--name=<name_of_donor>]
 	 * : Name with which you want to create new donor
 	 *
+	 * [--format=<output_format>]
+	 * : In which format you want to see results. Valid formats: table, json, csv
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp give donors --id=103
@@ -370,6 +373,7 @@ class GIVE_CLI_COMMAND {
 		$create   = isset( $assoc_args ) && array_key_exists( 'create', $assoc_args ) ? $assoc_args['create'] : false;
 		$number   = isset( $assoc_args ) && array_key_exists( 'number', $assoc_args ) ? $assoc_args['number'] : 10;
 		$form_id  = isset( $assoc_args ) && array_key_exists( 'form-id', $assoc_args ) ? $assoc_args['form-id'] : 0;
+		$format   = isset( $assoc_args ) && array_key_exists( 'format', $assoc_args ) ? $assoc_args['format'] : 'table';
 		$start    = time();
 
 		if ( $create ) {

--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -532,6 +532,24 @@ class GIVE_CLI_COMMAND {
 					WP_CLI::log( json_encode( $new_table_data ) );
 					break;
 
+				case 'csv':
+					$file_path = trailingslashit( WP_CONTENT_DIR ) . 'uploads/give_donors_' . date( 'Y_m_d_s', current_time( 'timestamp' ) ) . '.csv';
+					$fp        = fopen( $file_path, 'w' );
+
+					if( is_writable( $file_path ) ) {
+						foreach ( $table_data as $fields ) {
+							fputcsv( $fp, $fields );
+						}
+
+						fclose( $fp );
+
+						WP_CLI::success( "Donors list csv created successfully: {$file_path}" );
+					} else{
+						WP_CLI::warning( "Unable to create donors list csv file: {$file_path} (May folder do not have write permission)" );
+					}
+
+					break;
+
 				default:
 					$this->display_table( $table_data );
 			}

--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -465,7 +465,7 @@ class GIVE_CLI_COMMAND {
 
 			foreach ( $donors['donors'] as $donor_data ) {
 				// Set default table row data.
-				$table_first_row = array( __( 'S. No.', 'give' ) );
+				$table_first_row = array( __( 's_no', 'give' ) );
 				$table_row       = array( self::$counter );
 
 				foreach ( $donor_data as $key => $donor ) {
@@ -516,7 +516,24 @@ class GIVE_CLI_COMMAND {
 				self::$counter ++;
 			}
 
-			$this->display_table( $table_data );
+			switch ( $format ) {
+				case 'json':
+					$table_column_name = $table_data[0];
+					unset( $table_data[0] );
+					
+					$new_table_data = array();
+					foreach ( $table_data as $index => $data ) {
+						foreach ( $data as $key => $value ) {
+							$new_table_data[$index][$table_column_name[$key]] = $value;
+						}
+					}
+
+					WP_CLI::log( json_encode( $new_table_data ) );
+					break;
+
+				default:
+					$this->display_table( $table_data );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
This pr will fix #1191.
```
wp give donors --format=table (default)
wp give donors --format=csv (comma-separated list)
wp give donors --format=tab (tab-separated list) [ i am waiting for shawnhooper reply on this]
wp give donors --format=json (JSON string)
```

## How Has This Been Tested?
By running command in terminal

## Screenshots (jpeg or gifs if applicable):
![give-cli-format-support](https://cloud.githubusercontent.com/assets/1784821/20172220/295c3222-a75a-11e6-8e5a-6717ae4c0b42.gif)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.