### PR TITLE
Issue/1247

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1769,19 +1769,22 @@ function give_filter_where_older_than_week( $where = '' ) {
 function give_get_payment_form_title( $payment_meta, $include_level_name = false, $separator = '' ) {
 
 	$form_id    = isset( $payment_meta['form_id'] ) ? $payment_meta['form_id'] : 0;
-	$form_title = isset( $payment_meta['form_title'] ) ? $payment_meta['form_title'] : '';
 	$price_id   = isset( $payment_meta['price_id'] ) ? $payment_meta['price_id'] : null;
+	$form_title = isset( $payment_meta['form_title'] ) ? $payment_meta['form_title'] : '';
 
 	if ( $include_level_name == true ) {
 		$form_title = '';
 	}
 
+	//If multi-level, append to the form title.
 	if ( give_has_variable_prices( $form_id ) ) {
 
-		if ( ! empty( $form_title ) && ! empty( $separator ) ) {
-			$form_title .= ' ' . $separator;
+		//Only add separator if there is a form title.
+		if ( ! empty( $form_title ) ) {
+			$form_title .= ' ' . $separator . ' ';
 		}
-		$form_title .= ' <span class="donation-level-text-wrap">';
+
+		$form_title .= '<span class="donation-level-text-wrap">';
 
 		if ( $price_id == 'custom' ) {
 			$custom_amount_text = get_post_meta( $form_id, '_give_custom_amount_text', true );

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1754,38 +1754,38 @@ function give_filter_where_older_than_week( $where = '' ) {
 
 
 /**
- * Get Payment Form ID
+ * Get Payment Form ID.
  *
- * Retrieves the form title and appends the price ID title if applicable.
+ * Retrieves the form title and appends the level name if present.
  *
  * @since 1.5
  *
- * @param array  $payment_meta Payment meta data.
- * @param bool   $level_title  Whether you want the entire title or just the level title.
- * @param string $separator    Separator.
+ * @param array  $payment_meta       Payment meta data.
+ * @param bool   $include_level_name Whether you want the entire title or just the level name.
+ * @param string $separator          The separator between the .
  *
- * @return string $form_title Returns the full title if $level_title false, otherwise returns the levels title.
+ * @return string $form_title Returns the full title if $include_level_name is false, otherwise returns the levels title.
  */
-function give_get_payment_form_title( $payment_meta, $level_title = false, $separator = '' ) {
+function give_get_payment_form_title( $payment_meta, $include_level_name = false, $separator = '' ) {
 
 	$form_id    = isset( $payment_meta['form_id'] ) ? $payment_meta['form_id'] : 0;
 	$form_title = isset( $payment_meta['form_title'] ) ? $payment_meta['form_title'] : '';
 	$price_id   = isset( $payment_meta['price_id'] ) ? $payment_meta['price_id'] : null;
 
-	if ( $level_title == true ) {
+	if ( $include_level_name == true ) {
 		$form_title = '';
 	}
 
 	if ( give_has_variable_prices( $form_id ) ) {
 
-		if ( ! empty( $separator ) ) {
+		if ( ! empty( $form_title ) && ! empty( $separator ) ) {
 			$form_title .= ' ' . $separator;
 		}
 		$form_title .= ' <span class="donation-level-text-wrap">';
 
 		if ( $price_id == 'custom' ) {
 			$custom_amount_text = get_post_meta( $form_id, '_give_custom_amount_text', true );
-			$form_title .= ! empty( $custom_amount_text ) ? $custom_amount_text : esc_html__( 'Custom Amount', 'give' );
+			$form_title .= ! empty( $custom_amount_text ) ? $custom_amount_text : __( 'Custom Amount', 'give' );
 		} else {
 			$form_title .= give_get_price_option_name( $form_id, $price_id );
 		}


### PR DESCRIPTION
## Description
Revamps `give_get_payment_form_title` to only apply the separator and spacing if a form title is present. Some people create forms without titles and it looks strange #1247 when output.

## How Has This Been Tested?
Multiple test transactions and email previews.

## Types of changes
<!--- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.