### PR TITLE
Hotfix/setup_transaction_id

### DIFF
--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -1973,11 +1973,9 @@ final class Give_Payment {
 	private function setup_transaction_id() {
 		$transaction_id = $this->get_meta( '_give_payment_transaction_id', true );
 
-		if ( empty( $transaction_id ) || (int) $transaction_id === (int) $this->ID ) {
-
+		if ( empty( $transaction_id ) ) {
 			$gateway        = $this->gateway;
 			$transaction_id = apply_filters( "give_get_payment_transaction_id-{$gateway}", $this->ID );
-
 		}
 
 		return $transaction_id;


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
```
if ( empty( $transaction_id ) || (int) $transaction_id === (int) $this->ID ) {
 	$gateway        = $this->gateway;
 	$transaction_id = apply_filters( "give_get_payment_transaction_id-{$gateway}", $this->ID );
}
```

In above condition I think `(int) $transaction_id === (int) $this->ID` comparision is required to set default trasaction id. This PR will remove this extra check from `if` condition.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.