### PR TITLE
Issue/1551

### DIFF
--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -246,12 +246,10 @@ class Give_Email_Access {
 		// Must have a token.
 		if ( ! empty( $token ) ) {
 
-			// Token & verify key must be valid.
-			if (
-				! $this->is_valid_token( $token )
-				|| ! $this->is_valid_verify_key( $token )
-			) {
-				return false;
+			if ( ! $this->is_valid_token( $token ) ) {
+				if ( ! $this->is_valid_verify_key( $token ) ) {
+					return;
+				}
 			}
 
 			$this->token_exists = true;

--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -278,12 +278,12 @@ class Give_Email_Access {
 		// Make sure token isn't expired.
 		$expires = date( 'Y-m-d H:i:s', time() - $this->token_expiration );
 
-		$row = $wpdb->get_row(
+		$email = $wpdb->get_var(
 			$wpdb->prepare( "SELECT email FROM {$wpdb->prefix}give_customers WHERE token = %s AND verify_throttle >= %s LIMIT 1", $token, $expires )
 		);
 
-		if ( ! empty( $row ) ) {
-			$this->token_email = $row->email;
+		if ( ! empty( $email ) ) {
+			$this->token_email = $email;
 			$this->token       = $token;
 			return true;
 		}

--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -278,12 +278,12 @@ class Give_Email_Access {
 		// Make sure token isn't expired.
 		$expires = date( 'Y-m-d H:i:s', time() - $this->token_expiration );
 
-		$email = $wpdb->get_row(
+		$row = $wpdb->get_row(
 			$wpdb->prepare( "SELECT email FROM {$wpdb->prefix}give_customers WHERE token = %s AND verify_throttle >= %s LIMIT 1", $token, $expires )
 		);
 
-		if ( ! empty( $email ) ) {
-			$this->token_email = $email;
+		if ( ! empty( $row ) ) {
+			$this->token_email = $row->email;
 			$this->token       = $token;
 			return true;
 		}


### PR DESCRIPTION
This change allows the token to be set in the database, which then allows the user to view donation history via email access.


## Testing
The token validation appears to only work on the first view. When revisiting the donation history page, it tells me:

> It looks like you haven't made any donations.

I believe after the initial visit, cookie-based authentication should take over. That part needs testing.