### PR TITLE
Issue/1540

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -681,6 +681,29 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						echo $description;
 						break;
 
+					// Custom: Gateway API key.
+					case 'api_key' :
+						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
+						$type = !empty($option_name) ? 'password' : 'text';
+						?>
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+                            <input
+                                    name="<?php echo esc_attr( $value['id'] ); ?>"
+                                    id="<?php echo esc_attr( $value['id'] ); ?>"
+                                    type="<?php echo esc_attr( $type ); ?>"
+                                    style="<?php echo esc_attr( $value['css'] ); ?>"
+                                    value="<?php echo esc_attr( $option_value ); ?>"
+                                    class="give-input-field<?php echo( empty( $value['class'] ) ? '' : ' ' . esc_attr( $value['class'] ) ); ?>"
+								<?php echo implode( ' ', $custom_attributes ); ?>
+                            /> <?php echo $description; ?>
+                        </td>
+                        </tr><?php
+						break;
+
 					// Custom: Log field.
 					case 'logs' :
 						// Note: there are no need to check for html field param because we want custom html to this field.

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -380,22 +380,22 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
-							<input
-								name="<?php echo esc_attr( $value['id'] ); ?>"
-								id="<?php echo esc_attr( $value['id'] ); ?>"
-								type="<?php echo esc_attr( $type ); ?>"
-								style="<?php echo esc_attr( $value['css'] ); ?>"
-								value="<?php echo esc_attr( $option_value ); ?>"
-								class="give-input-field<?php echo( empty( $value['class'] ) ? '' : ' ' . esc_attr( $value['class'] ) ); ?>"
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+                            <input
+                                    name="<?php echo esc_attr( $value['id'] ); ?>"
+                                    id="<?php echo esc_attr( $value['id'] ); ?>"
+                                    type="<?php echo esc_attr( $type ); ?>"
+                                    style="<?php echo esc_attr( $value['css'] ); ?>"
+                                    value="<?php echo esc_attr( $option_value ); ?>"
+                                    class="give-input-field<?php echo( empty( $value['class'] ) ? '' : ' ' . esc_attr( $value['class'] ) ); ?>"
 								<?php echo implode( ' ', $custom_attributes ); ?>
-							/> <?php echo $description; ?>
-						</td>
-						</tr><?php
+                            /> <?php echo $description; ?>
+                        </td>
+                        </tr><?php
 						break;
 
 					// Textarea.
@@ -404,23 +404,23 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
 								<textarea
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									style="<?php echo esc_attr( $value['css'] ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>"
-									rows="10"
-									cols="60"
+                                        name="<?php echo esc_attr( $value['id'] ); ?>"
+                                        id="<?php echo esc_attr( $value['id'] ); ?>"
+                                        style="<?php echo esc_attr( $value['css'] ); ?>"
+                                        class="<?php echo esc_attr( $value['class'] ); ?>"
+                                        rows="10"
+                                        cols="60"
 									<?php echo implode( ' ', $custom_attributes ); ?>
-								><?php echo esc_textarea( $option_value ); ?></textarea>
+                                ><?php echo esc_textarea( $option_value ); ?></textarea>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Select boxes.
@@ -430,27 +430,27 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
-							<select
-								name="<?php echo esc_attr( $value['id'] ); ?><?php if ( $value['type'] == 'multiselect' ) {
-									echo '[]';
-								} ?>"
-								id="<?php echo esc_attr( $value['id'] ); ?>"
-								style="<?php echo esc_attr( $value['css'] ); ?>"
-								class="<?php echo esc_attr( $value['class'] ); ?>"
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+                            <select
+                                    name="<?php echo esc_attr( $value['id'] ); ?><?php if ( $value['type'] == 'multiselect' ) {
+										echo '[]';
+									} ?>"
+                                    id="<?php echo esc_attr( $value['id'] ); ?>"
+                                    style="<?php echo esc_attr( $value['css'] ); ?>"
+                                    class="<?php echo esc_attr( $value['class'] ); ?>"
 								<?php echo implode( ' ', $custom_attributes ); ?>
 								<?php echo ( 'multiselect' == $value['type'] ) ? 'multiple="multiple"' : ''; ?>
