### PR TITLE
Fix version comperision

### DIFF
--- a/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
+++ b/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
@@ -405,7 +405,7 @@ if ( ! class_exists( 'Give_CMB2_Settings_Loader' ) ) :
 
 					if ( in_array( $cmb2_filter_name, $wp_filter_keys ) ) {
 
-						if( 0 <= version_compare( 4.7, get_bloginfo('version') ) &&  ! empty( $wp_filter[$cmb2_filter_name]->callbacks ) ) {
+						if( 0 >= version_compare( 4.7, get_bloginfo('version') ) &&  ! empty( $wp_filter[$cmb2_filter_name]->callbacks ) ) {
 							$cmb2_filter_arr = current( $wp_filter[$cmb2_filter_name]->callbacks );
 						} else {
 							$cmb2_filter_arr = current( $wp_filter[ $cmb2_filter_name ] );


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
There are new updates for filter and action in WordPress 4.7 https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/

That why I added the new filter and action support in cmb2 backward compatibility.
We are facing some issues in add-ons with cmb2 backward compatibility
https://github.com/WordImpress/Give-Email-Reports/issues/21
https://github.com/WordImpress/Give-Constant-Contact/issues/22

This PR will fix those issues.

## Types of changes
<!--- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.