### PR TITLE
Fix cmb2 compability issue with php7

### DIFF
--- a/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
+++ b/includes/admin/settings/class-settings-cmb2-backward-compatibility.php
@@ -518,7 +518,9 @@ if ( ! class_exists( 'Give_CMB2_Settings_Loader' ) ) :
 						<td class="give-forminp" <?php echo $colspan; ?>>
 							<?php
 							if ( is_array( $field['func']['function'] ) ) {
-								$field['func']['function'][0]->$field['func']['function'][1]( $field_obj, $saved_value, '', '', $field_type_obj );
+								$classname = $field['func']['function'][0];
+								$function_name = $field['func']['function'][1];
+								$classname->$function_name( $field_obj, $saved_value, '', '', $field_type_obj );
 							} else {
 								$field['func']['function']( $field_obj, $saved_value, '', '', $field_type_obj );
 							}


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
In PHP 7 you can not create function or class name directly from array value.
For example` $field['func']['function'][0]->$field['func']['function'][1]( $field_obj, $saved_value, '', '', $field_type_obj )`

This can because of fatal error or notices.

## Types of changes
<!--- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.