### PR TITLE
Update to use `cmb2_init` action and `new_cmb2_box` function.

### DIFF
--- a/includes/admin/forms/metabox.php
+++ b/includes/admin/forms/metabox.php
@@ -14,16 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_filter( 'cmb2_meta_boxes', 'give_single_forms_cmb2_metaboxes' );
+add_action( 'cmb2_init', 'give_single_forms_cmb2_metaboxes', 6 );
 
 /**
  * Define the metabox and field configurations.
- *
- * @param  array $meta_boxes
- *
- * @return array
  */
-function give_single_forms_cmb2_metaboxes( array $meta_boxes ) {
+function give_single_forms_cmb2_metaboxes() {
 
 	$post_id               = give_get_admin_post_id();
 	$price                 = give_get_form_price( $post_id );
@@ -44,6 +40,9 @@ function give_single_forms_cmb2_metaboxes( array $meta_boxes ) {
 
 	// Start with an underscore to hide fields from custom fields list
 	$prefix = '_give_';
+
+	// Init metaboxes array.
+	$meta_boxes = array();
 
 	/**
 	 * Repeatable Field Groups
@@ -422,7 +421,9 @@ function give_single_forms_cmb2_metaboxes( array $meta_boxes ) {
 		)
 	) );
 
-	return $meta_boxes;
+	foreach ( $meta_boxes as $box ) {
+		$cmb = new_cmb2_box( $box );
+	}
 
 }
 


### PR DESCRIPTION
The `cmb2_meta_boxes` filter is mostly for back-compatibility and it is recommended to use the action and the API to add boxes/fields. I have updated to use the `cmb2_init` and to loop through the metaboxes and register them with `new_cmb2_box`. This is untested, but should work exactly the same, but be more resilient as it does not depend on [others using the filter correctly](https://wordpress.org/support/topic/fatal-error-upon-activation-24/).