### PR TITLE
Display [give_login] shortcode to prompt user to login to view donati…

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -52,6 +52,8 @@ function give_donation_history() {
 	} else {
 		$message = esc_html__( 'You must be logged in to view your donation history. Please login using your account or create an account using the same email you used to donate with.', 'give' );
 		echo apply_filters( 'give_donation_history_nonuser_message', give_output_error( $message, false ), $message );
+		echo do_shortcode( '[give_login]' );
+
 	}
 }
 


### PR DESCRIPTION
## Description
Added `[give_login]` shortcode when a user is trying to view donation history without being logged in. #1485 

## How Has This Been Tested?
Tested login and redirect.

## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
- UX improvement
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.