### PR TITLE
Minor fix

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -822,7 +822,7 @@ class Give_MetaBox_Form_Data {
 			foreach ( $this->settings as $setting ) {
 				if ( ! empty( $setting['fields'] ) ) {
 					foreach ( $setting['fields'] as $field ) {
-						if ( $field['id'] === $field_id ) {
+						if ( array_key_exists( 'id', $field ) && $field['id'] === $field_id ) {
 							$setting_field = $field;
 						}
 					}
@@ -834,7 +834,7 @@ class Give_MetaBox_Form_Data {
 		// Get field from group.
 		if ( ! empty( $group_id ) ) {
 			foreach ( $setting_field['fields'] as $field ) {
-				if ( $field['id'] === $_field_id ) {
+				if ( array_key_exists( 'id', $field ) && $field['id'] === $_field_id ) {
 					$setting_field = $field;
 				}
 			}

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -774,6 +774,10 @@ class Give_MetaBox_Form_Data {
 		foreach ( $this->settings as $setting ) {
 			if ( ! empty( $setting['fields'] ) ) {
 				foreach ( $setting['fields'] as $field ) {
+					if( ! array_key_exists( 'id', $field ) ) {
+						continue;
+					}
+
 					$meta_keys[] = $field['id'];
 				}
 			}

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -794,8 +794,12 @@ class Give_MetaBox_Form_Data {
 	 * @return string
 	 */
 	function get_field_type( $field_id, $group_id = '' ) {
+		$settings = $this->get_setting_field( $field_id, $group_id );
+		$type     = array_key_exists( 'type', $this->get_setting_field( $field_id, $group_id ) )
+			? $settings['type']
+			: '';
 
-		return $this->get_setting_field( $field_id, $group_id )['type'];
+		return $type;
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
This PR will fix two bugs:
1. Remove array short tags,
2. Form meta box settings can have a setting which developer may want to save into DB ( by not assigning any id to this, for example, `docs_link` field type ). I add updates setting API to ignore setting field which does not have `id`.
for ref: https://github.com/WordImpress/Give/pull/1363/files#diff-599b588679cb92b7cb0c8b9ba20f7fd0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Save any form setting.

## Types of changes
<!--- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.