### PR TITLE
Issue/1328

### DIFF
--- a/assets/js/frontend/give-checkout-global.js
+++ b/assets/js/frontend/give-checkout-global.js
@@ -9,20 +9,20 @@
  */
 var give_scripts, give_global_vars;
 
-jQuery( function ( $ ) {
+jQuery(function ($) {
 
-	var doc = $( document );
+	var doc = $(document);
 
 	/**
 	 * Update state/province fields per country selection
 	 */
 	function update_billing_state_field() {
-		var $this = $( this ),
-			$form = $this.parents( 'form' );
-		if ( 'card_state' != $this.attr( 'id' ) ) {
+		var $this = $(this),
+			$form = $this.parents('form');
+		if ('card_state' != $this.attr('id')) {
 
 			//Disable the State field until updated
-			$form.find( '#card_state' ).empty().append( '<option value="1">' + give_global_vars.general_loading + '</option>' ).prop( 'disabled', true );
+			$form.find('#card_state').empty().append('<option value="1">' + give_global_vars.general_loading + '</option>').prop('disabled', true);
 
 			// If the country field has changed, we need to update the state/province field
 			var postData = {
@@ -31,33 +31,33 @@ jQuery( function ( $ ) {
 				field_name: 'card_state'
 			};
 
-			$.ajax( {
+			$.ajax({
 				type: 'POST',
 				data: postData,
 				url: give_global_vars.ajaxurl,
 				xhrFields: {
 					withCredentials: true
 				},
-				success: function ( response ) {
-					if ( 'nostates' == response ) {
+				success: function (response) {
+					if ('nostates' == response) {
 						var text_field = '<input type="text" id="card_state" name="card_state" class="cart-state give-input required" value=""/>';
-						$form.find( 'input[name="card_state"], select[name="card_state"]' ).replaceWith( text_field );
+						$form.find('input[name="card_state"], select[name="card_state"]').replaceWith(text_field);
 					} else {
-						$form.find( 'input[name="card_state"], select[name="card_state"]' ).replaceWith( response );
+						$form.find('input[name="card_state"], select[name="card_state"]').replaceWith(response);
 					}
-					doc.trigger( 'give_checkout_billing_address_updated', [ response, $form.attr( 'id' ) ] );
+					doc.trigger('give_checkout_billing_address_updated', [response, $form.attr('id')]);
 				}
-			} ).fail( function ( data ) {
-				if ( window.console && window.console.log ) {
-					console.log( data );
+			}).fail(function (data) {
+				if (window.console && window.console.log) {
+					console.log(data);
 				}
-			} );
+			});
 		}
 
 		return false;
 	}
 
-	doc.on( 'change', '#give_cc_address input.card_state, #give_cc_address select', update_billing_state_field
+	doc.on('change', '#give_cc_address input.card_state, #give_cc_address select', update_billing_state_field
 	);
 
 
@@ -67,37 +67,37 @@ jQuery( function ( $ ) {
 	 * @since 1.2
 	 */
 	function format_cc_fields() {
-		give_form = $( 'form.give-form' );
+		give_form = $('form.give-form');
 
 		//Loop through forms on page and set CC validation
-		give_form.each( function () {
-			var card_number = $( this ).find( '.card-number' );
-			var card_cvc = $( this ).find( '.card-cvc' );
-			var card_expiry = $( this ).find( '.card-expiry' );
+		give_form.each(function () {
+			var card_number = $(this).find('.card-number');
+			var card_cvc = $(this).find('.card-cvc');
+			var card_expiry = $(this).find('.card-expiry');
 
 			//Only validate if there is a card field
-			if ( card_number.length === 0 ) {
+			if (card_number.length === 0) {
 				return false;
 			}
 
-			card_number.payment( 'formatCardNumber' );
-			card_cvc.payment( 'formatCardCVC' );
-			card_expiry.payment( 'formatCardExpiry' );
-		} );
+			card_number.payment('formatCardNumber');
+			card_cvc.payment('formatCardCVC');
+			card_expiry.payment('formatCardExpiry');
+		});
 
 	}
 
 	format_cc_fields();
 
 	// Trigger formatting function when gateway changes
-	doc.on( 'give_gateway_loaded', function () {
+	doc.on('give_gateway_loaded', function () {
 		format_cc_fields();
-	} );
+	});
 
 	// Toggle validation classes
-	$.fn.toggleError = function ( errored ) {
-		this.toggleClass( 'error', errored );
-		this.toggleClass( 'valid', ! errored );
+	$.fn.toggleError = function (errored) {
+		this.toggleClass('error', errored);
+		this.toggleClass('valid', !errored);
 
 		return this;
 	};
@@ -105,43 +105,43 @@ jQuery( function ( $ ) {
 	/**
 	 * Validate cc fields on change
 	 */
-	doc.on( 'keyup change', '.give-form .card-number, .give-form .card-cvc, .give-form .card-expiry', function () {
-		var el = $( this ),
-			give_form = el.parents( 'form.give-form' ),
-			id = el.attr( 'id' ),
-			card_number = give_form.find( '.card-number' ),
-			card_cvc = give_form.find( '.card-cvc' ),
-			card_expiry = give_form.find( '.card-expiry' ),
-			type = $.payment.cardType( card_number.val() );
+	doc.on('keyup change', '.give-form .card-number, .give-form .card-cvc, .give-form .card-expiry', function () {
+		var el = $(this),
+			give_form = el.parents('form.give-form'),
+			id = el.attr('id'),
+			card_number = give_form.find('.card-number'),
+			card_cvc = give_form.find('.card-cvc'),
+			card_expiry = give_form.find('.card-expiry'),
+			type = $.payment.cardType(card_number.val());
 
-		if ( id.indexOf( 'card_number' ) > - 1 ) {
+		if (id.indexOf('card_number') > -1) {
 
-			var card_type = give_form.find( '.card-type' );
+			var card_type = give_form.find('.card-type');
 
-			if ( type === null ) {
-				card_type.removeClass().addClass( 'off card-type' );
-				el.removeClass( 'valid' ).addClass( 'error' );
+			if (type === null) {
+				card_type.removeClass().addClass('off card-type');
+				el.removeClass('valid').addClass('error');
 			}
 			else {
-				card_type.removeClass().addClass( 'card-type ' + type );
+				card_type.removeClass().addClass('card-type ' + type);
 			}
 
-			card_number.toggleError( ! $.payment.validateCardNumber( card_number.val() ) );
+			card_number.toggleError(!$.payment.validateCardNumber(card_number.val()));
 		}
-		if ( id.indexOf( 'card_cvc' ) > - 1 ) {
+		if (id.indexOf('card_cvc') > -1) {
 
-			card_cvc.toggleError( ! $.payment.validateCardCVC( card_cvc.val(), type ) );
+			card_cvc.toggleError(!$.payment.validateCardCVC(card_cvc.val(), type));
 		}
-		if ( id.indexOf( 'card_expiry' ) > - 1 ) {
+		if (id.indexOf('card_expiry') > -1) {
 
-			card_expiry.toggleError( ! $.payment.validateCardExpiry( card_expiry.payment( 'cardExpiryVal' ) ) );
+			card_expiry.toggleError(!$.payment.validateCardExpiry(card_expiry.payment('cardExpiryVal')));
 
-			var expiry = card_expiry.payment( 'cardExpiryVal' );
+			var expiry = card_expiry.payment('cardExpiryVal');
 
-			give_form.find( '.card-expiry-month' ).val( expiry.month );
-			give_form.find( '.card-expiry-year' ).val( expiry.year );
+			give_form.find('.card-expiry-month').val(expiry.month);
+			give_form.find('.card-expiry-year').val(expiry.year);
 		}
-	} );
+	});
 
 	/**
 	 * Format Currency
@@ -151,14 +151,14 @@ jQuery( function ( $ ) {
 	 * @param args object
 	 * @returns {*|string}
 	 */
-	function give_format_currency( price, args ) {
+	function give_format_currency(price, args) {
 
 		//Properly position symbol after if selected
-		if ( give_global_vars.currency_pos == 'after' ) {
+		if (give_global_vars.currency_pos == 'after') {
 			args.format = "%v%s";
 		}
 
-		return accounting.formatMoney( price, args ).trim();
+		return accounting.formatMoney(price, args).trim();
 
 	}
 
@@ -168,8 +168,8 @@ jQuery( function ( $ ) {
 	 * @param price
 	 * @returns {number}
 	 */
-	function give_unformat_currency( price ) {
-		return Math.abs( parseFloat( accounting.unformat( price, give_global_vars.decimal_separator ) ) );
+	function give_unformat_currency(price) {
+		return Math.abs(parseFloat(accounting.unformat(price, give_global_vars.decimal_separator)));
 	}
 
 
@@ -178,7 +178,7 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {string/number} amount
 	 */
-	function give_format_amount( amount ) {
+	function give_format_amount(amount) {
 
 		//Set the custom amount input value format properly
 		var format_args = {
@@ -188,7 +188,7 @@ jQuery( function ( $ ) {
 			precision: give_global_vars.number_decimals
 		};
 
-		return accounting.formatMoney( amount, format_args );
+		return accounting.formatMoney(amount, format_args);
 	}
 
 
@@ -199,77 +199,77 @@ jQuery( function ( $ ) {
 	 *
 	 * @returns {Object}
 	 */
-	function give_get_variable_prices( $form ) {
+	function give_get_variable_prices($form) {
 		var variable_prices = [];
 
 		// check if currect form type is muti or not.
-		if ( ! $form.hasClass( 'give-form-type-multi' ) ) {
+		if (!$form.hasClass('give-form-type-multi')) {
 			return variable_prices;
 		}
 
-		$.each( $form.find( '.give-donation-levels-wrap [data-price-id] ' ), function ( index, item ) {
+		$.each($form.find('.give-donation-levels-wrap [data-price-id] '), function (index, item) {
 			// Get Jquery instance for item.
 			item = (
-				! (
-				item instanceof jQuery
-				) ? jQuery( item ) : item
+				!(
+					item instanceof jQuery
+				) ? jQuery(item) : item
 			);
 
 
 			// Add price id and amount to collector.
-			variable_prices.push( {
-				price_id: item.data( 'price-id' ),
-				amount: give_unformat_currency( item.val() )
-			} );
-		} );
+			variable_prices.push({
+				price_id: item.data('price-id'),
+				amount: give_unformat_currency(item.val())
+			});
+		});
 
 		return variable_prices;
 	}
 
 	// Make sure a gateway is selected
-	doc.on( 'submit', '#give_payment_mode', function () {
-		var gateway = $( '#give-gateway option:selected' ).val();
-		if ( gateway == 0 ) {
-			alert( give_global_vars.no_gateway );
+	doc.on('submit', '#give_payment_mode', function () {
+		var gateway = $('#give-gateway option:selected').val();
+		if (gateway == 0) {
+			alert(give_global_vars.no_gateway);
 			return false;
 		}
-	} );
+	});
 
 	// Add a class to the currently selected gateway on click
-	doc.on( 'click', '#give-payment-mode-select input', function () {
-		$( '#give-payment-mode-select label.give-gateway-option-selected' ).removeClass( 'give-gateway-option-selected' );
-		$( '#give-payment-mode-select input:checked' ).parent().addClass( 'give-gateway-option-selected' );
-	} );
+	doc.on('click', '#give-payment-mode-select input', function () {
+		$('#give-payment-mode-select label.give-gateway-option-selected').removeClass('give-gateway-option-selected');
+		$('#give-payment-mode-select input:checked').parent().addClass('give-gateway-option-selected');
+	});
 
 	/**
 	 * Custom Donation Amount Focus In
 	 *
 	 * @description: If user focuses on field & changes value then updates price
 	 */
-	doc.on( 'focus', '.give-donation-amount .give-text-input', function ( e ) {
+	doc.on('focus', '.give-donation-amount .give-text-input', function (e) {
 
-		var parent_form = $( this ).parents( 'form' );
+		var parent_form = $(this).parents('form');
 
 		//Remove any invalid class
-		$( this ).removeClass( 'invalid-amount' );
+		$(this).removeClass('invalid-amount');
 
 		//Set data amount
-		var current_total = parent_form.find( '.give-final-total-amount' ).data( 'total' );
-		$( this ).data( 'amount', give_unformat_currency( current_total ) );
+		var current_total = parent_form.find('.give-final-total-amount').data('total');
+		$(this).data('amount', give_unformat_currency(current_total));
 
 
 		//This class is used for CSS purposes
-		$( this ).parent( '.give-donation-amount' ).addClass( 'give-custom-amount-focus-in' );
+		$(this).parent('.give-donation-amount').addClass('give-custom-amount-focus-in');
 
 		//Set Multi-Level to Custom Amount Field
-		parent_form.find( '.give-default-level, .give-radio-input' ).removeClass( 'give-default-level' );
-		parent_form.find( '.give-btn-level-custom' ).addClass( 'give-default-level' );
-		parent_form.find( '.give-radio-input' ).prop( 'checked', false ); //Radio
-		parent_form.find( '.give-radio-input.give-radio-level-custom' ).prop( 'checked', true ); //Radio
-		parent_form.find( '.give-select-level' ).prop( 'selected', false ); //Select
-		parent_form.find( '.give-select-level .give-donation-level-custom' ).prop( 'selected', true ); //Select
+		parent_form.find('.give-default-level, .give-radio-input').removeClass('give-default-level');
+		parent_form.find('.give-btn-level-custom').addClass('give-default-level');
+		parent_form.find('.give-radio-input').prop('checked', false); //Radio
+		parent_form.find('.give-radio-input.give-radio-level-custom').prop('checked', true); //Radio
+		parent_form.find('.give-select-level').prop('selected', false); //Select
+		parent_form.find('.give-select-level .give-donation-level-custom').prop('selected', true); //Select
 
-	} );
+	});
 
 	/**
 	 * Custom Donation Focus Out
@@ -277,21 +277,21 @@ jQuery( function ( $ ) {
 	 * @description: Fires on focus end aka "blur"
 	 *
 	 */
-	doc.on( 'blur', '.give-donation-amount .give-text-input', function ( e, $parent_form, donation_amount, price_id ) {
+	doc.on('blur', '.give-donation-amount .give-text-input', function (e, $parent_form, donation_amount, price_id) {
 
 		var parent_form = (
-			$parent_form != undefined
-			) ? $parent_form : $( this ).closest( 'form' ),
-			pre_focus_amount = $( this ).data( 'amount' ),
+				$parent_form != undefined
+			) ? $parent_form : $(this).closest('form'),
+			pre_focus_amount = $(this).data('amount'),
 			this_value = (
-			donation_amount != undefined
-			) ? donation_amount : $( this ).val(),
-			$minimum_amount = parent_form.find( 'input[name="give-form-minimum"]' ),
-			value_min = give_unformat_currency( $minimum_amount.val() ),
+				donation_amount != undefined
+			) ? donation_amount : $(this).val(),
+			$minimum_amount = parent_form.find('input[name="give-form-minimum"]'),
+			value_min = give_unformat_currency($minimum_amount.val()),
 			value_now = (
-			this_value == 0
-			) ? value_min : give_unformat_currency( this_value ),
-			variable_prices = give_get_variable_prices( $( this ).parents( 'form' ) ),
+				this_value == 0
+			) ? value_min : give_unformat_currency(this_value),
+			variable_prices = give_get_variable_prices($(this).parents('form')),
 			error_msg = '';
 
 		/**
@@ -305,8 +305,8 @@ jQuery( function ( $ ) {
 		 * @type {number/string} Donation level ID.
 		 */
 		price_id = (
-		undefined != price_id
-		) ? price_id : - 1;
+			undefined != price_id
+		) ? price_id : -1;
 
 
 		//Set the custom amount input value format properly
@@ -317,148 +317,148 @@ jQuery( function ( $ ) {
 			precision: give_global_vars.number_decimals
 		};
 
-		var formatted_total = give_format_currency( value_now, format_args );
-		$( this ).val( formatted_total );
+		var formatted_total = give_format_currency(value_now, format_args);
+		$(this).val(formatted_total);
 
 		// Find price id with amount in variable prices.
-		if ( variable_prices.length && ! (
-			- 1 < price_id
-			) ) {
+		if (variable_prices.length && !(
+				-1 < price_id
+			)) {
 
 			// Find amount in donation levels.
-			$.each( variable_prices, function ( index, variable_price ) {
-				if ( variable_price.amount === value_now ) {
+			$.each(variable_prices, function (index, variable_price) {
+				if (variable_price.amount === value_now) {
 					price_id = variable_price.price_id;
 					return false;
 				}
-			} );
+			});
 
 			// Set level to custom.
-			if ( ! (
-				- 1 < price_id
+			if (!(
+					-1 < price_id
 				) && (
-			     value_min <= value_now
-			     ) ) {
+					value_min <= value_now
+				)) {
 				price_id = 'custom';
 			}
 		}
 
 		//Does this number have an accepted minimum value?
-		if ( (
-		     value_now < value_min || value_now < 1
-		     ) && (
-		     - 1 === price_id
-		     ) ) {
+		if ((
+				value_now < value_min || value_now < 1
+			) && (
+				-1 === price_id
+			)) {
 
 			//It doesn't... Invalid Minimum
-			$( this ).addClass( 'give-invalid-amount' );
+			$(this).addClass('give-invalid-amount');
 			format_args.symbol = give_global_vars.currency_sign;
-			error_msg = give_global_vars.bad_minimum + ' ' + give_format_currency( value_min, format_args );
+			error_msg = give_global_vars.bad_minimum + ' ' + give_format_currency(value_min, format_args);
 
 			//Disable submit
-			parent_form.find( '.give-submit' ).prop( 'disabled', true );
-			var invalid_minimum = parent_form.find( '.give-invalid-minimum' );
+			parent_form.find('.give-submit').prop('disabled', true);
+			var invalid_minimum = parent_form.find('.give-invalid-minimum');
 
 			//If no error present, create it, insert, slide down (show)
-			if ( invalid_minimum.length === 0 ) {
-				var error = $( '<div class="give_error give-invalid-minimum">' + error_msg + '</div>' ).hide();
-				error.insertBefore( parent_form.find( '.give-total-wrap' ) ).show();
+			if (invalid_minimum.length === 0) {
+				var error = $('<div class="give_error give-invalid-minimum">' + error_msg + '</div>').hide();
+				error.insertBefore(parent_form.find('.give-total-wrap')).show();
 			}
 
 		} else {
 
 			// Remove error massage class from price field.
-			$( this ).removeClass( 'give-invalid-amount' );
+			$(this).removeClass('give-invalid-amount');
 
 			//Minimum amount met - slide up error & remove it from DOM
-			parent_form.find( '.give-invalid-minimum' ).slideUp( 300, function () {
-				$( this ).remove();
-			} );
+			parent_form.find('.give-invalid-minimum').slideUp(300, function () {
+				$(this).remove();
+			});
 
 			//Re-enable submit
-			parent_form.find( '.give-submit' ).prop( 'disabled', false );
+			parent_form.find('.give-submit').prop('disabled', false);
 
 		}
 
 
 		//If values don't match up then proceed with updating donation total value
-		if ( pre_focus_amount !== value_now ) {
+		if (pre_focus_amount !== value_now) {
 
 			//update donation total (include currency symbol)
 			format_args.symbol = give_global_vars.currency_sign;
-			parent_form.find( '.give-final-total-amount' ).data( 'total', value_now ).text( give_format_currency( value_now, format_args ) );
+			parent_form.find('.give-final-total-amount').data('total', value_now).text(give_format_currency(value_now, format_args));
 
 		}
 
 		// Set price id for current amount.
-		if ( - 1 !== price_id ) {
+		if (-1 !== price_id) {
 
 			// Auto set give price id.
-			$( 'input[name="give-price-id"]', parent_form ).val( price_id );
+			$('input[name="give-price-id"]', parent_form).val(price_id);
 
 			// Update hidden amount field
-			parent_form.find( '.give-amount-hidden' ).val( give_format_amount( value_now ) );
+			parent_form.find('.give-amount-hidden').val(give_format_amount(value_now));
 
 			// Remove old selected class & add class for CSS purposes
-			parent_form.find( '.give-default-level' ).removeClass( 'give-default-level' );
+			parent_form.find('.give-default-level').removeClass('give-default-level');
 
 			// Auto select variable price items ( Radio/Button/Select ).
-			switch ( true ) {
+			switch (true) {
 
 				// Auto select radio button.
 				case (
-					! ! parent_form.find( '.give-radio-input' ).length
+					!!parent_form.find('.give-radio-input').length
 				) :
-					parent_form.find( '.give-radio-input' ).prop( 'checked', false );
-					parent_form.find( '.give-radio-input[data-price-id="' + price_id + '"]' )
-					           .prop( 'checked', true )
-					           .addClass( 'give-default-level' );
+					parent_form.find('.give-radio-input').prop('checked', false);
+					parent_form.find('.give-radio-input[data-price-id="' + price_id + '"]')
+						.prop('checked', true)
+						.addClass('give-default-level');
 					break;
 
 				// Set focus to price id button.
 				case (
-					! ! parent_form.find( 'button.give-donation-level-btn' ).length
+					!!parent_form.find('button.give-donation-level-btn').length
 				) :
-					parent_form.find( 'button.give-donation-level-btn' ).blur();
-					parent_form.find( 'button.give-donation-level-btn[data-price-id="' + price_id + '"]' )
-					           .focus()
-					           .addClass( 'give-default-level' );
+					parent_form.find('button.give-donation-level-btn').blur();
+					parent_form.find('button.give-donation-level-btn[data-price-id="' + price_id + '"]')
+						.focus()
+						.addClass('give-default-level');
 					break;
 
 				// Auto select option.
 				case (
-					! ! parent_form.find( 'select.give-select-level' ).length
+					!!parent_form.find('select.give-select-level').length
 				) :
-					parent_form.find( 'select.give-select-level option' ).prop( 'selected', false );
-					parent_form.find( 'select.give-select-level option[data-price-id="' + price_id + '"]' )
-					           .prop( 'selected', true )
-					           .addClass( 'give-default-level' );
+					parent_form.find('select.give-select-level option').prop('selected', false);
+					parent_form.find('select.give-select-level option[data-price-id="' + price_id + '"]')
+						.prop('selected', true)
+						.addClass('give-default-level');
 					break;
 
 			}
 		}
 
 		//This class is used for CSS purposes
-		$( this ).parent( '.give-donation-amount' ).removeClass( 'give-custom-amount-focus-in' );
+		$(this).parent('.give-donation-amount').removeClass('give-custom-amount-focus-in');
 
-	} );
+	});
 
 
 	//Multi-level Buttons: Update Amount Field based on Multi-level Donation Select
-	doc.on( 'click touchend', '.give-donation-level-btn', function ( e ) {
+	doc.on('click touchend', '.give-donation-level-btn', function (e) {
 		e.preventDefault(); //don't let the form submit
-		update_multiselect_vals( $( this ) );
-	} );
+		update_multiselect_vals($(this));
+	});
 
 	//Multi-level Radios: Update Amount Field based on Multi-level Donation Select
-	doc.on( 'click touchend', '.give-radio-input-level', function ( e ) {
-		update_multiselect_vals( $( this ) );
-	} );
+	doc.on('click touchend', '.give-radio-input-level', function (e) {
+		update_multiselect_vals($(this));
+	});
 
 	//Multi-level Radios: Update Amount Field based on Multi-level Donation Select
-	doc.on( 'change', '.give-select-level', function ( e ) {
-		update_multiselect_vals( $( this ) );
-	} );
+	doc.on('change', '.give-select-level', function (e) {
+		update_multiselect_vals($(this));
+	});
 
 	/**
 	 * Update Multiselect Values
@@ -468,40 +468,40 @@ jQuery( function ( $ ) {
 	 * @param selected_field
 	 * @returns {boolean}
 	 */
-	function update_multiselect_vals( selected_field ) {
+	function update_multiselect_vals(selected_field) {
 
-		var $parent_form = selected_field.parents( 'form' ),
+		var $parent_form = selected_field.parents('form'),
 			this_amount = selected_field.val(),
-			price_id = selected_field.data( 'price-id' );
+			price_id = selected_field.data('price-id');
 
 		// Check if price ID blank because of dropdown type
-		if ( ! price_id ) {
-			price_id = selected_field.find( 'option:selected' ).data( 'price-id' );
+		if (!price_id) {
+			price_id = selected_field.find('option:selected').data('price-id');
 		}
 
 		// Is this a custom amount selection?
-		if ( this_amount === 'custom' ) {
+		if (this_amount === 'custom') {
 			//It is, so focus on the custom amount input
-			$parent_form.find( '.give-amount-top' ).val( '' ).focus();
+			$parent_form.find('.give-amount-top').val('').focus();
 			return false; //Bounce out
 		}
 
 		//update custom amount field
-		$parent_form.find( '.give-amount-top' ).val( this_amount );
-		$parent_form.find( 'span.give-amount-top' ).text( this_amount );
+		$parent_form.find('.give-amount-top').val(this_amount);
+		$parent_form.find('span.give-amount-top').text(this_amount);
 
 		// Manually trigger blur event with two params:
 		// (a) form jquery object
 		// (b) price id
 		// (c) donation amount
-		$parent_form.find( '.give-donation-amount .give-text-input' ).trigger( 'blur', [
+		$parent_form.find('.give-donation-amount .give-text-input').trigger('blur', [
 			$parent_form,
 			this_amount,
 			price_id
-		] );
+		]);
 
 		// trigger an event for hooks
-		$( document ).trigger( 'give_donation_value_updated', [ $parent_form, this_amount, price_id ] );
+		$(document).trigger('give_donation_value_updated', [$parent_form, this_amount, price_id]);
 	}
 
 	/**
@@ -509,29 +509,30 @@ jQuery( function ( $ ) {
 	 */
 	function sent_back_to_form() {
 
-		var form_id = give_get_parameter_by_name( 'form-id' );
-		var payment_mode = give_get_parameter_by_name( 'payment-mode' );
+		var form_id = give_get_parameter_by_name('form-id');
+		var payment_mode = give_get_parameter_by_name('payment-mode');
 
 		//Sanity check - only proceed if query strings in place
-		if ( ! form_id || ! payment_mode ) {
+		if (!form_id || !payment_mode) {
 			return false;
 		}
 
-		var form_wrap = $( 'body' ).find( '#give-form-' + form_id + '-wrap' );
-		var form = form_wrap.find( 'form.give-form' );
-		var display_modal = form_wrap.hasClass( 'give-display-modal' );
-		var display_reveal = form_wrap.hasClass( 'give-display-reveal' );
+		var form_wrap = $('body').find('#give-form-' + form_id + '-wrap');
+		var form = form_wrap.find('form.give-form');
+		var display_modal = form_wrap.hasClass('give-display-modal');
+		var display_reveal = form_wrap.hasClass('give-display-reveal');
 
 		//Update payment mode radio so it's correctly checked
-		form.find( '#give-gateway-radio-list label' ).removeClass( 'give-gateway-option-selected' );
-		form.find( 'input[name=payment-mode][value=' + payment_mode + ']' ).prop( 'checked', true ).parent().addClass( 'give-gateway-option-selected' );
+		form.find('#give-gateway-radio-list label').removeClass('give-gateway-option-selected');
+		form.find('input[name=payment-mode][value=' + payment_mode + ']').prop('checked', true).parent().addClass('give-gateway-option-selected');
 
 		//This form is modal display so show the modal
-		if ( display_modal ) {
+		if (display_modal) {
 
 			//@TODO: Make this DRYer - repeated in give.js
-			$.magnificPopup.open( {
-				mainClass: 'give-modal',
+			$.magnificPopup.open({
+				mainClass: give_global_vars.magnific_options.main_class,
+				closeOnBgClick: give_global_vars.magnific_options.close_on_bg_click,
 				items: {
 					src: form,
 					type: 'inline'
@@ -540,23 +541,23 @@ jQuery( function ( $ ) {
 					open: function () {
 						// Will fire when this exact popup is opened
 						// this - is Magnific Popup object
-						if ( $( '.mfp-content' ).outerWidth() >= 500 ) {
-							$( '.mfp-content' ).addClass( 'give-responsive-mfp-content' );
+						if ($('.mfp-content').outerWidth() >= 500) {
+							$('.mfp-content').addClass('give-responsive-mfp-content');
 						}
 					},
 					close: function () {
 						//Remove popup class
-						form.removeClass( 'mfp-hide' );
+						form.removeClass('mfp-hide');
 
 					}
 				}
-			} );
+			});
 		}
 		//This is a reveal form, show it
-		else if ( display_reveal ) {
+		else if (display_reveal) {
 
-			form.find( '.give-btn-reveal' ).hide();
-			form.find( '#give-payment-mode-select, #give_purchase_form_wrap' ).slideDown();
+			form.find('.give-btn-reveal').hide();
+			form.find('#give-payment-mode-select, #give_purchase_form_wrap').slideDown();
 
 		}
 
@@ -574,21 +575,21 @@ jQuery( function ( $ ) {
 	 * @since 1.4.2
 	 * @returns {*}
 	 */
-	function give_get_parameter_by_name( name, url ) {
-        if ( ! url ) {
-            url = window.location.href;
-        }
-		name = name.replace( /[\[\]]/g, "\\$&" );
-		var regex = new RegExp( "[?&]" + name + "(=([^&#]*)|&|#|$)" ),
-			results = regex.exec( url );
-        if ( ! results ) {
-            return null;
-        }
-        if ( ! results[ 2 ] ) {
-            return '';
-        }
-		return decodeURIComponent( results[ 2 ].replace( /\+/g, " " ) );
+	function give_get_parameter_by_name(name, url) {
+		if (!url) {
+			url = window.location.href;
+		}
+		name = name.replace(/[\[\]]/g, "\\$&");
+		var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+			results = regex.exec(url);
+		if (!results) {
+			return null;
+		}
+		if (!results[2]) {
+			return '';
+		}
+		return decodeURIComponent(results[2].replace(/\+/g, " "));
 	}
 
 
-} );
+});

--- a/assets/js/frontend/give.js
+++ b/assets/js/frontend/give.js
@@ -9,7 +9,7 @@
  */
 
 
-var give_scripts;
+var give_global_vars;
 
 jQuery( function ( $ ) {
 
@@ -81,8 +81,8 @@ jQuery( function ( $ ) {
 
 		//Alls well, open popup!
 		$.magnificPopup.open( {
-			mainClass   : 'give-modal',
-			closeOnBgClick : false,
+			mainClass   : give_global_vars.magnific_options.main_class,
+			closeOnBgClick : give_global_vars.magnific_options.close_on_bg_click,
 			items       : {
 				src : this_form,
 				type: 'inline'

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -46,10 +46,11 @@ function give_load_scripts() {
 		'purchase_loading'    => __( 'Please Wait...', 'give' ),
 		'number_decimals'     => give_get_price_decimals(),
 		'give_version'        => GIVE_VERSION,
-		'magnific_options'            => apply_filters(
-            'give_magnific_options',
+		'magnific_options'    => apply_filters(
+			'give_magnific_options',
 			array(
-				'close_on_bg_click' => true,
+				'main_class'        => 'give-modal',
+				'close_on_bg_click' => false,
 			)
 		),
 		'form_translation'    => apply_filters(

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -33,38 +33,38 @@ function give_load_scripts() {
 	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	// Localize / PHP to AJAX vars.
-	$localize_give_checkout = apply_filters( 'give_global_script_vars', array(
+	$localize_give_vars = apply_filters( 'give_global_script_vars', array(
 		'ajaxurl'             => give_get_ajax_url(),
 		'checkout_nonce'      => wp_create_nonce( 'give_checkout_nonce' ),
 		'currency_sign'       => give_currency_filter( '' ),
 		'currency_pos'        => give_get_currency_position(),
 		'thousands_separator' => give_get_price_thousand_separator(),
 		'decimal_separator'   => give_get_price_decimal_separator(),
-		'no_gateway'          => esc_html__( 'Please select a payment method.', 'give' ),
-		'bad_minimum'         => esc_html__( 'The minimum donation amount for this form is', 'give' ),
-		'general_loading'     => esc_html__( 'Loading...', 'give' ),
-		'purchase_loading'    => esc_html__( 'Please Wait...', 'give' ),
+		'no_gateway'          => __( 'Please select a payment method.', 'give' ),
+		'bad_minimum'         => __( 'The minimum donation amount for this form is', 'give' ),
+		'general_loading'     => __( 'Loading...', 'give' ),
+		'purchase_loading'    => __( 'Please Wait...', 'give' ),
 		'number_decimals'     => give_get_price_decimals(),
 		'give_version'        => GIVE_VERSION,
 		'form_translation'    => apply_filters(
 			'give_form_translation_js',
 			array(
 				// Field name               Validation message.
-				'payment-mode'           => esc_html__( 'Please select payment mode.', 'give' ),
-				'give_first'             => esc_html__( 'Please enter your first name.', 'give' ),
-				'give_email'             => esc_html__( 'Please enter a valid email address.', 'give' ),
-				'give_user_login'        => esc_html__( 'Invalid username. Only lowercase letters (a-z) and numbers are allowed.', 'give' ),
-				'give_user_pass'         => esc_html__( 'Enter a password.', 'give' ),
-				'give_user_pass_confirm' => esc_html__( 'Enter a confirm password.', 'give' ),
-				'give_agree_to_terms'    => esc_html__( 'You must agree to the terms and conditions.', 'give' ),
+				'payment-mode'           => __( 'Please select payment mode.', 'give' ),
+				'give_first'             => __( 'Please enter your first name.', 'give' ),
+				'give_email'             => __( 'Please enter a valid email address.', 'give' ),
+				'give_user_login'        => __( 'Invalid username. Only lowercase letters (a-z) and numbers are allowed.', 'give' ),
+				'give_user_pass'         => __( 'Enter a password.', 'give' ),
+				'give_user_pass_confirm' => __( 'Enter a confirm password.', 'give' ),
+				'give_agree_to_terms'    => __( 'You must agree to the terms and conditions.', 'give' ),
 			)
 		),
 	) );
-	$localize_give_ajax     = apply_filters( 'give_global_ajax_vars', array(
+	$localize_give_ajax = apply_filters( 'give_global_ajax_vars', array(
 		'ajaxurl'         => give_get_ajax_url(),
-		'loading'         => esc_html__( 'Loading', 'give' ),
+		'loading'         => __( 'Loading', 'give' ),
 		// General loading message.
-		'select_option'   => esc_html__( 'Please select an option', 'give' ),
+		'select_option'   => __( 'Please select an option', 'give' ),
 		// Variable pricing error with multi-donation option enabled.
 		'default_gateway' => give_get_default_gateway( null ),
 		'permalinks'      => get_option( 'permalink_structure' ) ? '1' : '0',
@@ -106,7 +106,7 @@ function give_load_scripts() {
 		wp_enqueue_script( 'give-ajax' );
 
 		// Localize / Pass AJAX vars from PHP,
-		wp_localize_script( 'give-checkout-global', 'give_global_vars', $localize_give_checkout );
+		wp_localize_script( 'give-checkout-global', 'give_global_vars', $localize_give_vars );
 		wp_localize_script( 'give-ajax', 'give_scripts', $localize_give_ajax );
 
 	} else {
@@ -116,7 +116,7 @@ function give_load_scripts() {
 		wp_enqueue_script( 'give' );
 
 		// Localize / Pass AJAX vars from PHP.
-		wp_localize_script( 'give', 'give_global_vars', $localize_give_checkout );
+		wp_localize_script( 'give', 'give_global_vars', $localize_give_vars );
 		wp_localize_script( 'give', 'give_scripts', $localize_give_ajax );
 
 	}
@@ -153,7 +153,7 @@ add_action( 'wp_enqueue_scripts', 'give_register_styles' );
  *
  * @since 1.6
  *
- * @return mixed|void
+ * @return string
  */
 function give_get_stylesheet_uri() {
 
@@ -174,9 +174,12 @@ function give_get_stylesheet_uri() {
 
 	$uri = false;
 
-	// Look in the child theme directory first, followed by the parent theme,
-	// followed by the Give core templates directory also look for the min version first, followed by non minified version, even if SCRIPT_DEBUG is not enabled.
-	// This allows users to copy just give.css to their theme.
+	/**
+	 * Look in the child theme directory first, followed by the parent theme,
+	 * followed by the Give core templates directory also look for the min version first,
+	 * followed by non minified version, even if SCRIPT_DEBUG is not enabled.
+	 * This allows users to copy just give.css to their theme.
+	 */
 	if ( file_exists( $child_theme_style_sheet ) || ( ! empty( $suffix ) && ( $nonmin = file_exists( $child_theme_style_sheet_2 ) ) ) ) {
 		if ( ! empty( $nonmin ) ) {
 			$uri = trailingslashit( get_stylesheet_directory_uri() ) . $templates_dir . 'give' . $direction . '.css';
@@ -286,31 +289,31 @@ function give_load_admin_scripts( $hook ) {
 		'give_version'            => GIVE_VERSION,
 		'thousands_separator'     => $thousand_separator,
 		'decimal_separator'       => $decimal_separator,
-		'quick_edit_warning'      => esc_html__( 'Not available for variable priced forms.', 'give' ),
-		'delete_payment'         => esc_html__( 'Are you sure you wish to delete this payment?', 'give' ),
-		'delete_payment_note'    => esc_html__( 'Are you sure you wish to delete this note?', 'give' ),
-		'revoke_api_key'          => esc_html__( 'Are you sure you wish to revoke this API key?', 'give' ),
-		'regenerate_api_key'      => esc_html__( 'Are you sure you wish to regenerate this API key?', 'give' ),
-		'resend_receipt'          => esc_html__( 'Are you sure you wish to resend the donation receipt?', 'give' ),
-		'copy_download_link_text' => esc_html__( 'Copy these links to your clipboard and give them to your donor.', 'give' ),
-		'delete_payment_download' => esc_html__( 'Are you sure you wish to delete this form?', 'give' ),
-		'one_price_min'           => esc_html__( 'You must have at least one price.', 'give' ),
-		'one_file_min'            => esc_html__( 'You must have at least one file.', 'give' ),
-		'one_field_min'           => esc_html__( 'You must have at least one field.', 'give' ),
-		'one_option'              => esc_html__( 'Choose a form', 'give' ),
-		'one_or_more_option'      => esc_html__( 'Choose one or more forms', 'give' ),
-		'numeric_item_price'      => esc_html__( 'Item price must be numeric.', 'give' ),
-		'numeric_quantity'        => esc_html__( 'Quantity must be numeric.', 'give' ),
+		'quick_edit_warning'      => __( 'Not available for variable priced forms.', 'give' ),
+		'delete_payment'          => __( 'Are you sure you wish to delete this payment?', 'give' ),
+		'delete_payment_note'     => __( 'Are you sure you wish to delete this note?', 'give' ),
+		'revoke_api_key'          => __( 'Are you sure you wish to revoke this API key?', 'give' ),
+		'regenerate_api_key'      => __( 'Are you sure you wish to regenerate this API key?', 'give' ),
+		'resend_receipt'          => __( 'Are you sure you wish to resend the donation receipt?', 'give' ),
+		'copy_download_link_text' => __( 'Copy these links to your clipboard and give them to your donor.', 'give' ),
+		'delete_payment_download' => __( 'Are you sure you wish to delete this form?', 'give' ),
+		'one_price_min'           => __( 'You must have at least one price.', 'give' ),
+		'one_file_min'            => __( 'You must have at least one file.', 'give' ),
+		'one_field_min'           => __( 'You must have at least one field.', 'give' ),
+		'one_option'              => __( 'Choose a form', 'give' ),
+		'one_or_more_option'      => __( 'Choose one or more forms', 'give' ),
+		'numeric_item_price'      => __( 'Item price must be numeric.', 'give' ),
+		'numeric_quantity'        => __( 'Quantity must be numeric.', 'give' ),
 		'currency_sign'           => give_currency_filter( '' ),
 		'currency_pos'            => isset( $give_options['currency_position'] ) ? $give_options['currency_position'] : 'before',
 		'currency_decimals'       => give_currency_decimal_filter( give_get_price_decimals() ),
 		'new_media_ui'            => apply_filters( 'give_use_35_media_ui', 1 ),
-		'remove_text'             => esc_html__( 'Remove', 'give' ),
-		'type_to_search'          => esc_html__( 'Type to search forms', 'give' ),
-		'batch_export_no_class'   => esc_html__( 'You must choose a method.', 'give' ),
-		'batch_export_no_reqs'    => esc_html__( 'Required fields not completed.', 'give' ),
+		'remove_text'             => __( 'Remove', 'give' ),
+		'type_to_search'          => __( 'Type to search forms', 'give' ),
+		'batch_export_no_class'   => __( 'You must choose a method.', 'give' ),
+		'batch_export_no_reqs'    => __( 'Required fields not completed.', 'give' ),
 		'reset_stats_warn'        => __( 'Are you sure you want to reset Give? This process is <strong><em>not reversible</em></strong> and will delete all data regardless of test or live mode. Please be sure you have a recent backup before proceeding.', 'give' ),
-		'price_format_guide'      => sprintf( esc_html__( 'Please enter amount in monetary decimal ( %1$s ) format without thousand separator ( %2$s ) .', 'give' ), $decimal_separator, $thousand_separator ),
+		'price_format_guide'      => sprintf( __( 'Please enter amount in monetary decimal ( %1$s ) format without thousand separator ( %2$s ) .', 'give' ), $decimal_separator, $thousand_separator ),
 	) );
 
 	if ( function_exists( 'wp_enqueue_media' ) && version_compare( get_bloginfo( 'version' ), '3.5', '>=' ) ) {
@@ -333,30 +336,30 @@ add_action( 'admin_enqueue_scripts', 'give_load_admin_scripts', 100 );
  */
 function give_admin_icon() {
 	?>
-	<style type="text/css" media="screen">
+    <style type="text/css" media="screen">
 
-		<?php if ( version_compare( get_bloginfo( 'version' ), '3.8-RC', '>=' ) || version_compare( get_bloginfo( 'version' ), '3.8', '>=' ) ) { ?>
-		@font-face {
-			font-family: 'give-icomoon';
-			src: url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.eot?-ngjl88'; ?>');
-			src: url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.eot?#iefix-ngjl88'?>') format('embedded-opentype'),
-			url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.woff?-ngjl88'; ?>') format('woff'),
-			url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.svg?-ngjl88#icomoon'; ?>') format('svg');
-			font-weight: normal;
-			font-style: normal;
-		}
+        <?php if ( version_compare( get_bloginfo( 'version' ), '3.8-RC', '>=' ) || version_compare( get_bloginfo( 'version' ), '3.8', '>=' ) ) { ?>
+        @font-face {
+            font-family: 'give-icomoon';
+            src: url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.eot?-ngjl88'; ?>');
+            src: url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.eot?#iefix-ngjl88'?>') format('embedded-opentype'),
+            url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.woff?-ngjl88'; ?>') format('woff'),
+            url('<?php echo GIVE_PLUGIN_URL . '/assets/fonts/icomoon.svg?-ngjl88#icomoon'; ?>') format('svg');
+            font-weight: normal;
+            font-style: normal;
+        }
 
-		.dashicons-give:before, #adminmenu div.wp-menu-image.dashicons-give:before {
-			font-family: 'give-icomoon';
-			font-size: 18px;
-			width: 18px;
-			height: 18px;
-			content: "\e800";
-		}
+        .dashicons-give:before, #adminmenu div.wp-menu-image.dashicons-give:before {
+            font-family: 'give-icomoon';
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+            content: "\e800";
+        }
 
-		<?php }  ?>
+        <?php }  ?>
 
-	</style>
+    </style>
 	<?php
 }
 
@@ -373,7 +376,7 @@ add_action( 'admin_head', 'give_admin_icon' );
  */
 function give_admin_hide_notice_shortly_js() {
 	?>
-	<script>
+    <script>
 		jQuery(document).ready(function ($) {
 			$('.give-license-notice').on('click', 'button.notice-dismiss', function (e) {
 				e.preventDefault();
@@ -386,7 +389,7 @@ function give_admin_hide_notice_shortly_js() {
 				}
 			});
 		});
-	</script>
+    </script>
 	<?php
 }
 

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -46,6 +46,12 @@ function give_load_scripts() {
 		'purchase_loading'    => __( 'Please Wait...', 'give' ),
 		'number_decimals'     => give_get_price_decimals(),
 		'give_version'        => GIVE_VERSION,
+		'magnific_options'            => apply_filters(
+            'give_magnific_options',
+			array(
+				'close_on_bg_click' => true,
+			)
+		),
 		'form_translation'    => apply_filters(
 			'give_form_translation_js',
 			array(
@@ -60,6 +66,7 @@ function give_load_scripts() {
 			)
 		),
 	) );
+
 	$localize_give_ajax = apply_filters( 'give_global_ajax_vars', array(
 		'ajaxurl'         => give_get_ajax_url(),
 		'loading'         => __( 'Loading', 'give' ),
@@ -75,39 +82,39 @@ function give_load_scripts() {
 	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 
 		if ( give_is_cc_verify_enabled() ) {
-			wp_register_script( 'give-cc-validator', $js_plugins . 'jquery.payment' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-			wp_enqueue_script( 'give-cc-validator' );
+			wp_register_script( 'give_cc_validator', $js_plugins . 'jquery.payment' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+			wp_enqueue_script( 'give_cc_validator' );
 		}
 
-		wp_register_script( 'give-float-labels', $js_plugins . 'float-labels' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-float-labels' );
+		wp_register_script( 'give_float_labels', $js_plugins . 'float-labels' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_float_labels' );
 
-		wp_register_script( 'give-blockui', $js_plugins . 'jquery.blockUI' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-blockui' );
+		wp_register_script( 'give_blockui', $js_plugins . 'jquery.blockUI' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_blockui' );
 
-		wp_register_script( 'give-qtip', $js_plugins . 'jquery.qtip' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-qtip' );
+		wp_register_script( 'give_qtip', $js_plugins . 'jquery.qtip' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_qtip' );
 
-		wp_register_script( 'give-accounting', $js_plugins . 'accounting' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-accounting' );
+		wp_register_script( 'give_accounting', $js_plugins . 'accounting' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_accounting' );
 
-		wp_register_script( 'give-magnific', $js_plugins . 'jquery.magnific-popup' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-magnific' );
+		wp_register_script( 'give_magnific', $js_plugins . 'jquery.magnific-popup' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_magnific' );
 
-		wp_register_script( 'give-checkout-global', $js_dir . 'give-checkout-global' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-checkout-global' );
+		wp_register_script( 'give_checkout_global', $js_dir . 'give-checkout-global' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_checkout_global' );
 
 		// General scripts.
-		wp_register_script( 'give-scripts', $js_dir . 'give' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-scripts' );
+		wp_register_script( 'give_scripts', $js_dir . 'give' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_scripts' );
 
 		// Load AJAX scripts, if enabled.
-		wp_register_script( 'give-ajax', $js_dir . 'give-ajax' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
-		wp_enqueue_script( 'give-ajax' );
+		wp_register_script( 'give_ajax', $js_dir . 'give-ajax' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, $scripts_footer );
+		wp_enqueue_script( 'give_ajax' );
 
 		// Localize / Pass AJAX vars from PHP,
-		wp_localize_script( 'give-checkout-global', 'give_global_vars', $localize_give_vars );
-		wp_localize_script( 'give-ajax', 'give_scripts', $localize_give_ajax );
+		wp_localize_script( 'give_checkout_global', 'give_global_vars', $localize_give_vars );
+		wp_localize_script( 'give_ajax', 'give_scripts', $localize_give_ajax );
 
 	} else {
 


### PR DESCRIPTION
## Description
Passing new options via PHP `wp_localize_script` to JS for magnific modal options.

Also cleaned up the JS loading and standardized enqueue script names with underscores rather than hyphens. Remove unnecessary escaping as well.

Fixes #1328 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
- Improvement to code customizations via new filter
- Reverting escaping
- Code cleanup

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.