### PR TITLE
Use `the_content` to output Goal complete message #1545

### DIFF
--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -469,7 +469,6 @@ class Give_Plugin_Settings {
 							'id'   => 'disable_forms_excerpt',
 							'type' => 'checkbox'
 						),
-
 						array(
 							'name'    => esc_html__( 'Featured Image Size', 'give' ),
 							'desc'    => esc_html__( 'The Featured Image is an image that is chosen as the representative image for a donation form. Some themes may have custom featured image sizes. Please select the size you would like to display for your single donation form\'s featured image.', 'give' ),
@@ -508,27 +507,6 @@ class Give_Plugin_Settings {
 							'id'   => 'tags',
 							'type' => 'checkbox'
 						),
-						// array(
-						// 	'name' => esc_html__( 'Term and Conditions', 'give' ),
-						// 	'desc' => '',
-						// 	'id'   => 'give_title_display_settings_4',
-						// 	'type' => 'give_title'
-						// ),
-						// array(
-						// 	'name' => esc_html__( 'Agree to Terms Label', 'give' ),
-						// 	'desc' => esc_html__( 'The label shown next to the agree to terms check box. Add your own to customize or leave blank to use the default text placeholder. Note: You can customize the label per form as needed.', 'give' ),
-						// 	'id'   => 'agree_to_terms_label',
-						// 	'attributes'  => array(
-						// 		'placeholder' => esc_attr__( 'Agree to Terms?', 'give' ),
-						// 	),
-						// 	'type' => 'text'
-						// ),
-						// array(
-						// 	'name' => esc_html__( 'Agreement Text', 'give' ),
-						// 	'desc' => esc_html__( 'This is the actual text which the user will have to agree to in order to make a donation. Note: You can customize the content per form as needed.', 'give' ),
-						// 	'id'   => 'agreement_text',
-						// 	'type' => 'wysiwyg'
-						// ),
 					)
 				)
 

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -395,13 +395,11 @@ class Give_MetaBox_Form_Data {
 						),
 					),
 					array(
-						'name'       => esc_html__( 'Goal Achieved Message', 'give' ),
-						'desc'       => esc_html__( 'Do you want to display a custom message when the goal is closed? If none is provided the default message will be displayed', 'give' ),
+						'name'       => __( 'Goal Achieved Message', 'give' ),
+						'desc'       => __( 'Do you want to display a custom message when the goal is closed?', 'give' ),
 						'id'         => $prefix . 'form_goal_achieved_message',
 						'type'       => 'wysiwyg',
-						'attributes' => array(
-							'placeholder' => esc_attr__( 'Thank you to all our donors, we have met our fundraising goal.', 'give' ),
-						),
+                        'default' => __( 'Thank you to all our donors, we have met our fundraising goal.', 'give' ),
 					),
 					array(
 						'name'  => 'donation_goal_docs',

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -53,7 +53,6 @@ function give_get_field_callback( $field ) {
 			$func_name = "{$func_name_prefix}_text_input";
 			break;
 
-
 		case 'textarea' :
 			$func_name = "{$func_name_prefix}_textarea_input";
 			break;
@@ -134,7 +133,6 @@ function give_render_field( $field ) {
 	$field['attributes']['class'] = trim( "give-field {$field['attributes']['class']} give-{$field['type']} {$field['class']}" );
 	unset( $field['class'] );
 
-
 	// CMB2 compatibility: Set wrapper class if any.
 	if ( ! empty( $field['row_classes'] ) ) {
 		$field['wrapper_class'] = $field['row_classes'];
@@ -209,21 +207,23 @@ function give_render_field( $field ) {
  * Output a text input box.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of text input field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $type            Type of input field. Default 'text'.
- *     @type string             $before_field    Text/HTML to add before input field. Default ''.
- *     @type string             $after_field     Text/HTML to add after input field. Default ''.
- *     @type string             $data_type       Define data type for value of input to filter it properly. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field         {
+ *                              Optional. Array of text input field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $type          Type of input field. Default 'text'.
+ * @type string  $before_field  Text/HTML to add before input field. Default ''.
+ * @type string  $after_field   Text/HTML to add after input field. Default ''.
+ * @type string  $data_type     Define data type for value of input to filter it properly. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
@@ -258,17 +258,17 @@ function give_text_input( $field ) {
 
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
-		<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
-		<?php echo $field['before_field']; ?>
-		<input
+	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
+	<?php echo $field['before_field']; ?>
+	<input
 			type="<?php echo esc_attr( $field['type'] ); ?>"
 			style="<?php echo esc_attr( $field['style'] ); ?>"
 			name="<?php echo give_get_field_name( $field ); ?>"
 			id="<?php echo esc_attr( $field['id'] ); ?>"
 			value="<?php echo esc_attr( $field['value'] ); ?>"
-			<?php echo give_get_custom_attributes( $field ); ?>
-		/>
-		<?php echo $field['after_field']; ?>
+		<?php echo give_get_custom_attributes( $field ); ?>
+	/>
+	<?php echo $field['after_field']; ?>
 	<?php
 	echo give_get_field_description( $field );
 	echo '</p>';
@@ -278,15 +278,17 @@ function give_text_input( $field ) {
  * Output a hidden input box.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of hidden text input field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $type            Type of input field. Default 'text'.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field      {
+ *                           Optional. Array of hidden text input field arguments.
+ *
+ * @type string  $id         Field ID. Default ''.
+ * @type string  $value      Value of input field. Default ''.
+ * @type string  $name       Name of input field. Default ''.
+ * @type string  $type       Type of input field. Default 'text'.
+ * @type array   $attributes List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
@@ -308,10 +310,10 @@ function give_hidden_input( $field ) {
 	?>
 
 	<input
-		type="hidden"
-		name="<?php echo give_get_field_name( $field ); ?>"
-		id="<?php echo esc_attr( $field['id'] ); ?>"
-		value="<?php echo esc_attr( $field['value'] ); ?>"
+			type="hidden"
+			name="<?php echo give_get_field_name( $field ); ?>"
+			id="<?php echo esc_attr( $field['id'] ); ?>"
+			value="<?php echo esc_attr( $field['value'] ); ?>"
 		<?php echo give_get_custom_attributes( $field ); ?>
 	/>
 	<?php
@@ -322,17 +324,19 @@ function give_hidden_input( $field ) {
  *
  * @since  1.8
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of textarea input field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field         {
+ *                              Optional. Array of textarea input field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
@@ -346,15 +350,15 @@ function give_textarea_input( $field ) {
 
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
-		<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
-		<textarea
+	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
+	<textarea
 			style="<?php echo esc_attr( $field['style'] ); ?>"
 			name="<?php echo give_get_field_name( $field ); ?>"
 			id="<?php echo esc_attr( $field['id'] ); ?>"
 			rows="10"
 			cols="20"
-			<?php echo give_get_custom_attributes( $field ); ?>
-		><?php echo esc_textarea( $field['value'] ); ?></textarea>
+		<?php echo give_get_custom_attributes( $field ); ?>
+	><?php echo esc_textarea( $field['value'] ); ?></textarea>
 	<?php
 	echo give_get_field_description( $field );
 	echo '</p>';
@@ -364,38 +368,46 @@ function give_textarea_input( $field ) {
  * Output a wysiwyg.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of WordPress editor field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field         {
+ *                              Optional. Array of WordPress editor field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
 function give_wysiwyg( $field ) {
 	global $thepostid, $post;
 
-	$thepostid                = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['style']           = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class']   = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']           = give_get_field_value( $field, $thepostid );
+	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$default_content        = isset( $value['default'] ) ? $value['default'] : '';
+	$field['value']         = ! empty( give_get_field_value( $field, $thepostid ) ) ? give_get_field_value( $field, $thepostid ) : $default_content;
+	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+
 	$field['unique_field_id'] = give_get_field_name( $field );
 	$editor_attributes        = array(
 		'textarea_name' => isset( $field['repeatable_field_id'] ) ? $field['repeatable_field_id'] : $field['id'],
 		'textarea_rows' => '10',
 		'editor_css'    => esc_attr( $field['style'] ),
-		'editor_class'  => $field['attributes']['class']
+		'editor_class'  => $field['attributes']['class'],
 	);
-	$data_wp_editor           = ' data-wp-editor="'. base64_encode( json_encode( array( $field['value'], $field['unique_field_id'],$editor_attributes ) ) ) .'"';
+	$data_wp_editor           = ' data-wp-editor="' . base64_encode( json_encode( array(
+			$field['value'],
+			$field['unique_field_id'],
+			$editor_attributes,
+	) ) ) . '"';
 	$data_wp_editor           = isset( $field['repeatable_field_id'] ) ? $data_wp_editor : '';
 
-	echo '<div class="give-field-wrap ' . $field['unique_field_id'] . '_field ' . esc_attr( $field['wrapper_class'] ) . '"'.$data_wp_editor.'><label for="' . $field['unique_field_id'] . '">' . wp_kses_post( $field['name'] ) . '</label>';
+	echo '<div class="give-field-wrap ' . $field['unique_field_id'] . '_field ' . esc_attr( $field['wrapper_class'] ) . '"' . $data_wp_editor . '><label for="' . $field['unique_field_id'] . '">' . wp_kses_post( $field['name'] ) . '</label>';
 
 	wp_editor(
 		$field['value'],
@@ -411,18 +423,20 @@ function give_wysiwyg( $field ) {
  * Output a checkbox input box.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of checkbox field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $cbvalue         Checkbox value. Default 'on'.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field         {
+ *                              Optional. Array of checkbox field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $cbvalue       Checkbox value. Default 'on'.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
@@ -437,16 +451,16 @@ function give_checkbox( $field ) {
 	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
-		<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
-		<input
+	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
+	<input
 			type="checkbox"
 			style="<?php echo esc_attr( $field['style'] ); ?>"
 			name="<?php echo give_get_field_name( $field ); ?>"
 			id="<?php echo esc_attr( $field['id'] ); ?>"
 			value="<?php echo esc_attr( $field['cbvalue'] ); ?>"
-			<?php echo checked( $field['value'], $field['cbvalue'], false ); ?>
-			<?php echo give_get_custom_attributes( $field ); ?>
-		/>
+		<?php echo checked( $field['value'], $field['cbvalue'], false ); ?>
+		<?php echo give_get_custom_attributes( $field ); ?>
+	/>
 	<?php
 	echo give_get_field_description( $field );
 	echo '</p>';
@@ -456,18 +470,20 @@ function give_checkbox( $field ) {
  * Output a select input box.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of select field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
- *     @type array              $options         List of options. Default array().
+ * @param  array $field         {
+ *                              Optional. Array of select field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
+ * @type array   $options       List of options. Default array().
  *                                               for example: 'options' => array( '' => 'None', 'yes' => 'Yes' )
  * }
  * @return void
@@ -482,13 +498,13 @@ function give_select( $field ) {
 	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
-		<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
-		<select
-			id="<?php echo esc_attr( $field['id'] ); ?>"
-			name="<?php echo give_get_field_name( $field ); ?>"
-			style="<?php echo esc_attr( $field['style'] ) ?>"
-			<?php echo give_get_custom_attributes( $field ); ?>
-		>
+	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
+	<select
+	id="<?php echo esc_attr( $field['id'] ); ?>"
+	name="<?php echo give_get_field_name( $field ); ?>"
+	style="<?php echo esc_attr( $field['style'] ) ?>"
+	<?php echo give_get_custom_attributes( $field ); ?>
+	>
 	<?php
 	foreach ( $field['options'] as $key => $value ) {
 		echo '<option value="' . esc_attr( $key ) . '" ' . selected( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
@@ -502,19 +518,22 @@ function give_select( $field ) {
  * Output a radio input box.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of radio field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
- *     @type array              $options         List of options. Default array().
- *                                               for example: 'options' => array( 'enable' => 'Enable', 'disable' => 'Disable' )
+ * @param  array $field         {
+ *                              Optional. Array of radio field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
+ * @type array   $options       List of options. Default array().
+ *                                               for example: 'options' => array( 'enable' => 'Enable', 'disable' =>
+ *                                               'Disable' )
  * }
  * @return void
  */
@@ -537,7 +556,7 @@ function give_radio( $field ) {
 				type="radio"
 				style="' . esc_attr( $field['style'] ) . '"
 				' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . ' '
-				. give_get_custom_attributes( $field ) . '
+		     . give_get_custom_attributes( $field ) . '
 				/> ' . esc_html( $value ) . '</label>
 		</li>';
 	}
@@ -551,17 +570,19 @@ function give_radio( $field ) {
  * Output a colorpicker.
  *
  * @since  1.8
- * @param  array $field {
- *     Optional. Array of colorpicker field arguments.
  *
- *     @type string             $id              Field ID. Default ''.
- *     @type string             $style           CSS style for input field. Default ''.
- *     @type string             $wrapper_class   CSS class to use for wrapper of input field. Default ''.
- *     @type string             $value           Value of input field. Default ''.
- *     @type string             $name            Name of input field. Default ''.
- *     @type string             $description     Description of input field. Default ''.
- *     @type array              $attributes      List of attributes of input field. Default array().
- *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
+ * @param  array $field         {
+ *                              Optional. Array of colorpicker field arguments.
+ *
+ * @type string  $id            Field ID. Default ''.
+ * @type string  $style         CSS style for input field. Default ''.
+ * @type string  $wrapper_class CSS class to use for wrapper of input field. Default ''.
+ * @type string  $value         Value of input field. Default ''.
+ * @type string  $name          Name of input field. Default ''.
+ * @type string  $description   Description of input field. Default ''.
+ * @type array   $attributes    List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
  * }
  * @return void
  */
@@ -576,14 +597,14 @@ function give_colorpicker( $field ) {
 	$field['type']          = 'text';
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
-		<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
-		<input
+	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
+	<input
 			type="<?php echo esc_attr( $field['type'] ); ?>"
 			style="<?php echo esc_attr( $field['style'] ); ?>"
 			name="<?php echo give_get_field_name( $field ); ?>"
 			id="' . esc_attr( $field['id'] ) . '" value="<?php echo esc_attr( $field['value'] ); ?>"
-			<?php echo give_get_custom_attributes( $field ); ?>
-		/>
+		<?php echo give_get_custom_attributes( $field ); ?>
+	/>
 	<?php
 	echo give_get_field_description( $field );
 	echo '</p>';
@@ -596,33 +617,33 @@ function give_colorpicker( $field ) {
  * @since  1.8
  *
  * @param array $field
- *
  */
 function give_media( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = give_get_field_value( $field, $thepostid );
-	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-	$field['type']          = 'text';
+	$thepostid                    = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['style']               = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class']       = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+	$field['value']               = give_get_field_value( $field, $thepostid );
+	$field['name']                = isset( $field['name'] ) ? $field['name'] : $field['id'];
+	$field['type']                = 'text';
 	$field['attributes']['class'] = "{$field['attributes']['class']} give-text-medium";
 
 	// Allow developer to save attachment ID or attachment url as metadata.
-	$field['fvalue']        = isset( $field['fvalue'] ) ? $field['fvalue'] : 'url';
+	$field['fvalue'] = isset( $field['fvalue'] ) ? $field['fvalue'] : 'url';
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
 		<label for="<?php echo give_get_field_name( $field ) ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
 		<input
-			name="<?php echo give_get_field_name( $field ); ?>"
-			id="<?php echo esc_attr( $field['id'] ); ?>"
-			type="text"
-			value="<?php echo $field['value']; ?>"
-			style="<?php echo esc_attr( $field['style'] ); ?>"
-			data-fvalue="<?php echo $field['fvalue']; ?>"
+				name="<?php echo give_get_field_name( $field ); ?>"
+				id="<?php echo esc_attr( $field['id'] ); ?>"
+				type="text"
+				value="<?php echo $field['value']; ?>"
+				style="<?php echo esc_attr( $field['style'] ); ?>"
+				data-fvalue="<?php echo $field['fvalue']; ?>"
 			<?php echo give_get_custom_attributes( $field ); ?>
-		/>&nbsp;&nbsp;&nbsp;&nbsp;<input class="give-media-upload button" type="button" value="<?php echo esc_html__( 'Add or Upload File', 'give' ); ?>">
+		/>&nbsp;&nbsp;&nbsp;&nbsp;<input class="give-media-upload button" type="button"
+										 value="<?php echo esc_html__( 'Add or Upload File', 'give' ); ?>">
 		<?php echo give_get_field_description( $field ); ?>
 	</p>
 	<?php
@@ -645,13 +666,13 @@ function give_default_gateway( $field ) {
 	$field['options'] = array();
 
 	// Set field option value.
-	if( ! empty( $gateways ) ) {
+	if ( ! empty( $gateways ) ) {
 		foreach ( $gateways as $key => $option ) {
 			$field['options'][ $key ] = $option['admin_label'];
 		}
 	}
 
-	//Add a field to the Give Form admin single post view of this field
+	// Add a field to the Give Form admin single post view of this field
 	if ( is_object( $post ) && 'give_forms' === $post->post_type ) {
 		$field['options'] = array_merge( array( 'global' => esc_html__( 'Global Default', 'give' ) ), $field['options'] );
 	}
@@ -661,30 +682,32 @@ function give_default_gateway( $field ) {
 }
 
 /**
-  * Output the documentation link.
-  *
-  * @since  1.8
-  * @param  array $field {
-  *     Optional. Array of customizable link attributes.
-  *
-  *     @type string             $name            Name of input field. Default ''.
-  *     @type string             $type            Type of input field. Default 'text'.
-  *     @type string             $url             Value to be passed as a link. Default 'https://givewp.com/documentation'.
-  *     @type string             $title           Value to be passed as text of link. Default 'Documentation'.
-  *     @type array              $attributes      List of attributes of input field. Default array().
-  *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class' => '****' )
-  * }
-  * @return void
-*/
+ * Output the documentation link.
+ *
+ * @since  1.8
+ *
+ * @param  array $field      {
+ *                           Optional. Array of customizable link attributes.
+ *
+ * @type string  $name       Name of input field. Default ''.
+ * @type string  $type       Type of input field. Default 'text'.
+ * @type string  $url        Value to be passed as a link. Default 'https://givewp.com/documentation'.
+ * @type string  $title      Value to be passed as text of link. Default 'Documentation'.
+ * @type array   $attributes List of attributes of input field. Default array().
+ *                                               for example: 'attributes' => array( 'placeholder' => '*****', 'class'
+ *                                               => '****' )
+ * }
+ * @return void
+ */
 
-function give_docs_link($field) {
-	$field['url']   = isset($field['url']) ? $field['url'] : 'https://givewp.com/documentation';
-	$field['title'] = isset($field['title']) ? $field['title'] : 'Documentation';
+function give_docs_link( $field ) {
+	$field['url']   = isset( $field['url'] ) ? $field['url'] : 'https://givewp.com/documentation';
+	$field['title'] = isset( $field['title'] ) ? $field['title'] : 'Documentation';
 
-	echo '<p class="give-docs-link"><a href="' . esc_url($field['url'])
-		. '" target="_blank">'
-		. sprintf(esc_html__('Need Help? See docs on "%s"'), $field['title'])
-		. '<span class="dashicons dashicons-editor-help"></span></a></p>';
+	echo '<p class="give-docs-link"><a href="' . esc_url( $field['url'] )
+	     . '" target="_blank">'
+	     . sprintf( esc_html__( 'Need Help? See docs on "%s"' ), $field['title'] )
+	     . '<span class="dashicons dashicons-editor-help"></span></a></p>';
 }
 
 /**
@@ -716,7 +739,6 @@ function give_get_field_value( $field, $postid ) {
 	 */
 	$field_value = apply_filters( "{$field['id']}_field_value", $field_value, $field, $postid );
 
-
 	// Set default value if no any data saved to db.
 	if ( ! $field_value && isset( $field['default'] ) ) {
 		$field_value = $field['default'];
@@ -730,6 +752,7 @@ function give_get_field_value( $field, $postid ) {
  * Get field description html.
  *
  * @since 1.8
+ *
  * @param $field
  *
  * @return string
@@ -748,6 +771,7 @@ function give_get_field_description( $field ) {
  * Get field custom attributes as string.
  *
  * @since 1.8
+ *
  * @param $field
  *
  * @return string
@@ -831,7 +855,6 @@ function give_get_repeater_field_id( $field, $fields, $default = false ) {
 	 */
 	$field_id = apply_filters( "give_get_repeater_field_{$field['id']}_id", $field_id, $field, $fields, $default );
 
-
 	/**
 	 * Filter the repeater field id
 	 *
@@ -872,6 +895,7 @@ function give_get_field_name( $field ) {
 /**
  * Output repeater field or multi donation type form on donation from edit screen.
  * Note: internal use only.
+ *
  * @TODO   : Add support for wysiwyg type field.
  *
  * @since  1.8
@@ -889,9 +913,10 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 	}
 
 	$group_numbering = isset( $fields['options']['group_numbering'] ) ? (int) $fields['options']['group_numbering'] : 0;
-	$close_tabs      = isset( $fields['options']['close_tabs'] )      ? (int) $fields['options']['close_tabs']      : 0;
+	$close_tabs      = isset( $fields['options']['close_tabs'] ) ? (int) $fields['options']['close_tabs'] : 0;
 	?>
-	<div class="give-repeatable-field-section" id="<?php echo "{$fields['id']}_field"; ?>" data-group-numbering="<?php echo $group_numbering; ?>" data-close-tabs="<?php echo $close_tabs; ?>">
+	<div class="give-repeatable-field-section" id="<?php echo "{$fields['id']}_field"; ?>"
+		 data-group-numbering="<?php echo $group_numbering; ?>" data-close-tabs="<?php echo $close_tabs; ?>">
 		<?php if ( ! empty( $fields['name'] ) ) : ?>
 			<p class="give-repeater-field-name"><?php echo $fields['name']; ?></p>
 		<?php endif; ?>
@@ -918,73 +943,39 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 			}
 			?>
 			<tbody class="container"<?php echo " data-rf-row-count=\"{$fields_count}\""; ?>>
-				<!--Repeater field group template-->
-				<tr class="give-template give-row">
-					<td class="give-repeater-field-wrap give-column" colspan="2">
-						<div class="give-row-head give-move">
-							<button type="button" class="handlediv button-link"><span class="toggle-indicator"></span>
-							</button>
-							<span class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-</span>
-							<h2>
-								<span data-header-title="<?php echo $header_title; ?>"><?php echo $header_title; ?></span>
-							</h2>
-						</div>
-						<div class="give-row-body">
-							<?php foreach ( $fields['fields'] as $field ) : ?>
-								<?php if ( ! give_is_field_callback_exist( $field ) ) {
-									continue;
-								} ?>
-								<?php
-								$field['repeat']              = true;
-								$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields );
-								$field['id']                  = str_replace( array( '[', ']' ), array(
-									'_',
-									'',
-								), $field['repeatable_field_id'] );
-								?>
-								<?php give_render_field( $field ); ?>
-							<?php endforeach; ?>
-						</div>
-					</td>
-				</tr>
+			<!--Repeater field group template-->
+			<tr class="give-template give-row">
+				<td class="give-repeater-field-wrap give-column" colspan="2">
+					<div class="give-row-head give-move">
+						<button type="button" class="handlediv button-link"><span class="toggle-indicator"></span>
+						</button>
+						<span class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-</span>
+						<h2>
+							<span data-header-title="<?php echo $header_title; ?>"><?php echo $header_title; ?></span>
+						</h2>
+					</div>
+					<div class="give-row-body">
+						<?php foreach ( $fields['fields'] as $field ) : ?>
+							<?php if ( ! give_is_field_callback_exist( $field ) ) {
+								continue;
+} ?>
+							<?php
+							$field['repeat']              = true;
+							$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields );
+							$field['id']                  = str_replace( array( '[', ']' ), array(
+								'_',
+								'',
+							), $field['repeatable_field_id'] );
+							?>
+							<?php give_render_field( $field ); ?>
+						<?php endforeach; ?>
+					</div>
+				</td>
+			</tr>
 
-				<?php if ( ! empty( $repeater_field_values ) ) : ?>
-					<!--Stored repeater field group-->
-					<?php foreach ( $repeater_field_values as $index => $field_group ) : ?>
-						<tr class="give-row">
-							<td class="give-repeater-field-wrap give-column" colspan="2">
-								<div class="give-row-head give-move">
-									<button type="button" class="handlediv button-link">
-										<span class="toggle-indicator"></span></button>
-									<sapn class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-
-									</sapn>
-									<h2>
-										<span data-header-title="<?php echo $header_title; ?>"><?php echo $header_title; ?></span>
-									</h2>
-								</div>
-								<div class="give-row-body">
-									<?php foreach ( $fields['fields'] as $field ) : ?>
-										<?php if ( ! give_is_field_callback_exist( $field ) ) {
-											continue;
-										} ?>
-										<?php
-										$field['repeat']              = true;
-										$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields, $index );
-										$field['attributes']['value'] = give_get_repeater_field_value( $field, $field_group, $fields );
-										$field['id']                  = str_replace( array( '[', ']' ), array(
-											'_',
-											'',
-										), $field['repeatable_field_id'] );
-										?>
-										<?php give_render_field( $field ); ?>
-									<?php endforeach; ?>
-								</div>
-							</td>
-						</tr>
-					<?php endforeach;; ?>
-
-				<?php elseif ( $add_default_donation_field ) : ?>
-					<!--Default repeater field group-->
+			<?php if ( ! empty( $repeater_field_values ) ) : ?>
+				<!--Stored repeater field group-->
+				<?php foreach ( $repeater_field_values as $index => $field_group ) : ?>
 					<tr class="give-row">
 						<td class="give-repeater-field-wrap give-column" colspan="2">
 							<div class="give-row-head give-move">
@@ -997,38 +988,73 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 								</h2>
 							</div>
 							<div class="give-row-body">
-								<?php
-								foreach ( $fields['fields'] as $field ) :
-									if ( ! give_is_field_callback_exist( $field ) ) {
+								<?php foreach ( $fields['fields'] as $field ) : ?>
+									<?php if ( ! give_is_field_callback_exist( $field ) ) {
 										continue;
-									}
-
+} ?>
+									<?php
 									$field['repeat']              = true;
-									$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields, 0 );
-									$field['attributes']['value'] = apply_filters( "give_default_field_group_field_{$field['id']}_value", ( ! empty( $field['default'] ) ? $field['default'] : '' ), $field );
+									$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields, $index );
+									$field['attributes']['value'] = give_get_repeater_field_value( $field, $field_group, $fields );
 									$field['id']                  = str_replace( array( '[', ']' ), array(
 										'_',
 										'',
 									), $field['repeatable_field_id'] );
-									give_render_field( $field );
-								endforeach;
-								?>
+									?>
+									<?php give_render_field( $field ); ?>
+								<?php endforeach; ?>
 							</div>
 						</td>
 					</tr>
-				<?php endif; ?>
-			</tbody>
-			<tfoot>
-				<tr>
-					<?php
-					$add_row_btn_title = isset( $fields['options']['add_button'] )
-						? $add_row_btn_title = $fields['options']['add_button']
-						: esc_html__( 'Add Row', 'give' );
-					?>
-					<td colspan="2" class="give-add-repeater-field-section-row-wrap">
-						<span class="button button-primary give-add-repeater-field-section-row"><?php echo $add_row_btn_title; ?></span>
+				<?php endforeach;
+; ?>
+
+			<?php elseif ( $add_default_donation_field ) : ?>
+				<!--Default repeater field group-->
+				<tr class="give-row">
+					<td class="give-repeater-field-wrap give-column" colspan="2">
+						<div class="give-row-head give-move">
+							<button type="button" class="handlediv button-link">
+								<span class="toggle-indicator"></span></button>
+							<sapn class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-
+							</sapn>
+							<h2>
+								<span data-header-title="<?php echo $header_title; ?>"><?php echo $header_title; ?></span>
+							</h2>
+						</div>
+						<div class="give-row-body">
+							<?php
+							foreach ( $fields['fields'] as $field ) :
+								if ( ! give_is_field_callback_exist( $field ) ) {
+									continue;
+								}
+
+								$field['repeat']              = true;
+								$field['repeatable_field_id'] = give_get_repeater_field_id( $field, $fields, 0 );
+								$field['attributes']['value'] = apply_filters( "give_default_field_group_field_{$field['id']}_value", ( ! empty( $field['default'] ) ? $field['default'] : '' ), $field );
+								$field['id']                  = str_replace( array( '[', ']' ), array(
+									'_',
+									'',
+								), $field['repeatable_field_id'] );
+								give_render_field( $field );
+							endforeach;
+							?>
+						</div>
 					</td>
 				</tr>
+			<?php endif; ?>
+			</tbody>
+			<tfoot>
+			<tr>
+				<?php
+				$add_row_btn_title = isset( $fields['options']['add_button'] )
+					? $add_row_btn_title = $fields['options']['add_button']
+					: esc_html__( 'Add Row', 'give' );
+				?>
+				<td colspan="2" class="give-add-repeater-field-section-row-wrap">
+					<span class="button button-primary give-add-repeater-field-section-row"><?php echo $add_row_btn_title; ?></span>
+				</td>
+			</tr>
 			</tfoot>
 		</table>
 	</div>
@@ -1085,7 +1111,7 @@ function give_get_current_setting_section() {
 	// Get current section.
 	$current_section = empty( $_REQUEST['section'] ) ? $default_current_section : urldecode( $_REQUEST['section'] );
 
-	//Output.
+	// Output.
 	return $current_section;
 }
 
@@ -1099,14 +1125,15 @@ function give_get_current_setting_page() {
 	// Get current page.
 	$setting_page = ! empty( $_GET['page'] ) ? urldecode( $_GET['page'] ) : '';
 
-	//Output.
+	// Output.
 	return $setting_page;
 }
 
 /**
  * Set value for Form content --> Display content field setting.
  *
- * Backward compatibility:  set value by _give_content_option form meta field value if _give_display_content is not set yet.
+ * Backward compatibility:  set value by _give_content_option form meta field value if _give_display_content is not set
+ * yet.
  *
  * @since  1.8
  *
@@ -1136,7 +1163,8 @@ add_filter( '_give_display_content_field_value', '_give_display_content_field_va
 /**
  * Set value for Form content --> Content placement field setting.
  *
- * Backward compatibility:  set value by _give_content_option form meta field value if _give_content_placement is not set yet.
+ * Backward compatibility:  set value by _give_content_option form meta field value if _give_content_placement is not
+ * set yet.
  *
  * @since  1.8
  *
@@ -1191,7 +1219,8 @@ add_filter( '_give_terms_option_field_value', '_give_terms_option_field_value', 
 /**
  * Set value for Form Display --> Offline Donation --> Billing Fields.
  *
- * Backward compatibility:  set value by _give_offline_donation_enable_billing_fields_single form meta field value if it's value is on.
+ * Backward compatibility:  set value by _give_offline_donation_enable_billing_fields_single form meta field value if
+ * it's value is on.
  *
  * @since  1.8
  *
@@ -1268,7 +1297,8 @@ add_filter( '_give_goal_option_field_value', '_give_goal_option_field_value', 10
 /**
  * Set value for Donation Goal --> close Form.
  *
- * Backward compatibility:  set value by _give_close_form_when_goal_achieved form meta field value if it's value is yes or no.
+ * Backward compatibility:  set value by _give_close_form_when_goal_achieved form meta field value if it's value is yes
+ * or no.
  *
  * @since  1.8
  *
@@ -1319,7 +1349,8 @@ add_filter( '_give_logged_in_only_field_value', '_give_logged_in_only_value', 10
 /**
  * Set value for Offline Donations --> Offline Donations.
  *
- * Backward compatibility:  set value by _give_customize_offline_donations form meta field value if it's value is yes or no.
+ * Backward compatibility:  set value by _give_customize_offline_donations form meta field value if it's value is yes
+ * or no.
  *
  * @since  1.8
  *
@@ -1356,7 +1387,7 @@ add_filter( '_give_customize_offline_donations_field_value', '_give_customize_of
  */
 function _give_set_multi_level_repeater_field_id( $field_id, $field, $fields, $default ) {
 	$row_placeholder = false !== $default ? $default : '{{row-count-placeholder}}';
-	$field_id = "{$fields['id']}[{$row_placeholder}][{$field['id']}][level_id]";
+	$field_id        = "{$fields['id']}[{$row_placeholder}][{$field['id']}][level_id]";
 
 	return $field_id;
 }
@@ -1424,10 +1455,11 @@ add_filter( 'give_default_field_group_field__give_default_value', '_give_set_fie
  * @return string
  */
 function give_repeater_field_set_editor_id( $field_name, $field ) {
-	if ( isset( $field['repeatable_field_id'] ) &&  'wysiwyg' == $field['type'] ) {
+	if ( isset( $field['repeatable_field_id'] ) && 'wysiwyg' == $field['type'] ) {
 		$field_name = '_give_repeater_' . uniqid() . '_wysiwyg';
 	}
 
 	return $field_name;
 }
+
 add_filter( 'give_get_field_name', 'give_repeater_field_set_editor_id', 10, 2 );

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -388,8 +388,7 @@ function give_wysiwyg( $field ) {
 	global $thepostid, $post;
 
 	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$default_content        = isset( $value['default'] ) ? $value['default'] : '';
-	$field['value']         = ! empty( give_get_field_value( $field, $thepostid ) ) ? give_get_field_value( $field, $thepostid ) : $default_content;
+	$field['value']         = give_get_field_value( $field, $thepostid );
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -81,16 +81,16 @@ function give_get_donation_form( $args = array() ) {
 	do_action( 'give_pre_form_output', $form->ID, $args );
 
 	?>
-	<div id="give-form-<?php echo $form->ID; ?>-wrap" class="<?php echo $form_wrap_classes; ?>">
+    <div id="give-form-<?php echo $form->ID; ?>-wrap" class="<?php echo $form_wrap_classes; ?>">
 
 		<?php if ( $form->is_close_donation_form() ) {
 
-			//Get Goal thank you message.
-			$display_thankyou_message = get_post_meta( $form->ID, '_give_form_goal_achieved_message', true );
-			$display_thankyou_message = ! empty( $display_thankyou_message ) ? $display_thankyou_message : esc_html__( 'Thank you to all our donors, we have met our fundraising goal.', 'give' );
+			// Get Goal thank you message.
+			$goal_achieved_message = get_post_meta( $form->ID, '_give_form_goal_achieved_message', true );
+			$goal_achieved_message = ! empty( $goal_achieved_message ) ? apply_filters( 'the_content', $goal_achieved_message ) : '';
 
-			//Print thank you message.
-			echo apply_filters( 'give_goal_closed_output', give_output_error( $display_thankyou_message, false, 'success' ), $form->ID );
+			// Print thank you message.
+			echo apply_filters( 'give_goal_closed_output', $goal_achieved_message, $form->ID );
 
 		} else {
 			/**
@@ -117,29 +117,29 @@ function give_get_donation_form( $args = array() ) {
 			do_action( 'give_pre_form', $form->ID, $args );
 			?>
 
-			<form id="give-form-<?php echo $form_id; ?>" class="<?php echo $form_classes; ?>"
-			      action="<?php echo esc_url_raw( $form_action ); ?>" method="post">
-				<input type="hidden" name="give-form-id" value="<?php echo $form->ID; ?>"/>
-				<input type="hidden" name="give-form-title" value="<?php echo htmlentities( $form->post_title ); ?>"/>
-				<input type="hidden" name="give-current-url"
-				       value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
-				<input type="hidden" name="give-form-url"
-				       value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
-				<input type="hidden" name="give-form-minimum"
-				       value="<?php echo give_format_amount( give_get_form_minimum_price( $form->ID ) ); ?>"/>
+            <form id="give-form-<?php echo $form_id; ?>" class="<?php echo $form_classes; ?>"
+                  action="<?php echo esc_url_raw( $form_action ); ?>" method="post">
+                <input type="hidden" name="give-form-id" value="<?php echo $form->ID; ?>"/>
+                <input type="hidden" name="give-form-title" value="<?php echo htmlentities( $form->post_title ); ?>"/>
+                <input type="hidden" name="give-current-url"
+                       value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
+                <input type="hidden" name="give-form-url"
+                       value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
+                <input type="hidden" name="give-form-minimum"
+                       value="<?php echo give_format_amount( give_get_form_minimum_price( $form->ID ) ); ?>"/>
 
-				<!-- The following field is for robots only, invisible to humans: -->
-				<span class="give-hidden" style="display: none !important;">
+                <!-- The following field is for robots only, invisible to humans: -->
+                <span class="give-hidden" style="display: none !important;">
 					<label for="give-form-honeypot-<?php echo $form_id; ?>"></label>
 					<input id="give-form-honeypot-<?php echo $form_id; ?>" type="text" name="give-honeypot"
-					       class="give-honeypot give-hidden"/>
+                           class="give-honeypot give-hidden"/>
 				</span>
 
 				<?php
 
-				//Price ID hidden field for variable (mult-level) donation forms.
+				// Price ID hidden field for variable (mult-level) donation forms.
 				if ( give_has_variable_prices( $form_id ) ) {
-					//get default selected price ID.
+					// Get default selected price ID.
 					$prices   = apply_filters( 'give_form_variable_prices', give_get_variable_prices( $form_id ), $form_id );
 					$price_id = 0;
 					//loop through prices.
@@ -149,7 +149,7 @@ function give_get_donation_form( $args = array() ) {
 						};
 					}
 					?>
-					<input type="hidden" name="give-price-id" value="<?php echo $price_id; ?>"/>
+                    <input type="hidden" name="give-price-id" value="<?php echo $price_id; ?>"/>
 				<?php }
 
 				/**
@@ -183,7 +183,7 @@ function give_get_donation_form( $args = array() ) {
 				do_action( 'give_checkout_form_bottom', $form->ID, $args );
 
 				?>
-			</form>
+            </form>
 
 			<?php
 			/**
@@ -199,7 +199,7 @@ function give_get_donation_form( $args = array() ) {
 		}
 		?>
 
-	</div><!--end #give-form-<?php echo absint( $form->ID ); ?>-->
+    </div><!--end #give-form-<?php echo absint( $form->ID ); ?>-->
 	<?php
 
 	/**
@@ -332,7 +332,7 @@ function give_show_register_login_fields( $form_id ) {
 
 	if ( ( $show_register_form === 'registration' || ( $show_register_form === 'both' && ! isset( $_GET['login'] ) ) ) && ! is_user_logged_in() ) :
 		?>
-		<div id="give-checkout-login-register-<?php echo $form_id; ?>">
+        <div id="give-checkout-login-register-<?php echo $form_id; ?>">
 			<?php
 			/**
 			 * Fire if user registration form render.
@@ -341,11 +341,11 @@ function give_show_register_login_fields( $form_id ) {
 			 */
 			do_action( 'give_donation_form_register_fields', $form_id );
 			?>
-		</div>
+        </div>
 		<?php
 	elseif ( ( $show_register_form === 'login' || ( $show_register_form === 'both' && isset( $_GET['login'] ) ) ) && ! is_user_logged_in() ) :
 		?>
-		<div id="give-checkout-login-register-<?php echo $form_id; ?>">
+        <div id="give-checkout-login-register-<?php echo $form_id; ?>">
 			<?php
 			/**
 			 * Fire if user login form render.
@@ -354,7 +354,7 @@ function give_show_register_login_fields( $form_id ) {
 			 */
 			do_action( 'give_donation_form_login_fields', $form_id );
 			?>
-		</div>
+        </div>
 		<?php
 	endif;
 
@@ -373,7 +373,8 @@ add_action( 'give_donation_form_register_login_fields', 'give_show_register_logi
 /**
  * Donation Amount Field.
  *
- * Outputs the donation amount field that appears at the top of the donation forms. If the user has custom amount enabled the field will output as a customizable input.
+ * Outputs the donation amount field that appears at the top of the donation forms. If the user has custom amount
+ * enabled the field will output as a customizable input.
  *
  * @since  1.0
  *
@@ -406,35 +407,35 @@ function give_output_donation_amount_top( $form_id = 0, $args = array() ) {
 	//Set Price, No Custom Amount Allowed means hidden price field
 	if ( ! give_is_setting_enabled( $allow_custom_amount ) ) {
 		?>
-		<label class="give-hidden" for="give-amount-hidden"><?php esc_html_e( 'Donation Amount:', 'give' ); ?></label>
-		<input id="give-amount" class="give-amount-hidden" type="hidden" name="give-amount"
-		       value="<?php echo $default_amount; ?>" required aria-required="true"/>
-		<div class="set-price give-donation-amount form-row-wide">
+        <label class="give-hidden" for="give-amount-hidden"><?php esc_html_e( 'Donation Amount:', 'give' ); ?></label>
+        <input id="give-amount" class="give-amount-hidden" type="hidden" name="give-amount"
+               value="<?php echo $default_amount; ?>" required aria-required="true"/>
+        <div class="set-price give-donation-amount form-row-wide">
 			<?php if ( $currency_position == 'before' ) {
 				echo $currency_output;
 			} ?>
-			<span id="give-amount-text" class="give-text-input give-amount-top"><?php echo $default_amount; ?></span>
+            <span id="give-amount-text" class="give-text-input give-amount-top"><?php echo $default_amount; ?></span>
 			<?php if ( $currency_position == 'after' ) {
 				echo $currency_output;
 			} ?>
-		</div>
+        </div>
 		<?php
 	} else {
 		//Custom Amount Allowed.
 		?>
-		<div class="give-total-wrap">
-			<div class="give-donation-amount form-row-wide">
+        <div class="give-total-wrap">
+            <div class="give-donation-amount form-row-wide">
 				<?php if ( $currency_position == 'before' ) {
 					echo $currency_output;
 				} ?>
-				<label class="give-hidden" for="give-amount"><?php esc_html_e( 'Donation Amount:', 'give' ); ?></label>
-				<input class="give-text-input give-amount-top" id="give-amount" name="give-amount" type="tel"
-				       placeholder="" value="<?php echo $default_amount; ?>" autocomplete="off">
+                <label class="give-hidden" for="give-amount"><?php esc_html_e( 'Donation Amount:', 'give' ); ?></label>
+                <input class="give-text-input give-amount-top" id="give-amount" name="give-amount" type="tel"
+                       placeholder="" value="<?php echo $default_amount; ?>" autocomplete="off">
 				<?php if ( $currency_position == 'after' ) {
 					echo $currency_output;
 				} ?>
-			</div>
-		</div>
+            </div>
+        </div>
 	<?php }
 
 	/**
@@ -448,8 +449,8 @@ function give_output_donation_amount_top( $form_id = 0, $args = array() ) {
 	do_action( 'give_after_donation_amount', $form_id, $args );
 
 	//Custom Amount Text
-	if ( ! $variable_pricing &&  give_is_setting_enabled( $allow_custom_amount ) && ! empty( $custom_amount_text ) ) { ?>
-		<p class="give-custom-amount-text"><?php echo $custom_amount_text; ?></p>
+	if ( ! $variable_pricing && give_is_setting_enabled( $allow_custom_amount ) && ! empty( $custom_amount_text ) ) { ?>
+        <p class="give-custom-amount-text"><?php echo $custom_amount_text; ?></p>
 	<?php }
 
 	//Output Variable Pricing Levels.
@@ -599,9 +600,9 @@ function give_display_checkout_button( $form_id, $args ) {
 		? $args['display_style']
 		: get_post_meta( $form_id, '_give_payment_display', true );
 
-	if( 'button' === $display_option ) {
+	if ( 'button' === $display_option ) {
 		$display_option = 'modal';
-	}elseif ( $display_option === 'onpage' ) {
+	} elseif ( $display_option === 'onpage' ) {
 		return '';
 	}
 
@@ -635,48 +636,48 @@ function give_user_info_fields( $form_id ) {
 	 */
 	do_action( 'give_donation_form_before_personal_info', $form_id );
 	?>
-	<fieldset id="give_checkout_user_info">
-		<legend><?php echo apply_filters( 'give_checkout_personal_info_text', esc_html__( 'Personal Info', 'give' ) ); ?></legend>
-		<p id="give-first-name-wrap" class="form-row form-row-first form-row-responsive">
-			<label class="give-label" for="give-first">
+    <fieldset id="give_checkout_user_info">
+        <legend><?php echo apply_filters( 'give_checkout_personal_info_text', esc_html__( 'Personal Info', 'give' ) ); ?></legend>
+        <p id="give-first-name-wrap" class="form-row form-row-first form-row-responsive">
+            <label class="give-label" for="give-first">
 				<?php esc_html_e( 'First Name', 'give' ); ?>
 				<?php if ( give_field_is_required( 'give_first', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'We will use this to personalize your account experience.', 'give' ); ?>"></span>
-			</label>
-			<input
-				class="give-input required"
-				type="text"
-				name="give_first"
-				placeholder="<?php esc_attr_e( 'First Name', 'give' ); ?>"
-				id="give-first"
-				value="<?php echo isset( $give_user_info['give_first'] ) ? $give_user_info['give_first'] : ''; ?>"
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'We will use this to personalize your account experience.', 'give' ); ?>"></span>
+            </label>
+            <input
+                    class="give-input required"
+                    type="text"
+                    name="give_first"
+                    placeholder="<?php esc_attr_e( 'First Name', 'give' ); ?>"
+                    id="give-first"
+                    value="<?php echo isset( $give_user_info['give_first'] ) ? $give_user_info['give_first'] : ''; ?>"
 				<?php echo( give_field_is_required( 'give_first', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
-		<p id="give-last-name-wrap" class="form-row form-row-last form-row-responsive">
-			<label class="give-label" for="give-last">
+        <p id="give-last-name-wrap" class="form-row form-row-last form-row-responsive">
+            <label class="give-label" for="give-last">
 				<?php esc_html_e( 'Last Name', 'give' ); ?>
 				<?php if ( give_field_is_required( 'give_last', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'We will use this as well to personalize your account experience.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'We will use this as well to personalize your account experience.', 'give' ); ?>"></span>
+            </label>
 
-			<input
-				class="give-input<?php echo( give_field_is_required( 'give_last', $form_id ) ? ' required' : '' ); ?>"
-				type="text"
-				name="give_last"
-				id="give-last"
-				placeholder="<?php esc_attr_e( 'Last Name', 'give' ); ?>"
-				value="<?php echo isset( $give_user_info['give_last'] ) ? $give_user_info['give_last'] : ''; ?>"
+            <input
+                    class="give-input<?php echo( give_field_is_required( 'give_last', $form_id ) ? ' required' : '' ); ?>"
+                    type="text"
+                    name="give_last"
+                    id="give-last"
+                    placeholder="<?php esc_attr_e( 'Last Name', 'give' ); ?>"
+                    value="<?php echo isset( $give_user_info['give_last'] ) ? $give_user_info['give_last'] : ''; ?>"
 				<?php echo( give_field_is_required( 'give_last', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
 		<?php
 		/**
@@ -686,27 +687,27 @@ function give_user_info_fields( $form_id ) {
 		 */
 		do_action( 'give_donation_form_before_email', $form_id );
 		?>
-		<p id="give-email-wrap" class="form-row form-row-wide">
-			<label class="give-label" for="give-email">
+        <p id="give-email-wrap" class="form-row form-row-wide">
+            <label class="give-label" for="give-email">
 				<?php esc_html_e( 'Email Address', 'give' ); ?>
 				<?php if ( give_field_is_required( 'give_email', $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php } ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'We will send the donation receipt to this address.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'We will send the donation receipt to this address.', 'give' ); ?>"></span>
+            </label>
 
-			<input
-				class="give-input required"
-				type="email"
-				name="give_email"
-				placeholder="<?php esc_attr_e( 'Email Address', 'give' ); ?>"
-				id="give-email"
-				value="<?php echo isset( $give_user_info['give_email'] ) ? $give_user_info['give_email'] : ''; ?>"
+            <input
+                    class="give-input required"
+                    type="email"
+                    name="give_email"
+                    placeholder="<?php esc_attr_e( 'Email Address', 'give' ); ?>"
+                    id="give-email"
+                    value="<?php echo isset( $give_user_info['give_email'] ) ? $give_user_info['give_email'] : ''; ?>"
 				<?php echo( give_field_is_required( 'give_email', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
+            />
 
-		</p>
+        </p>
 		<?php
 		/**
 		 * Fire after user email field
@@ -722,7 +723,7 @@ function give_user_info_fields( $form_id ) {
 		 */
 		do_action( 'give_donation_form_user_info', $form_id );
 		?>
-	</fieldset>
+    </fieldset>
 	<?php
 	/**
 	 * Fire after user personal information fields
@@ -757,53 +758,53 @@ function give_get_cc_form( $form_id ) {
 	 */
 	do_action( 'give_before_cc_fields', $form_id );
 	?>
-	<fieldset id="give_cc_fields-<?php echo $form_id ?>" class="give-do-validate">
-		<legend><?php echo apply_filters( 'give_credit_card_fieldset_heading', esc_html__( 'Credit Card Info', 'give' ) ); ?></legend>
+    <fieldset id="give_cc_fields-<?php echo $form_id ?>" class="give-do-validate">
+        <legend><?php echo apply_filters( 'give_credit_card_fieldset_heading', esc_html__( 'Credit Card Info', 'give' ) ); ?></legend>
 		<?php if ( is_ssl() ) : ?>
-			<div id="give_secure_site_wrapper-<?php echo $form_id ?>">
-				<span class="give-icon padlock"></span>
-				<span><?php esc_html_e( 'This is a secure SSL encrypted payment.', 'give' ); ?></span>
-			</div>
+            <div id="give_secure_site_wrapper-<?php echo $form_id ?>">
+                <span class="give-icon padlock"></span>
+                <span><?php esc_html_e( 'This is a secure SSL encrypted payment.', 'give' ); ?></span>
+            </div>
 		<?php endif; ?>
-		<p id="give-card-number-wrap-<?php echo $form_id ?>" class="form-row form-row-two-thirds form-row-responsive">
-			<label for="card_number-<?php echo $form_id ?>" class="give-label">
+        <p id="give-card-number-wrap-<?php echo $form_id ?>" class="form-row form-row-two-thirds form-row-responsive">
+            <label for="card_number-<?php echo $form_id ?>" class="give-label">
 				<?php esc_html_e( 'Card Number', 'give' ); ?>
-				<span class="give-required-indicator">*</span>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The (typically) 16 digits on the front of your credit card.', 'give' ); ?>"></span>
-				<span class="card-type"></span>
-			</label>
+                <span class="give-required-indicator">*</span>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The (typically) 16 digits on the front of your credit card.', 'give' ); ?>"></span>
+                <span class="card-type"></span>
+            </label>
 
-			<input type="tel" autocomplete="off" name="card_number" id="card_number-<?php echo $form_id ?>"
-			       class="card-number give-input required" placeholder="<?php esc_attr_e( 'Card number', 'give' ); ?>"
-			       required aria-required="true"/>
-		</p>
+            <input type="tel" autocomplete="off" name="card_number" id="card_number-<?php echo $form_id ?>"
+                   class="card-number give-input required" placeholder="<?php esc_attr_e( 'Card number', 'give' ); ?>"
+                   required aria-required="true"/>
+        </p>
 
-		<p id="give-card-cvc-wrap-<?php echo $form_id ?>" class="form-row form-row-one-third form-row-responsive">
-			<label for="card_cvc-<?php echo $form_id ?>" class="give-label">
+        <p id="give-card-cvc-wrap-<?php echo $form_id ?>" class="form-row form-row-one-third form-row-responsive">
+            <label for="card_cvc-<?php echo $form_id ?>" class="give-label">
 				<?php esc_html_e( 'CVC', 'give' ); ?>
-				<span class="give-required-indicator">*</span>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The 3 digit (back) or 4 digit (front) value on your card.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-required-indicator">*</span>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The 3 digit (back) or 4 digit (front) value on your card.', 'give' ); ?>"></span>
+            </label>
 
-			<input type="tel" size="4" autocomplete="off" name="card_cvc" id="card_cvc-<?php echo $form_id ?>"
-			       class="card-cvc give-input required" placeholder="<?php esc_attr_e( 'Security code', 'give' ); ?>"
-			       required aria-required="true"/>
-		</p>
+            <input type="tel" size="4" autocomplete="off" name="card_cvc" id="card_cvc-<?php echo $form_id ?>"
+                   class="card-cvc give-input required" placeholder="<?php esc_attr_e( 'Security code', 'give' ); ?>"
+                   required aria-required="true"/>
+        </p>
 
-		<p id="give-card-name-wrap-<?php echo $form_id ?>" class="form-row form-row-two-thirds form-row-responsive">
-			<label for="card_name-<?php echo $form_id ?>" class="give-label">
+        <p id="give-card-name-wrap-<?php echo $form_id ?>" class="form-row form-row-two-thirds form-row-responsive">
+            <label for="card_name-<?php echo $form_id ?>" class="give-label">
 				<?php esc_html_e( 'Name on the Card', 'give' ); ?>
-				<span class="give-required-indicator">*</span>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The name printed on the front of your credit card.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-required-indicator">*</span>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The name printed on the front of your credit card.', 'give' ); ?>"></span>
+            </label>
 
-			<input type="text" autocomplete="off" name="card_name" id="card_name-<?php echo $form_id ?>"
-			       class="card-name give-input required" placeholder="<?php esc_attr_e( 'Card name', 'give' ); ?>"
-			       required aria-required="true"/>
-		</p>
+            <input type="text" autocomplete="off" name="card_name" id="card_name-<?php echo $form_id ?>"
+                   class="card-name give-input required" placeholder="<?php esc_attr_e( 'Card name', 'give' ); ?>"
+                   required aria-required="true"/>
+        </p>
 		<?php
 		/**
 		 * Fires while rendering credit card info form, before expiration fields.
@@ -814,23 +815,23 @@ function give_get_cc_form( $form_id ) {
 		 */
 		do_action( 'give_before_cc_expiration' );
 		?>
-		<p class="card-expiration form-row form-row-one-third form-row-responsive">
-			<label for="card_expiry-<?php echo $form_id ?>" class="give-label">
+        <p class="card-expiration form-row form-row-one-third form-row-responsive">
+            <label for="card_expiry-<?php echo $form_id ?>" class="give-label">
 				<?php esc_html_e( 'Expiration', 'give' ); ?>
-				<span class="give-required-indicator">*</span>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The date your credit card expires, typically on the front of the card.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-required-indicator">*</span>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The date your credit card expires, typically on the front of the card.', 'give' ); ?>"></span>
+            </label>
 
-			<input type="hidden" id="card_exp_month-<?php echo $form_id ?>" name="card_exp_month"
-			       class="card-expiry-month"/>
-			<input type="hidden" id="card_exp_year-<?php echo $form_id ?>" name="card_exp_year"
-			       class="card-expiry-year"/>
+            <input type="hidden" id="card_exp_month-<?php echo $form_id ?>" name="card_exp_month"
+                   class="card-expiry-month"/>
+            <input type="hidden" id="card_exp_year-<?php echo $form_id ?>" name="card_exp_year"
+                   class="card-expiry-year"/>
 
-			<input type="tel" autocomplete="off" name="card_expiry" id="card_expiry-<?php echo $form_id ?>"
-			       class="card-expiry give-input required" placeholder="<?php esc_attr_e( 'MM / YY', 'give' ); ?>"
-			       required aria-required="true"/>
-		</p>
+            <input type="tel" autocomplete="off" name="card_expiry" id="card_expiry-<?php echo $form_id ?>"
+                   class="card-expiry give-input required" placeholder="<?php esc_attr_e( 'MM / YY', 'give' ); ?>"
+                   required aria-required="true"/>
+        </p>
 		<?php
 		/**
 		 * Fires while rendering credit card info form, after expiration fields.
@@ -841,7 +842,7 @@ function give_get_cc_form( $form_id ) {
 		 */
 		do_action( 'give_after_cc_expiration', $form_id );
 		?>
-	</fieldset>
+    </fieldset>
 	<?php
 	/**
 	 * Fires while rendering credit card info form, before the fields.
@@ -882,8 +883,8 @@ function give_default_cc_address_fields( $form_id ) {
 
 	ob_start();
 	?>
-	<fieldset id="give_cc_address" class="cc-address">
-		<legend><?php echo apply_filters( 'give_billing_details_fieldset_heading', esc_html__( 'Billing Details', 'give' ) ); ?></legend>
+    <fieldset id="give_cc_address" class="cc-address">
+        <legend><?php echo apply_filters( 'give_billing_details_fieldset_heading', esc_html__( 'Billing Details', 'give' ) ); ?></legend>
 		<?php
 		/**
 		 * Fires while rendering credit card billing form, before address fields.
@@ -894,107 +895,107 @@ function give_default_cc_address_fields( $form_id ) {
 		 */
 		do_action( 'give_cc_billing_top' );
 		?>
-		<p id="give-card-address-wrap" class="form-row form-row-wide">
-			<label for="card_address" class="give-label">
+        <p id="give-card-address-wrap" class="form-row form-row-wide">
+            <label for="card_address" class="give-label">
 				<?php esc_html_e( 'Address 1', 'give' ); ?>
 				<?php
 				if ( give_field_is_required( 'card_address', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The primary billing address for your credit card.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The primary billing address for your credit card.', 'give' ); ?>"></span>
+            </label>
 
-			<input
-				type="text"
-				id="card_address"
-				name="card_address"
-				class="card-address give-input<?php echo( give_field_is_required( 'card_address', $form_id ) ? ' required' : '' ); ?>"
-				placeholder="<?php esc_attr_e( 'Address line 1', 'give' ); ?>"
-				value="<?php echo isset( $give_user_info['card_address'] ) ? $give_user_info['card_address'] : ''; ?>"
+            <input
+                    type="text"
+                    id="card_address"
+                    name="card_address"
+                    class="card-address give-input<?php echo( give_field_is_required( 'card_address', $form_id ) ? ' required' : '' ); ?>"
+                    placeholder="<?php esc_attr_e( 'Address line 1', 'give' ); ?>"
+                    value="<?php echo isset( $give_user_info['card_address'] ) ? $give_user_info['card_address'] : ''; ?>"
 				<?php echo( give_field_is_required( 'card_address', $form_id ) ? '  required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
-		<p id="give-card-address-2-wrap" class="form-row form-row-wide">
-			<label for="card_address_2" class="give-label">
+        <p id="give-card-address-2-wrap" class="form-row form-row-wide">
+            <label for="card_address_2" class="give-label">
 				<?php esc_html_e( 'Address 2', 'give' ); ?>
 				<?php if ( give_field_is_required( 'card_address_2', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( '(optional) The suite, apt no, PO box, etc, associated with your billing address.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( '(optional) The suite, apt no, PO box, etc, associated with your billing address.', 'give' ); ?>"></span>
+            </label>
 
-			<input
-				type="text"
-				id="card_address_2"
-				name="card_address_2"
-				class="card-address-2 give-input<?php echo( give_field_is_required( 'card_address_2', $form_id ) ? ' required' : '' ); ?>"
-				placeholder="<?php esc_attr_e( 'Address line 2', 'give' ); ?>"
-				value="<?php echo isset( $give_user_info['card_address_2'] ) ? $give_user_info['card_address_2'] : ''; ?>"
+            <input
+                    type="text"
+                    id="card_address_2"
+                    name="card_address_2"
+                    class="card-address-2 give-input<?php echo( give_field_is_required( 'card_address_2', $form_id ) ? ' required' : '' ); ?>"
+                    placeholder="<?php esc_attr_e( 'Address line 2', 'give' ); ?>"
+                    value="<?php echo isset( $give_user_info['card_address_2'] ) ? $give_user_info['card_address_2'] : ''; ?>"
 				<?php echo( give_field_is_required( 'card_address_2', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
-		<p id="give-card-city-wrap" class="form-row form-row-first form-row-responsive">
-			<label for="card_city" class="give-label">
+        <p id="give-card-city-wrap" class="form-row form-row-first form-row-responsive">
+            <label for="card_city" class="give-label">
 				<?php esc_html_e( 'City', 'give' ); ?>
 				<?php if ( give_field_is_required( 'card_city', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The city for your billing address.', 'give' ); ?>"></span>
-			</label>
-			<input
-				type="text"
-				id="card_city"
-				name="card_city"
-				class="card-city give-input<?php echo( give_field_is_required( 'card_city', $form_id ) ? ' required' : '' ); ?>"
-				placeholder="<?php esc_attr_e( 'City', 'give' ); ?>"
-				value="<?php echo isset( $give_user_info['card_city'] ) ? $give_user_info['card_city'] : ''; ?>"
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The city for your billing address.', 'give' ); ?>"></span>
+            </label>
+            <input
+                    type="text"
+                    id="card_city"
+                    name="card_city"
+                    class="card-city give-input<?php echo( give_field_is_required( 'card_city', $form_id ) ? ' required' : '' ); ?>"
+                    placeholder="<?php esc_attr_e( 'City', 'give' ); ?>"
+                    value="<?php echo isset( $give_user_info['card_city'] ) ? $give_user_info['card_city'] : ''; ?>"
 				<?php echo( give_field_is_required( 'card_city', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
-		<p id="give-card-zip-wrap" class="form-row form-row-last form-row-responsive">
-			<label for="card_zip" class="give-label">
+        <p id="give-card-zip-wrap" class="form-row form-row-last form-row-responsive">
+            <label for="card_zip" class="give-label">
 				<?php esc_html_e( 'Zip / Postal Code', 'give' ); ?>
 				<?php if ( give_field_is_required( 'card_zip', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The zip or postal code for your billing address.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The zip or postal code for your billing address.', 'give' ); ?>"></span>
+            </label>
 
-			<input
-				type="text"
-				size="4"
-				id="card_zip"
-				name="card_zip"
-				class="card-zip give-input<?php echo( give_field_is_required( 'card_zip', $form_id ) ? ' required' : '' ); ?>"
-				placeholder="<?php esc_attr_e( 'Zip / Postal Code', 'give' ); ?>"
-				value="<?php echo isset( $give_user_info['card_zip'] ) ? $give_user_info['card_zip'] : ''; ?>"
+            <input
+                    type="text"
+                    size="4"
+                    id="card_zip"
+                    name="card_zip"
+                    class="card-zip give-input<?php echo( give_field_is_required( 'card_zip', $form_id ) ? ' required' : '' ); ?>"
+                    placeholder="<?php esc_attr_e( 'Zip / Postal Code', 'give' ); ?>"
+                    value="<?php echo isset( $give_user_info['card_zip'] ) ? $give_user_info['card_zip'] : ''; ?>"
 				<?php echo( give_field_is_required( 'card_zip', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            />
+        </p>
 
-		<p id="give-card-country-wrap" class="form-row form-row-first form-row-responsive">
-			<label for="billing_country" class="give-label">
+        <p id="give-card-country-wrap" class="form-row form-row-first form-row-responsive">
+            <label for="billing_country" class="give-label">
 				<?php esc_html_e( 'Country', 'give' ); ?>
 				<?php if ( give_field_is_required( 'billing_country', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The country for your billing address.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The country for your billing address.', 'give' ); ?>"></span>
+            </label>
 
-			<select
-				name="billing_country"
-				id="billing_country"
-				class="billing-country billing_country give-select<?php echo( give_field_is_required( 'billing_country', $form_id ) ? ' required' : '' ); ?>"
+            <select
+                    name="billing_country"
+                    id="billing_country"
+                    class="billing-country billing_country give-select<?php echo( give_field_is_required( 'billing_country', $form_id ) ? ' required' : '' ); ?>"
 				<?php echo( give_field_is_required( 'billing_country', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			>
+            >
 				<?php
 
 				$selected_country = give_get_country();
@@ -1008,18 +1009,18 @@ function give_default_cc_address_fields( $form_id ) {
 					echo '<option value="' . esc_attr( $country_code ) . '"' . selected( $country_code, $selected_country, false ) . '>' . $country . '</option>';
 				}
 				?>
-			</select>
-		</p>
+            </select>
+        </p>
 
-		<p id="give-card-state-wrap" class="form-row form-row-last form-row-responsive">
-			<label for="card_state" class="give-label">
+        <p id="give-card-state-wrap" class="form-row form-row-last form-row-responsive">
+            <label for="card_state" class="give-label">
 				<?php esc_html_e( 'State / Province', 'give' ); ?>
 				<?php if ( give_field_is_required( 'card_state', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php endif; ?>
-				<span class="give-tooltip give-icon give-icon-question"
-				      data-tooltip="<?php esc_attr_e( 'The state or province for your billing address.', 'give' ); ?>"></span>
-			</label>
+                <span class="give-tooltip give-icon give-icon-question"
+                      data-tooltip="<?php esc_attr_e( 'The state or province for your billing address.', 'give' ); ?>"></span>
+            </label>
 
 			<?php
 			$selected_state = give_get_state();
@@ -1030,22 +1031,22 @@ function give_default_cc_address_fields( $form_id ) {
 			}
 
 			if ( ! empty( $states ) ) : ?>
-				<select
-					name="card_state"
-					id="card_state"
-					class="card_state give-select<?php echo( give_field_is_required( 'card_state', $form_id ) ? ' required' : '' ); ?>"
+                <select
+                        name="card_state"
+                        id="card_state"
+                        class="card_state give-select<?php echo( give_field_is_required( 'card_state', $form_id ) ? ' required' : '' ); ?>"
 					<?php echo( give_field_is_required( 'card_state', $form_id ) ? ' required aria-required="true" ' : '' ); ?>>
 					<?php
 					foreach ( $states as $state_code => $state ) {
 						echo '<option value="' . $state_code . '"' . selected( $state_code, $selected_state, false ) . '>' . $state . '</option>';
 					}
 					?>
-				</select>
+                </select>
 			<?php else : ?>
-				<input type="text" size="6" name="card_state" id="card_state" class="card_state give-input"
-				       placeholder="<?php esc_attr_e( 'State / Province', 'give' ); ?>"/>
+                <input type="text" size="6" name="card_state" id="card_state" class="card_state give-input"
+                       placeholder="<?php esc_attr_e( 'State / Province', 'give' ); ?>"/>
 			<?php endif; ?>
-		</p>
+        </p>
 		<?php
 		/**
 		 * Fires while rendering credit card billing form, after address fields.
@@ -1056,7 +1057,7 @@ function give_default_cc_address_fields( $form_id ) {
 		 */
 		do_action( 'give_cc_billing_bottom' );
 		?>
-	</fieldset>
+    </fieldset>
 	<?php
 	echo ob_get_clean();
 }
@@ -1065,7 +1066,8 @@ add_action( 'give_after_cc_fields', 'give_default_cc_address_fields' );
 
 
 /**
- * Renders the user registration fields. If the user is logged in, a login form is displayed other a registration form is provided for the user to create an account.
+ * Renders the user registration fields. If the user is logged in, a login form is displayed other a registration form
+ * is provided for the user to create an account.
  *
  * @since  1.0
  *
@@ -1084,18 +1086,18 @@ function give_get_register_fields( $form_id ) {
 	$show_register_form = give_show_login_register_option( $form_id );
 
 	ob_start(); ?>
-	<fieldset id="give-register-fields-<?php echo $form_id; ?>">
+    <fieldset id="give-register-fields-<?php echo $form_id; ?>">
 
 		<?php if ( $show_register_form == 'both' ) { ?>
-			<div class="give-login-account-wrap">
-				<p class="give-login-message"><?php esc_html_e( 'Already have an account?', 'give' ); ?>&nbsp;
-					<a href="<?php echo esc_url( add_query_arg( 'login', 1 ) ); ?>" class="give-checkout-login"
-					   data-action="give_checkout_login"><?php esc_html_e( 'Login', 'give' ); ?></a>
-				</p>
-				<p class="give-loading-text">
-					<span class="give-loading-animation"></span>
+            <div class="give-login-account-wrap">
+                <p class="give-login-message"><?php esc_html_e( 'Already have an account?', 'give' ); ?>&nbsp;
+                    <a href="<?php echo esc_url( add_query_arg( 'login', 1 ) ); ?>" class="give-checkout-login"
+                       data-action="give_checkout_login"><?php esc_html_e( 'Login', 'give' ); ?></a>
                 </p>
-			</div>
+                <p class="give-loading-text">
+                    <span class="give-loading-animation"></span>
+                </p>
+            </div>
 		<?php } ?>
 
 		<?php
@@ -1109,15 +1111,15 @@ function give_get_register_fields( $form_id ) {
 		do_action( 'give_register_fields_before', $form_id );
 		?>
 
-		<fieldset id="give-register-account-fields-<?php echo $form_id; ?>">
-			<legend>
+        <fieldset id="give-register-account-fields-<?php echo $form_id; ?>">
+            <legend>
 				<?php
 				echo apply_filters( 'give_create_account_fieldset_heading', esc_html__( 'Create an account', 'give' ) );
 				if ( ! give_logged_in_only( $form_id ) ) {
 					echo ' <span class="sub-text">' . esc_html__( '(optional)', 'give' ) . '</span>';
 				}
 				?>
-			</legend>
+            </legend>
 			<?php
 			/**
 			 * Fires while rendering user registration form, before account fields.
@@ -1128,51 +1130,53 @@ function give_get_register_fields( $form_id ) {
 			 */
 			do_action( 'give_register_account_fields_before', $form_id );
 			?>
-			<div id="give-user-login-wrap-<?php echo $form_id; ?>" class="form-row form-row-one-third form-row-first form-row-responsive">
-				<label for="give-user-login-<?php echo $form_id; ?>">
+            <div id="give-user-login-wrap-<?php echo $form_id; ?>"
+                 class="form-row form-row-one-third form-row-first form-row-responsive">
+                <label for="give-user-login-<?php echo $form_id; ?>">
 					<?php esc_html_e( 'Username', 'give' ); ?>
 					<?php if ( give_logged_in_only( $form_id ) ) { ?>
-						<span class="give-required-indicator">*</span>
+                        <span class="give-required-indicator">*</span>
 					<?php } ?>
-					<span class="give-tooltip give-icon give-icon-question"
-					      data-tooltip="<?php esc_attr_e( 'The username you will use to log into your account.', 'give' ); ?>"></span>
-				</label>
+                    <span class="give-tooltip give-icon give-icon-question"
+                          data-tooltip="<?php esc_attr_e( 'The username you will use to log into your account.', 'give' ); ?>"></span>
+                </label>
 
-				<input name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" class="give-input"
-				       type="text"
-				       placeholder="<?php esc_attr_e( 'Username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-			</div>
+                <input name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" class="give-input"
+                       type="text"
+                       placeholder="<?php esc_attr_e( 'Username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+            </div>
 
-			<div id="give-user-pass-wrap-<?php echo $form_id; ?>" class="form-row form-row-one-third form-row-responsive">
-				<label for="give-user-pass-<?php echo $form_id; ?>">
+            <div id="give-user-pass-wrap-<?php echo $form_id; ?>"
+                 class="form-row form-row-one-third form-row-responsive">
+                <label for="give-user-pass-<?php echo $form_id; ?>">
 					<?php esc_html_e( 'Password', 'give' ); ?>
 					<?php if ( give_logged_in_only( $form_id ) ) { ?>
-						<span class="give-required-indicator">*</span>
+                        <span class="give-required-indicator">*</span>
 					<?php } ?>
-					<span class="give-tooltip give-icon give-icon-question"
-					      data-tooltip="<?php esc_attr_e( 'The password used to access your account.', 'give' ); ?>"></span>
-				</label>
+                    <span class="give-tooltip give-icon give-icon-question"
+                          data-tooltip="<?php esc_attr_e( 'The password used to access your account.', 'give' ); ?>"></span>
+                </label>
 
-				<input name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>" class="give-input"
-				       placeholder="<?php esc_attr_e( 'Password', 'give' ); ?>"
-				       type="password"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-			</div>
+                <input name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>" class="give-input"
+                       placeholder="<?php esc_attr_e( 'Password', 'give' ); ?>"
+                       type="password"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+            </div>
 
-			<div id="give-user-pass-confirm-wrap-<?php echo $form_id; ?>"
-			     class="give-register-password form-row form-row-one-third form-row-responsive">
-				<label for="give-user-pass-confirm-<?php echo $form_id; ?>">
+            <div id="give-user-pass-confirm-wrap-<?php echo $form_id; ?>"
+                 class="give-register-password form-row form-row-one-third form-row-responsive">
+                <label for="give-user-pass-confirm-<?php echo $form_id; ?>">
 					<?php esc_html_e( 'Confirm PW', 'give' ); ?>
 					<?php if ( give_logged_in_only( $form_id ) ) { ?>
-						<span class="give-required-indicator">*</span>
+                        <span class="give-required-indicator">*</span>
 					<?php } ?>
-					<span class="give-tooltip give-icon give-icon-question"
-					      data-tooltip="<?php esc_attr_e( 'Please retype your password to confirm.', 'give' ); ?>"></span>
-				</label>
+                    <span class="give-tooltip give-icon give-icon-question"
+                          data-tooltip="<?php esc_attr_e( 'Please retype your password to confirm.', 'give' ); ?>"></span>
+                </label>
 
-				<input name="give_user_pass_confirm" id="give-user-pass-confirm-<?php echo $form_id; ?>"
-				       class="give-input" placeholder="<?php esc_attr_e( 'Confirm password', 'give' ); ?>"
-				       type="password"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-			</div>
+                <input name="give_user_pass_confirm" id="give-user-pass-confirm-<?php echo $form_id; ?>"
+                       class="give-input" placeholder="<?php esc_attr_e( 'Confirm password', 'give' ); ?>"
+                       type="password"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+            </div>
 			<?php
 			/**
 			 * Fires while rendering user registration form, after account fields.
@@ -1183,7 +1187,7 @@ function give_get_register_fields( $form_id ) {
 			 */
 			do_action( 'give_register_account_fields_after', $form_id );
 			?>
-		</fieldset>
+        </fieldset>
 
 		<?php
 		/**
@@ -1196,7 +1200,7 @@ function give_get_register_fields( $form_id ) {
 		do_action( 'give_register_fields_after', $form_id );
 		?>
 
-		<input type="hidden" name="give-purchase-var" value="needs-to-register"/>
+        <input type="hidden" name="give-purchase-var" value="needs-to-register"/>
 
 		<?php
 		/**
@@ -1207,7 +1211,7 @@ function give_get_register_fields( $form_id ) {
 		do_action( 'give_donation_form_user_info', $form_id );
 		?>
 
-	</fieldset>
+    </fieldset>
 	<?php
 	echo ob_get_clean();
 }
@@ -1232,25 +1236,25 @@ function give_get_login_fields( $form_id ) {
 
 	ob_start();
 	?>
-	<fieldset id="give-login-fields-<?php echo $form_id; ?>">
-		<legend><?php echo apply_filters( 'give_account_login_fieldset_heading', esc_html__( 'Login to Your Account', 'give' ) );
+    <fieldset id="give-login-fields-<?php echo $form_id; ?>">
+        <legend><?php echo apply_filters( 'give_account_login_fieldset_heading', esc_html__( 'Login to Your Account', 'give' ) );
 			if ( ! give_logged_in_only( $form_id ) ) {
 				echo ' <span class="sub-text">' . esc_html__( '(optional)', 'give' ) . '</span>';
 			} ?>
-		</legend>
+        </legend>
 		<?php if ( $show_register_form == 'both' ) { ?>
-			<p class="give-new-account-link">
+            <p class="give-new-account-link">
 				<?php esc_html_e( 'Need to create an account?', 'give' ); ?>&nbsp;
-				<a href="<?php echo remove_query_arg( 'login' ); ?>" class="give-checkout-register-cancel"
-				   data-action="give_checkout_register">
+                <a href="<?php echo remove_query_arg( 'login' ); ?>" class="give-checkout-register-cancel"
+                   data-action="give_checkout_register">
 					<?php esc_html_e( 'Register', 'give' );
 					if ( ! give_logged_in_only( $form_id ) ) {
 						echo ' ' . esc_html__( 'or checkout as a guest &raquo;', 'give' );
 					} ?>
-				</a>
-			</p>
-			<p class="give-loading-text">
-				<span class="give-loading-animation"></span>
+                </a>
+            </p>
+            <p class="give-loading-text">
+                <span class="give-loading-animation"></span>
             </p>
 		<?php } ?>
 		<?php
@@ -1263,49 +1267,50 @@ function give_get_login_fields( $form_id ) {
 		 */
 		do_action( 'give_checkout_login_fields_before', $form_id );
 		?>
-		<div id="give-user-login-wrap-<?php echo $form_id; ?>" class="form-row form-row-first form-row-responsive">
-			<label class="give-label" for="give-user-login-<?php echo $form_id; ?>">
+        <div id="give-user-login-wrap-<?php echo $form_id; ?>" class="form-row form-row-first form-row-responsive">
+            <label class="give-label" for="give-user-login-<?php echo $form_id; ?>">
 				<?php esc_html_e( 'Username', 'give' ); ?>
 				<?php if ( give_logged_in_only( $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php } ?>
-			</label>
+            </label>
 
-			<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>" type="text"
-			       name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" value=""
-			       placeholder="<?php esc_attr_e( 'Your username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-		</div>
+            <input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>" type="text"
+                   name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" value=""
+                   placeholder="<?php esc_attr_e( 'Your username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+        </div>
 
-		<div id="give-user-pass-wrap-<?php echo $form_id; ?>" class="give_login_password form-row form-row-last form-row-responsive">
-			<label class="give-label" for="give-user-pass-<?php echo $form_id; ?>">
+        <div id="give-user-pass-wrap-<?php echo $form_id; ?>"
+             class="give_login_password form-row form-row-last form-row-responsive">
+            <label class="give-label" for="give-user-pass-<?php echo $form_id; ?>">
 				<?php esc_html_e( 'Password', 'give' ); ?>
 				<?php if ( give_logged_in_only( $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
+                    <span class="give-required-indicator">*</span>
 				<?php } ?>
-			</label>
-			<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>"
-			       type="password" name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>"
-			       placeholder="<?php esc_attr_e( 'Your password', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-			<input type="hidden" name="give-purchase-var" value="needs-to-login"/>
-		</div>
+            </label>
+            <input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>"
+                   type="password" name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>"
+                   placeholder="<?php esc_attr_e( 'Your password', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+            <input type="hidden" name="give-purchase-var" value="needs-to-login"/>
+        </div>
 
-		<div id="give-forgot-password-wrap-<?php echo $form_id; ?>" class="give_login_forgot_password">
+        <div id="give-forgot-password-wrap-<?php echo $form_id; ?>" class="give_login_forgot_password">
 			 <span class="give-forgot-password ">
 				 <a href="<?php echo wp_lostpassword_url() ?>"
-				    target="_blank"><?php esc_html_e( 'Reset Password', 'give' ) ?></a>
+                    target="_blank"><?php esc_html_e( 'Reset Password', 'give' ) ?></a>
 			 </span>
-		</div>
+        </div>
 
-		<div id="give-user-login-submit-<?php echo $form_id; ?>" class="give-clearfix">
-			<input type="submit" class="give-submit give-btn button" name="give_login_submit"
-			       value="<?php esc_attr_e( 'Login', 'give' ); ?>"/>
+        <div id="give-user-login-submit-<?php echo $form_id; ?>" class="give-clearfix">
+            <input type="submit" class="give-submit give-btn button" name="give_login_submit"
+                   value="<?php esc_attr_e( 'Login', 'give' ); ?>"/>
 			<?php if ( $show_register_form !== 'login' ) { ?>
-				<input type="button" data-action="give_cancel_login"
-				       class="give-cancel-login give-checkout-register-cancel give-btn button" name="give_login_cancel"
-				       value="<?php esc_attr_e( 'Cancel', 'give' ); ?>"/>
+                <input type="button" data-action="give_cancel_login"
+                       class="give-cancel-login give-checkout-register-cancel give-btn button" name="give_login_cancel"
+                       value="<?php esc_attr_e( 'Cancel', 'give' ); ?>"/>
 			<?php } ?>
-			<span class="give-loading-animation"></span>
-		</div>
+            <span class="give-loading-animation"></span>
+        </div>
 		<?php
 		/**
 		 * Fires while rendering checkout login form, after the fields.
@@ -1316,7 +1321,7 @@ function give_get_login_fields( $form_id ) {
 		 */
 		do_action( 'give_checkout_login_fields_after', $form_id );
 		?>
-	</fieldset><!--end #give-login-fields-->
+    </fieldset><!--end #give-login-fields-->
 	<?php
 	echo ob_get_clean();
 }
@@ -1351,7 +1356,7 @@ function give_payment_mode_select( $form_id ) {
 	do_action( 'give_payment_mode_top', $form_id );
 	?>
 
-	<fieldset id="give-payment-mode-select" <?php if ( count( $gateways ) <= 1 ) {
+    <fieldset id="give-payment-mode-select" <?php if ( count( $gateways ) <= 1 ) {
 		echo 'style="display: none;"';
 	} ?>>
 		<?php
@@ -1364,14 +1369,14 @@ function give_payment_mode_select( $form_id ) {
 		 */
 		do_action( 'give_payment_mode_before_gateways_wrap' );
 		?>
-		<legend
-			class="give-payment-mode-label"><?php echo apply_filters( 'give_checkout_payment_method_text', esc_html__( 'Select Payment Method', 'give' ) ); ?>
+        <legend
+                class="give-payment-mode-label"><?php echo apply_filters( 'give_checkout_payment_method_text', esc_html__( 'Select Payment Method', 'give' ) ); ?>
             <span class="give-loading-text"><span
                         class="give-loading-animation"></span>
             </span>
         </legend>
 
-		<div id="give-payment-mode-wrap">
+        <div id="give-payment-mode-wrap">
 			<?php
 			/**
 			 * Fires while selecting payment gateways, befire the gateways list.
@@ -1380,29 +1385,29 @@ function give_payment_mode_select( $form_id ) {
 			 */
 			do_action( 'give_payment_mode_before_gateways' )
 			?>
-			<ul id="give-gateway-radio-list">
+            <ul id="give-gateway-radio-list">
 				<?php
 				/**
 				 * Loop through the active payment gateways.
 				 */
-				$selected_gateway = give_get_chosen_gateway( $form_id );
+				$selected_gateway  = give_get_chosen_gateway( $form_id );
 
 				foreach ( $gateways as $gateway_id => $gateway ) :
 					//Determine the default gateway.
-					$checked       = checked( $gateway_id, $selected_gateway, false );
+					$checked = checked( $gateway_id, $selected_gateway, false );
 					$checked_class = $checked ? ' class="give-gateway-option-selected"' : ''; ?>
-					<li<?php echo $checked_class?>>
-						<input type="radio" name="payment-mode" class="give-gateway"
-						       id="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
-						       value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
-						<label for="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
-						       class="give-gateway-option"
-						       id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $gateway['checkout_label'] ); ?></label>
-					</li>
+                    <li<?php echo $checked_class ?>>
+                        <input type="radio" name="payment-mode" class="give-gateway"
+                               id="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
+                               value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
+                        <label for="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
+                               class="give-gateway-option"
+                               id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $gateway['checkout_label'] ); ?></label>
+                    </li>
 					<?php
 				endforeach;
 				?>
-			</ul>
+            </ul>
 			<?php
 			/**
 			 * Fires while selecting payment gateways, before the gateways list.
@@ -1411,7 +1416,7 @@ function give_payment_mode_select( $form_id ) {
 			 */
 			do_action( 'give_payment_mode_after_gateways' );
 			?>
-		</div>
+        </div>
 		<?php
 		/**
 		 * Fires while selecting payment gateways, after the wrap div.
@@ -1422,7 +1427,7 @@ function give_payment_mode_select( $form_id ) {
 		 */
 		do_action( 'give_payment_mode_after_gateways_wrap' );
 		?>
-	</fieldset>
+    </fieldset>
 
 	<?php
 	/**
@@ -1435,7 +1440,7 @@ function give_payment_mode_select( $form_id ) {
 	do_action( 'give_payment_mode_bottom', $form_id );
 	?>
 
-	<div id="give_purchase_form_wrap">
+    <div id="give_purchase_form_wrap">
 
 		<?php
 		/**
@@ -1446,7 +1451,7 @@ function give_payment_mode_select( $form_id ) {
 		do_action( 'give_donation_form', $form_id );
 		?>
 
-	</div>
+    </div>
 
 	<?php
 	/**
@@ -1501,9 +1506,9 @@ function give_terms_agreement( $form_id ) {
 	}
 
 	?>
-	<fieldset id="give_terms_agreement">
-		<legend><?php echo apply_filters( 'give_terms_agreement_text', esc_html__( 'Terms', 'give' ) ); ?></legend>
-		<div id="give_terms" class="give_terms-<?php echo $form_id; ?>" style="display:none;">
+    <fieldset id="give_terms_agreement">
+        <legend><?php echo apply_filters( 'give_terms_agreement_text', esc_html__( 'Terms', 'give' ) ); ?></legend>
+        <div id="give_terms" class="give_terms-<?php echo $form_id; ?>" style="display:none;">
 			<?php
 			/**
 			 * Fires while rendering terms of agreement, before the fields.
@@ -1520,18 +1525,19 @@ function give_terms_agreement( $form_id ) {
 			 */
 			do_action( 'give_after_terms' );
 			?>
-		</div>
-		<div id="give_show_terms">
-			<a href="#" class="give_terms_links give_terms_links-<?php echo $form_id; ?>" role="button"
-			   aria-controls="give_terms"><?php esc_html_e( 'Show Terms', 'give' ); ?></a>
-			<a href="#" class="give_terms_links give_terms_links-<?php echo $form_id; ?>" role="button"
-			   aria-controls="give_terms" style="display:none;"><?php esc_html_e( 'Hide Terms', 'give' ); ?></a>
-		</div>
+        </div>
+        <div id="give_show_terms">
+            <a href="#" class="give_terms_links give_terms_links-<?php echo $form_id; ?>" role="button"
+               aria-controls="give_terms"><?php esc_html_e( 'Show Terms', 'give' ); ?></a>
+            <a href="#" class="give_terms_links give_terms_links-<?php echo $form_id; ?>" role="button"
+               aria-controls="give_terms" style="display:none;"><?php esc_html_e( 'Hide Terms', 'give' ); ?></a>
+        </div>
 
-		<input name="give_agree_to_terms" class="required" type="checkbox" id="give_agree_to_terms-<?php echo $form_id; ?>" value="1" required aria-required="true" />
-		<label for="give_agree_to_terms-<?php echo $form_id; ?>"><?php echo $label; ?></label>
+        <input name="give_agree_to_terms" class="required" type="checkbox"
+               id="give_agree_to_terms-<?php echo $form_id; ?>" value="1" required aria-required="true"/>
+        <label for="give_agree_to_terms-<?php echo $form_id; ?>"><?php echo $label; ?></label>
 
-	</fieldset>
+    </fieldset>
 	<?php
 }
 
@@ -1561,12 +1567,12 @@ function give_checkout_final_total( $form_id ) {
 		return;
 	}
 	?>
-	<p id="give-final-total-wrap" class="form-wrap ">
+    <p id="give-final-total-wrap" class="form-wrap ">
 		<span
-			class="give-donation-total-label"><?php echo apply_filters( 'give_donation_total_label', esc_html__( 'Donation Total:', 'give' ) ); ?></span>
-		<span class="give-final-total-amount"
-		      data-total="<?php echo give_format_amount( $total ); ?>"><?php echo give_currency_filter( give_format_amount( $total ) ); ?></span>
-	</p>
+                class="give-donation-total-label"><?php echo apply_filters( 'give_donation_total_label', esc_html__( 'Donation Total:', 'give' ) ); ?></span>
+        <span class="give-final-total-amount"
+              data-total="<?php echo give_format_amount( $total ); ?>"><?php echo give_currency_filter( give_format_amount( $total ) ); ?></span>
+    </p>
 	<?php
 }
 
@@ -1583,7 +1589,7 @@ add_action( 'give_donation_form_before_submit', 'give_checkout_final_total', 999
  */
 function give_checkout_submit( $form_id ) {
 	?>
-	<fieldset id="give_purchase_submit">
+    <fieldset id="give_purchase_submit">
 		<?php
 		/**
 		 * Fire before donation form submit.
@@ -1603,7 +1609,7 @@ function give_checkout_submit( $form_id ) {
 		 */
 		do_action( 'give_donation_form_after_submit', $form_id );
 		?>
-	</fieldset>
+    </fieldset>
 	<?php
 }
 
@@ -1625,11 +1631,11 @@ function give_checkout_button_purchase( $form_id ) {
 	$display_label_field = get_post_meta( $form_id, '_give_checkout_label', true );
 	$display_label       = ( ! empty( $display_label_field ) ? $display_label_field : esc_html__( 'Donate Now', 'give' ) );
 	ob_start(); ?>
-	<div class="give-submit-button-wrap give-clearfix">
-		<input type="submit" class="give-submit give-btn" id="give-purchase-button" name="give-purchase"
-		       value="<?php echo $display_label; ?>"/>
-		<span class="give-loading-animation"></span>
-	</div>
+    <div class="give-submit-button-wrap give-clearfix">
+        <input type="submit" class="give-submit give-btn" id="give-purchase-button" name="give-purchase"
+               value="<?php echo $display_label; ?>"/>
+        <span class="give-loading-animation"></span>
+    </div>
 	<?php
 	return apply_filters( 'give_checkout_button_purchase', ob_get_clean(), $form_id );
 }
@@ -1651,7 +1657,7 @@ function give_agree_to_terms_js( $form_id ) {
 
 	if ( give_is_setting_enabled( $form_option, array( 'enabled', 'global' ) ) ) {
 		?>
-		<script type="text/javascript">
+        <script type="text/javascript">
 			jQuery(document).ready(function ($) {
 				$('body').on('click', '.give_terms_links-<?php echo $form_id;?>', function (e) {
 					e.preventDefault();
@@ -1660,7 +1666,7 @@ function give_agree_to_terms_js( $form_id ) {
 					return false;
 				});
 			});
-		</script>
+        </script>
 		<?php
 	}
 }
@@ -1696,8 +1702,10 @@ add_action( 'give_pre_form', 'give_show_goal_progress', 10, 2 );
  * Get form content position.
  *
  * @since  1.8
+ *
  * @param  $form_id
  * @param  $args
+ *
  * @return mixed|string
  */
 function give_get_form_content_placement( $form_id, $args ) {
@@ -1743,7 +1751,7 @@ function give_form_content( $form_id, $args ) {
 	$show_content = give_get_form_content_placement( $form_id, $args );
 
 	// Bailout.
-	if( empty( $show_content ) ) {
+	if ( empty( $show_content ) ) {
 		return false;
 	}
 
@@ -1804,10 +1812,10 @@ function give_checkout_hidden_fields( $form_id ) {
 	do_action( 'give_hidden_fields_before', $form_id );
 
 	if ( is_user_logged_in() ) { ?>
-		<input type="hidden" name="give-user-id" value="<?php echo get_current_user_id(); ?>"/>
+        <input type="hidden" name="give-user-id" value="<?php echo get_current_user_id(); ?>"/>
 	<?php } ?>
-	<input type="hidden" name="give_action" value="purchase"/>
-	<input type="hidden" name="give-gateway" value="<?php echo give_get_chosen_gateway( $form_id ); ?>"/>
+    <input type="hidden" name="give_action" value="purchase"/>
+    <input type="hidden" name="give-gateway" value="<?php echo give_get_chosen_gateway( $form_id ); ?>"/>
 	<?php
 	/**
 	 * Fires while rendering hidden checkout fields, after the fields.


### PR DESCRIPTION
## Description

1. oEmbeds and Shortcode support 
As described in #1545 - we were outputting a notification for the Goal Complete message which closes the form from accepting further donations. This is pretty weak functionality. Likely, people would want to use this to output a shortcode, embed a video, etc. 

2. WYSIWYGs now support `default` arg. 
I noticed that we were passing some default text in and the current field wasn't supporting that so I fixed it here: https://github.com/WordImpress/Give/pull/1549/commits/91e6923438553e0613eccf2a9bd477cd9713560a#diff-f3d5982e056a4167c9ee02f2c77d6031R392 

Also reformatted the code to WP coding standards.

## How Has This Been Tested?

**Video Embed w/ YouTube:**
![2017-02-24_12-03-40](https://cloud.githubusercontent.com/assets/1571635/23319120/32c093b6-fa8a-11e6-9df5-f6ad1df2a9d5.png)

![2017-02-24_12-01-04](https://cloud.githubusercontent.com/assets/1571635/23319116/2d988e8e-fa8a-11e6-9476-a0ba76cab7c7.png)

**Shortcode Usage:**
![2017-02-24_12-12-01](https://cloud.githubusercontent.com/assets/1571635/23319198/7620a970-fa8a-11e6-9e69-63c36bc4310c.png)

**Default content WYSIWYG support:**
![2017-02-24_12-27-19](https://cloud.githubusercontent.com/assets/1571635/23319706/99a7546e-fa8c-11e6-893d-603df93df7e4.png)

## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
- Enhancement
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.