-							>
+                            >
 
 								<?php
 								if ( ! empty( $value['options'] ) ) {
 									foreach ( $value['options'] as $key => $val ) {
 										?>
-										<option value="<?php echo esc_attr( $key ); ?>" <?php
+                                        <option value="<?php echo esc_attr( $key ); ?>" <?php
 
 										if ( is_array( $option_value ) ) {
 											selected( in_array( $key, $option_value ), true );
@@ -464,9 +464,9 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 								}
 								?>
 
-							</select> <?php echo $description; ?>
-						</td>
-						</tr><?php
+                            </select> <?php echo $description; ?>
+                        </td>
+                        </tr><?php
 						break;
 
 					// Radio inputs.
@@ -475,56 +475,56 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'radio' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?> <?php echo( ! empty( $value['class'] ) ? $value['class'] : '' ); ?>">
-							<fieldset>
-								<ul>
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?> <?php echo( ! empty( $value['class'] ) ? $value['class'] : '' ); ?>">
+                            <fieldset>
+                                <ul>
 									<?php
 									foreach ( $value['options'] as $key => $val ) {
 										?>
-										<li>
-											<label><input
-													name="<?php echo esc_attr( $value['id'] ); ?>"
-													value="<?php echo $key; ?>"
-													type="radio"
-													style="<?php echo esc_attr( $value['css'] ); ?>"
+                                        <li>
+                                            <label><input
+                                                        name="<?php echo esc_attr( $value['id'] ); ?>"
+                                                        value="<?php echo $key; ?>"
+                                                        type="radio"
+                                                        style="<?php echo esc_attr( $value['css'] ); ?>"
 													<?php echo implode( ' ', $custom_attributes ); ?>
 													<?php checked( $key, $option_value ); ?>
-												/> <?php echo $val ?></label>
-										</li>
+                                                /> <?php echo $val ?></label>
+                                        </li>
 										<?php
 									}
 									?>
 									<?php echo $description; ?>
-							</fieldset>
-						</td>
-						</tr><?php
+                            </fieldset>
+                        </td>
+                        </tr><?php
 						break;
 
 					// Checkbox input.
 					case 'checkbox' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-							</th>
-							<td class="give-forminp">
-								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									type="checkbox"
-									class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
-									value="1"
+                        <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                            <th scope="row" class="titledesc">
+                                <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                            </th>
+                            <td class="give-forminp">
+                                <input
+                                        name="<?php echo esc_attr( $value['id'] ); ?>"
+                                        id="<?php echo esc_attr( $value['id'] ); ?>"
+                                        type="checkbox"
+                                        class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
+                                        value="1"
 									<?php checked( $option_value, 'on' ); ?>
 									<?php echo implode( ' ', $custom_attributes ); ?>
-								/>
+                                />
 								<?php echo $description; ?>
-							</td>
-						</tr>
+                            </td>
+                        </tr>
 						<?php
 						break;
 
@@ -533,37 +533,37 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						$option_value = is_array( $option_value ) ? $option_value : array();
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-							</th>
-							<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?> <?php echo( ! empty( $value['class'] ) ? $value['class'] : '' ); ?>">
-								<fieldset>
-									<ul>
+                        <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                            <th scope="row" class="titledesc">
+                                <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                            </th>
+                            <td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?> <?php echo( ! empty( $value['class'] ) ? $value['class'] : '' ); ?>">
+                                <fieldset>
+                                    <ul>
 										<?php
 										foreach ( $value['options'] as $key => $val ) {
 											?>
-											<li>
-												<label>
-													<input
-														name="<?php echo esc_attr( $value['id'] ); ?>[]"
-														value="<?php echo $key; ?>"
-														type="checkbox"
-														style="<?php echo esc_attr( $value['css'] ); ?>"
+                                            <li>
+                                                <label>
+                                                    <input
+                                                            name="<?php echo esc_attr( $value['id'] ); ?>[]"
+                                                            value="<?php echo $key; ?>"
+                                                            type="checkbox"
+                                                            style="<?php echo esc_attr( $value['css'] ); ?>"
 														<?php echo implode( ' ', $custom_attributes ); ?>
 														<?php if ( in_array( $key, $option_value ) ) {
 															echo 'checked="checked"';
 														} ?>
-													/> <?php echo $val ?>
-												</label>
-											</li>
+                                                    /> <?php echo $val ?>
+                                                </label>
+                                            </li>
 											<?php
 										}
 										?>
 										<?php echo $description; ?>
-								</fieldset>
-							</td>
-						</tr>
+                                </fieldset>
+                            </td>
+                        </tr>
 						<?php
 						break;
 
@@ -571,31 +571,32 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'file' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
-							<div class="give-field-wrap">
-								<label for="<?php echo $value['id'] ?>">
-									<input
-										name="<?php echo esc_attr( $value['id'] ); ?>"
-										id="<?php echo esc_attr( $value['id'] ); ?>"
-										type="text"
-										class="give-input-field<?php echo esc_attr( isset( $value['class'] ) ? ' ' . $value['class'] : '' ); ?>"
-										value="<?php echo $option_value; ?>"
-										style="<?php echo esc_attr( $value['css'] ); ?>"
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
+                            <div class="give-field-wrap">
+                                <label for="<?php echo $value['id'] ?>">
+                                    <input
+                                            name="<?php echo esc_attr( $value['id'] ); ?>"
+                                            id="<?php echo esc_attr( $value['id'] ); ?>"
+                                            type="text"
+                                            class="give-input-field<?php echo esc_attr( isset( $value['class'] ) ? ' ' . $value['class'] : '' ); ?>"
+                                            value="<?php echo $option_value; ?>"
+                                            style="<?php echo esc_attr( $value['css'] ); ?>"
 										<?php echo implode( ' ', $custom_attributes ); ?>
-									/>&nbsp;&nbsp;&nbsp;&nbsp;<input class="give-upload-button button" type="button" value="<?php echo esc_html__( 'Add or Upload File', 'give' ); ?>">
+                                    />&nbsp;&nbsp;&nbsp;&nbsp;<input class="give-upload-button button" type="button"
+                                                                     value="<?php echo esc_html__( 'Add or Upload File', 'give' ); ?>">
 									<?php echo $description ?>
-									<div class="give-image-thumb<?php echo ! $option_value ? ' give-hidden' : ''; ?>">
-										<span class="give-delete-image-thumb dashicons dashicons-no-alt"></span>
-										<img src="<?php echo $option_value; ?>" alt="">
-									</div>
-								</label>
-							</div>
-						</td>
-						</tr><?php
+                                    <div class="give-image-thumb<?php echo ! $option_value ? ' give-hidden' : ''; ?>">
+                                        <span class="give-delete-image-thumb dashicons dashicons-no-alt"></span>
+                                        <img src="<?php echo $option_value; ?>" alt="">
+                                    </div>
+                                </label>
+                            </div>
+                        </td>
+                        </tr><?php
 						break;
 
 					// WordPress Editor.
@@ -606,73 +607,73 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						// Get editor settings.
 						$editor_settings = ! empty( $value['options'] ) ? $value['options'] : array();
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
 							<?php wp_editor( $option_value, $value['id'], $editor_settings ); ?>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Custom: System setting field.
 					case 'system_info' :
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
 							<?php give_system_info_callback(); ?>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Custom: Default gateways setting field.
 					case 'default_gateway' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
 							<?php give_default_gateway_callback( $value, $option_value ); ?>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Custom: Enable gateways setting field.
 					case 'enabled_gateways' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
 							<?php give_enabled_gateways_callback( $value, $option_value ); ?>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Custom: Email preview buttons field.
 					case 'email_preview_buttons' :
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <th scope="row" class="titledesc">
+                            <label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+                        </th>
+                        <td class="give-forminp">
 							<?php give_email_preview_buttons_callback(); ?>
 							<?php echo $description; ?>
-						</td>
-						</tr><?php
+                        </td>
+                        </tr><?php
 						break;
 
 					// Custom: API field.
@@ -684,7 +685,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					// Custom: Gateway API key.
 					case 'api_key' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
-						$type = !empty($option_name) ? 'password' : 'text';
+						$type         = ! empty( $option_value ) ? 'password' : 'text';
 						?>
                     <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
                         <th scope="row" class="titledesc">
@@ -720,16 +721,16 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					// Custom: Give Docs Link field type.
 					case 'give_docs_link' :
 						?>
-						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<td class="give-docs-link" colspan="2">
-						<?php
+                    <tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+                        <td class="give-docs-link" colspan="2">
+							<?php
 							echo '<p class="give-docs-link"><a href="' . esc_url( $value['url'] )
-							. '" target="_blank">'
-							. sprintf( esc_html__( 'Need Help? See docs on "%s"' ), $value['title'] )
-							. '<span class="dashicons dashicons-editor-help"></span></a></p>';
-						?>
-						</td>
-						</tr><?php
+							     . '" target="_blank">'
+							     . sprintf( esc_html__( 'Need Help? See docs on "%s"' ), $value['title'] )
+							     . '<span class="dashicons dashicons-editor-help"></span></a></p>';
+							?>
+                        </td>
+                        </tr><?php
 						break;
 
 					// Default: run an action
@@ -744,20 +745,24 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 		}
 
 		/**
-		 * Helper function to get the formated description for a given form field.
+		 * Helper function to get the formatted description for a given form field.
 		 * Plugins can call this when implementing their own custom settings types.
 		 *
 		 * @since  1.8
 		 *
 		 * @param  array $value The form field value array
 		 *
-		 * @return array The description and tip as a 2 element array
+		 * @return string The HTML description of the field.
 		 */
 		public static function get_field_description( $value ) {
 			$description = '';
 
-			if ( ! empty( $value['desc'] ) ) {
-				$description = '<p class="give-field-description">' . wp_kses_post( $value['desc'] ) . '</p>';
+			// Support for both 'description' and 'desc' args.
+			$description_key = isset( $value['description'] ) ? 'description' : 'desc';
+			$value           = ( isset( $value[ $description_key ] ) && ! empty( $value[ $description_key ] ) ) ? $value[ $description_key ] : '';
+
+			if ( ! empty( $value ) ) {
+				$description = '<p class="give-field-description">' . wp_kses_post( $value ) . '</p>';
 			}
 
 			return $description;

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -697,7 +697,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
                                     id="<?php echo esc_attr( $value['id'] ); ?>"
                                     type="<?php echo esc_attr( $type ); ?>"
                                     style="<?php echo esc_attr( $value['css'] ); ?>"
-                                    value="<?php echo esc_attr( $option_value ); ?>"
+                                    value="<?php echo esc_attr( trim( $option_value ) ); ?>"
                                     class="give-input-field<?php echo( empty( $value['class'] ) ? '' : ' ' . esc_attr( $value['class'] ) ); ?>"
 								<?php echo implode( ' ', $custom_attributes ); ?>
                             /> <?php echo $description; ?>

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -233,7 +233,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 			$sections = array(
 				'gateways-settings' => __( 'Gateways', 'give' ),
 				'paypal-standard'   => __( 'PayPal Standard', 'give' ),
-				'offline-donations' => __( 'Offline', 'give' )
+				'offline-donations' => __( 'Offline Donations', 'give' )
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -37,10 +37,12 @@ function give_do_automatic_upgrades() {
 		case version_compare( $give_version, '1.6', '<' ) :
 			give_v16_upgrades();
 			$did_upgrade = true;
+			break;
 
 		case version_compare( $give_version, '1.7', '<' ) :
 			give_v17_upgrades();
 			$did_upgrade = true;
+            break;
 
 		case version_compare( $give_version, '1.8', '<' ) :
 			give_v18_upgrades();
@@ -131,9 +133,9 @@ function give_show_upgrade_notices() {
 	?>
 	<script>
 		jQuery(document).ready(function($){
-			var $upgrdae_links = $('.give-upgrade-link');
-			if( $upgrdae_links.length ) {
-				$upgrdae_links.on( 'click', function(e){
+			var $upgrade_links = $('.give-upgrade-link');
+			if( $upgrade_links.length ) {
+				$upgrade_links.on( 'click', function(e){
 					e.preventDefault();
 
 					if( ! window.confirm( give_vars.upgrade_confirmation ) ) {


### PR DESCRIPTION
## Description
New API key field within the admin Settings API. #1540 https://github.com/WordImpress/Give/compare/release/1.8.3...issue/1540?expand=1#diff-03befedde978b9a55cce3fecea4fa8feR686

Additional updates:
1. I noticed PayPal was using `description` rather than `desc` so I added support for that - https://github.com/WordImpress/Give/compare/release/1.8.3...issue/1540?expand=1#diff-03befedde978b9a55cce3fecea4fa8feR761
2. Typo fixes
3. Minor code improvement. 

![2017-02-23_13-08-33](https://cloud.githubusercontent.com/assets/1571635/23279217/3dc4dd60-f9c9-11e6-9959-c43483d6fa94.gif)

## How Has This Been Tested?
- Ensured that the gateways work with new field type
- Ensured when the field is empty field returns to text type
- Ensured when the field has a value it is a password type

## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
- New feature
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.