### PR TITLE
Update cmb2 backword competibility to WP version 4.7

### DIFF
--- a/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
+++ b/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
@@ -389,6 +389,7 @@ if ( ! class_exists( 'Give_CMB2_Settings_Loader' ) ) :
 				}
 
 				// Third party plugin backward compatibility.
+				$wp_filter_keys = array_keys( $wp_filter );
 				foreach ( $new_setting_fields as $index => $field ) {
 
 					if ( in_array( $field['type'], array( 'title', 'sectionend' ) ) ) {
@@ -397,8 +398,13 @@ if ( ! class_exists( 'Give_CMB2_Settings_Loader' ) ) :
 
 					$cmb2_filter_name = "cmb2_render_{$field['type']}";
 
-					if ( ! empty( $wp_filter[ $cmb2_filter_name ] ) ) {
-						$cmb2_filter_arr = current( $wp_filter[ $cmb2_filter_name ] );
+					if ( in_array( $cmb2_filter_name, $wp_filter_keys ) ) {
+
+						if( 0 <= version_compare( 4.7, get_bloginfo('version') ) &&  ! empty( $wp_filter[$cmb2_filter_name]->callbacks ) ) {
+							$cmb2_filter_arr = current( $wp_filter[$cmb2_filter_name]->callbacks );
+						} else {
+							$cmb2_filter_arr = current( $wp_filter[ $cmb2_filter_name ] );
+						}
 
 						if ( ! empty( $cmb2_filter_arr ) ) {
 							// Note: function can be called either globally or with class object, it depends on how developer invoke it.


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
This will update cmb2 backward compatibility to work better with WP verison `4.7`. This will fix #1166.

## Types of changes
<!--- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.