### PR TITLE
Add colorpicker setting field

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -293,7 +293,13 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 				// Set title.
 				$defaults['title'] = isset( $value['name'] ) ? $value['name'] : '';
 
+				// Set default setting.
 				$value = wp_parse_args( $value, $defaults );
+
+				// Colorpicker field.
+				$value['class'] = ( 'colorpicker' === $value['type'] ? trim( $value['class'] ) . ' give-colorpicker' : $value['class'] );
+				$value['type']  = ( 'colorpicker' === $value['type'] ? 'text' : $value['type'] );
+
 
 				// Custom attribute handling.
 				$custom_attributes = array();
@@ -371,6 +377,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						break;
 
 					// Standard text inputs and subtypes like 'number'.
+					case 'colorpicker':
 					case 'text':
 					case 'email':
 					case 'number':

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -54,9 +54,6 @@ class Give_MetaBox_Form_Data {
 		// Add metabox.
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 30 );
 
-		// Load required scripts.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_script' ) );
-
 		// Save form meta.
 		add_action( 'save_post_give_forms', array( $this, 'save' ), 10, 2 );
 
@@ -552,8 +549,7 @@ class Give_MetaBox_Form_Data {
 		global $post;
 
 		if ( is_object( $post ) && 'give_forms' === $post->post_type ) {
-			wp_enqueue_style( 'wp-color-picker' );
-			wp_enqueue_script( 'wp-color-picker' );
+
 		}
 	}
 

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -255,6 +255,8 @@ function give_load_admin_scripts( $hook ) {
 	wp_register_style( 'jquery-chosen', $css_dir . 'chosen' . $suffix . '.css', array(), GIVE_VERSION );
 	wp_enqueue_style( 'jquery-chosen' );
 	wp_enqueue_style( 'thickbox' );
+	wp_enqueue_style( 'wp-color-picker' );
+
 
 	// JS.
 	wp_register_script( 'jquery-chosen', $js_plugins . 'chosen.jquery' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION );
@@ -263,7 +265,11 @@ function give_load_admin_scripts( $hook ) {
 	wp_register_script( 'give-accounting', $js_plugins . 'accounting' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, false );
 	wp_enqueue_script( 'give-accounting' );
 
-	wp_register_script( 'give-admin-scripts', $js_dir . 'admin-scripts' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, false );
+	wp_enqueue_script( 'wp-color-picker' );
+	wp_enqueue_script( 'jquery-ui-datepicker' );
+	wp_enqueue_script( 'thickbox' );
+
+	wp_register_script( 'give-admin-scripts', $js_dir . 'admin-scripts' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker', 'wp-color-picker' ), GIVE_VERSION, false );
 	wp_enqueue_script( 'give-admin-scripts' );
 
 	wp_register_script( 'jquery-flot', $js_plugins . 'jquery.flot' . $suffix . '.js' );
@@ -274,9 +280,6 @@ function give_load_admin_scripts( $hook ) {
 
 	wp_register_script( 'give-repeatable-fields', $js_plugins . 'repeatable-fields' . $suffix . '.js', array( 'jquery' ), GIVE_VERSION, false );
 	wp_enqueue_script( 'give-repeatable-fields' );
-
-	wp_enqueue_script( 'jquery-ui-datepicker' );
-	wp_enqueue_script( 'thickbox' );
 
 	// Forms CPT Script.
 	if ( $post_type === 'give_forms' ) {


### PR DESCRIPTION
## Description
<!--- Please describe your changes -->
This PR will resolve #1566 
Note: You can see implementation here:
https://github.com/WordImpress/Give-Settings-API-Example/tree/feature/colorpicker
https://github.com/WordImpress/Give-Settings-API-Example/blob/feature/colorpicker/includes/class-setting-api-fields.php#L136#L144

## Screenshots (jpeg or gifs if applicable):
![screen shot 2017-03-06 at 10 29 00 am](https://cloud.githubusercontent.com/assets/1784821/23597418/bb536494-0258-11e7-8bb5-cc9db60722e1.png)


## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.