### PR TITLE
Issue/1430

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -79,8 +79,8 @@ function give_form_shortcode( $atts ) {
 	), $atts, 'give_form' );
 
 	// Convert string to bool.
-	$atts['show_title'] = (bool) $atts['show_title'];
-	$atts['show_goal']  = (bool) $atts['show_goal'];
+	$atts['show_title'] = filter_var( $atts['show_title'], FILTER_VALIDATE_BOOLEAN );
+	$atts['show_goal'] = filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN );
 
 	//get the Give Form
 	ob_start();

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -80,7 +80,7 @@ function give_form_shortcode( $atts ) {
 
 	// Convert string to bool.
 	$atts['show_title'] = filter_var( $atts['show_title'], FILTER_VALIDATE_BOOLEAN );
-	$atts['show_goal'] = filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN );
+	$atts['show_goal']  = filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN );
 
 	//get the Give Form
 	ob_start();


### PR DESCRIPTION
Fixes #1430 by evaluating `give_form` shortcode arguments with a boolean filter so that `"true"` and `"false"` are correctly evaluated as `true` and `false`.

`show_title` and `show_goal` are now reflected in the form output.