### PR TITLE
Hotfix/fix notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .sass-cache/*
 /bower
 /node_modules
+/vendor
 
 # Unit tests
 /tmp

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -306,7 +306,11 @@ class Give_Addon_Activation_Banner {
 
 			// Check addon file path.
 			if ( ! empty( $this->banner_details['file'] ) ) {
-				$file_name = explode( '/', explode( '/plugins/', $this->banner_details['file'] )[1] )[0];
+				$file_name = '';
+				if ( $file_path = explode( '/plugins/', $this->banner_details['file'] ) ) {
+					$file_path = array_pop( $file_path );
+					$file_name = current( explode( '/', $file_path ) );
+				}
 
 				foreach ( $active_plugins as $plugin ) {
 					if ( false !== strpos( $plugin, $file_name ) ) {

--- a/includes/admin/settings/class-settings-addon.php
+++ b/includes/admin/settings/class-settings-addon.php
@@ -56,8 +56,9 @@ if ( ! class_exists( 'Give_Settings_Addon' ) ) :
 		 * @return array
 		 */
 		public function add_settings_page( $pages ) {
+			$setting = $this->get_settings();
 			// Bailout: Do not add addons setting tab if it does not contain any setting fields.
-			if( ! empty( $this->get_settings() ) ) {
+			if( ! empty( $setting ) ) {
 				$pages[ $this->id ] = $this->label;
 			}
 

--- a/includes/admin/settings/class-settings-license.php
+++ b/includes/admin/settings/class-settings-license.php
@@ -57,8 +57,9 @@ if ( ! class_exists( 'Give_Settings_License' ) ) :
 		 * @return array
 		 */
 		public function add_settings_page( $pages ) {
+			$setting = $this->get_settings();
 			// Bailout: Do not add licenses setting tab if it does not contain any setting fields.
-			if( ! empty( $this->get_settings() ) ) {
+			if( ! empty( $setting ) ) {
 				$pages[ $this->id ] = $this->label;
 			}
 


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
I was getting these notices on fresh plugin install.

```
Fatal error: Can't use method return value in write context in /wp-content/plugins/Give/includes/admin/settings/class-settings-license.php on line 61
Fatal error: Can't use method return value in write context in /wp-content/plugins/Give/includes/admin/settings/class-settings-addon.php on line 61
Parse error: syntax error, unexpected '[' in /wp-content/plugins/Give/includes/admin/class-addon-activation-banner.php on line 309
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.