### PR TITLE
refactor give_get_payment_status

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -564,9 +564,9 @@ function give_check_for_existing_payment( $payment_id ) {
  *
  * @since 1.0
  *
- * @param WP_Post $payment      Payment object.
- * @param bool    $return_label Whether to return the translated status label
- *                              instead of status value. Default false.
+ * @param WP_Post|Give_Payment $payment      Payment object.
+ * @param bool                 $return_label Whether to return the translated status label
+ *                                           instead of status value. Default false.
  *
  * @return bool|mixed True if payment status exists, false otherwise.
  */
@@ -582,7 +582,8 @@ function give_get_payment_status( $payment, $return_label = false ) {
 		return false;
 	}
 
-	$payment = new Give_Payment( $payment->ID );
+	// Get payment object if no already given.
+	$payment = $payment instanceof Give_Payment ? $payment : new Give_Payment( $payment->ID );
 
 	if ( array_key_exists( $payment->status, $statuses ) ) {
 		if ( true === $return_label ) {


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
We can pass the first param of `give_get_payment_status`  as an object which can be an instance of `WP_Post` or `Give_Payment`, so if param is an instance of `Give_Payment` there are not need to recreate of an object.

## How Has This Been Tested?
By visiting some page like donations list where `give_get_payment_status` function is using.

## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
perfomance improvment

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
