### PR TITLE
Issue/1334

### DIFF
--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -24,12 +24,12 @@ function give_get_payment_gateways() {
 	// Default, built-in gateways
 	$gateways = array(
 		'paypal' => array(
-			'admin_label'    => esc_html__( 'PayPal Standard', 'give' ),
-			'checkout_label' => esc_html__( 'PayPal', 'give' ),
+			'admin_label'    => __( 'PayPal Standard', 'give' ),
+			'checkout_label' => __( 'PayPal', 'give' ),
 		),
 		'manual' => array(
-			'admin_label'    => esc_html__( 'Test Donation', 'give' ),
-			'checkout_label' => esc_html__( 'Test Donation', 'give' )
+			'admin_label'    => __( 'Test Donation', 'give' ),
+			'checkout_label' => __( 'Test Donation', 'give' )
 		),
 	);
 
@@ -124,7 +124,7 @@ function give_get_gateway_admin_label( $gateway ) {
 
 	if ( $gateway == 'manual' && $payment ) {
 		if ( give_get_payment_amount( $payment ) == 0 ) {
-			$label = esc_html__( 'Test Donation', 'give' );
+			$label = __( 'Test Donation', 'give' );
 		}
 	}
 
@@ -145,7 +145,7 @@ function give_get_gateway_checkout_label( $gateway ) {
 	$label    = isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ]['checkout_label'] : $gateway;
 
 	if ( $gateway == 'manual' ) {
-		$label = esc_html__( 'Test Donation', 'give' );
+		$label = __( 'Test Donation', 'give' );
 	}
 
 	return apply_filters( 'give_gateway_checkout_label', $label, $gateway );

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -35,14 +35,14 @@ add_action( 'give_paypal_cc_form', '__return_false' );
 function give_process_paypal_payment( $payment_data ) {
 
 	if ( ! wp_verify_nonce( $payment_data['gateway_nonce'], 'give-gateway' ) ) {
-		wp_die( esc_html__( 'Nonce verification has failed.', 'give' ), esc_html__( 'Error', 'give' ), array( 'response' => 403 ) );
+		wp_die( __( 'Nonce verification has failed.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
 	}
 
 	$form_id  = intval( $payment_data['post_data']['give-form-id'] );
 	$price_id = isset( $payment_data['post_data']['give-price-id'] ) ? $payment_data['post_data']['give-price-id'] : '';
 
-	// Collect payment data.
-	$payment_data = array(
+	// Collect Give's payment data.
+	$insert_payment_args = array(
 		'price'           => $payment_data['price'],
 		'give_form_title' => $payment_data['post_data']['give-form-title'],
 		'give_form_id'    => $form_id,
@@ -57,7 +57,7 @@ function give_process_paypal_payment( $payment_data ) {
 	);
 
 	// Record the pending payment.
-	$payment_id = give_insert_payment( $payment_data );
+	$payment_id = give_insert_payment( $insert_payment_args );
 
 	// Check payment.
 	if ( ! $payment_id ) {


### PR DESCRIPTION
## Description
I fixed the issue with PayPal Standard's arguments being passed over. When I changed the var name `$purchase_args` to `$payment_args` I inadvertently also caused the variable to be overwritten  here: https://github.com/WordImpress/Give/blob/master/includes/gateways/paypal-standard.php#L45

I've made the array passed into `give_insert_payment` unique now. Fixes #1334

## How Has This Been Tested?
- Multiple sandbox payments and verified array params being passed

## Types of changes
<!--- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.