### PR TITLE
Issue/1370

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -380,7 +380,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -404,7 +404,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -430,7 +430,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -475,7 +475,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'radio' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -508,7 +508,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'checkbox' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 							</th>
@@ -533,7 +533,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						$option_value = is_array( $option_value ) ? $option_value : array();
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 							</th>
@@ -571,7 +571,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'file' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -606,7 +606,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						// Get editor settings.
 						$editor_settings = ! empty( $value['options'] ) ? $value['options'] : array();
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -620,7 +620,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					// Custom: System setting field.
 					case 'system_info' :
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -635,7 +635,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'default_gateway' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -650,7 +650,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'enabled_gateways' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -664,7 +664,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					// Custom: Email preview buttons field.
 					case 'email_preview_buttons' :
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<th scope="row" class="titledesc">
 							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
 						</th>
@@ -697,7 +697,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					// Custom: Give Docs Link field type.
 					case 'give_docs_link' :
 						?>
-						<tr valign="top">
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 						<td class="give-docs-link" colspan="2">
 						<?php
 							echo '<p class="give-docs-link"><a href="' . esc_url( $value['url'] )

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -89,7 +89,7 @@ function give_get_field_callback( $field ) {
 }
 
 /**
- * This function add backward compatibility to render cmb2 type field type.
+ * This function adds backward compatibility to render cmb2 type field type.
  *
  * @since  1.8
  *
@@ -98,6 +98,7 @@ function give_get_field_callback( $field ) {
  * @return bool
  */
 function give_render_field( $field ) {
+
 	$func_name = give_get_field_callback( $field );
 
 	// Check if render callback exist or not.

--- a/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
+++ b/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
@@ -286,6 +286,12 @@ if ( ! class_exists( 'Give_CMB2_Settings_Loader' ) ) :
 						continue;
 					}
 
+					// Set wrapper class if any.
+					if ( ! empty( $field['row_classes'] ) ) {
+						$field['wrapper_class'] = $field['row_classes'];
+						unset( $field['row_classes'] );
+					}
+
 					$field['name'] = ! isset( $field['name'] ) ? '' : $field['name'];
 					$field['desc'] = ! isset( $field['desc'] ) ? '' : $field['desc'];
 


### PR DESCRIPTION
## Description
Added support for CMB2 `row_classes` usage within Add-ons like Stripe. Fixes #1370 

## How Has This Been Tested?
With the Stripe Add-on

## Screenshots (jpeg or gifs if applicable):
![2016-12-30_12-20-31](https://cloud.githubusercontent.com/assets/1571635/21572101/731df0ec-ce8a-11e6-90bd-2e9aeaed2fa7.gif)


## Types of changes
- Compatibility fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.