### PR TITLE
Change reCAPTCHA to shortlink for easier redirect in the future

### DIFF
--- a/includes/admin/settings/class-settings-general.php
+++ b/includes/admin/settings/class-settings-general.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 							'id'      => 'recaptcha_key',
 							'name'    => esc_html__( 'reCAPTCHA Site Key', 'give' ),
 							/* translators: %s: https://www.google.com/recaptcha/ */
-							'desc'    => sprintf( __( 'If you would like to prevent spam on the email access form navigate to <a href="%s" target="_blank">the reCAPTCHA website</a> and sign up for an API key. The reCAPTCHA uses Google\'s user-friendly single click verification method.', 'give' ), esc_url( 'https://www.google.com/recaptcha/' ) ),
+							'desc'    => sprintf( __( 'If you would like to prevent spam on the email access form navigate to <a href="%s" target="_blank">the reCAPTCHA website</a> and sign up for an API key. The reCAPTCHA uses Google\'s user-friendly single click verification method.', 'give' ), esc_url( 'http://docs.givewp.com/recaptcha' ) ),
 							'default' => '',
 							'type'    => 'text'
 						),


### PR DESCRIPTION
Changed the reCAPTCHA link to a shortlink so we can change it on the fly if Google happens to change their URLs or the new "Invisible" reCAPTCHA ever gets launched officially.

This is the new link: http://docs.givewp.com/recaptcha