### PR TITLE
donors export: show custom fields to be added inside the CSV export

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -420,8 +420,19 @@ function give_reports_tab_export() {
 											<label for="give-export-donation-sum"><input type="checkbox" checked name="give_export_option[donation_sum]" id="give-export-donation-sum"><?php esc_html_e( 'Total Donated', 'give' ); ?>
 											</label>
 										</li>
+										<?php
+										$custom_cols = [];
+										$custom_cols = apply_filters( 'give_export_csv_cols_customers', $custom_cols );
+										foreach($custom_cols as $col_id => $col_name):
+										?>
+										  <li>
+										    <label for="give-export-<?= str_replace('_','-',$col_id) ?>"><input type="checkbox" class="give_custom_field" checked="checked" readonly="readonly" name="give_export_option[<?= $col_id ?>]" id="give-export-<?= str_replace('_','-',$col_id) ?>"><?php esc_html_e( $col_name, 'give' ); ?>
+										    </label>
+										  </li>
+										<?php endforeach; ?>
 									</ul>
 								</div>
+
 								<?php wp_nonce_field( 'give_ajax_export', 'give_ajax_export' ); ?>
 								<input type="hidden" name="give-export-class" value="Give_Batch_Customers_Export"/>
 								<input type="hidden" name="give-action" value="email_export"/>


### PR DESCRIPTION
## Description
show custom fields to be added inside the CSV export (see issue #744 )

## How Has This Been Tested?

Go inside wp-admin/edit.php?post_type=give_forms&page=give-reports&tab=export
Visual testing: HTML difference only if hook is implemented

## Screenshots (jpeg or gifs if applicable):

## Types of changes

![screenshot-2016-11-30_22-30-51-crop](https://cloud.githubusercontent.com/assets/1169926/20778493/e3942a8a-b74c-11e6-9164-36b2d72e0aa4.png)

HTML changes in the backoffice for hooks implementers
(no change if `give_export_csv_cols_customers` isn't implemented)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
