### PR TITLE
Fixes for #1579 and #1580

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -42,7 +42,7 @@ function give_do_automatic_upgrades() {
 		case version_compare( $give_version, '1.7', '<' ) :
 			give_v17_upgrades();
 			$did_upgrade = true;
-            break;
+			break;
 
 		case version_compare( $give_version, '1.8', '<' ) :
 			give_v18_upgrades();
@@ -138,7 +138,7 @@ function give_show_upgrade_notices() {
 				$upgrade_links.on( 'click', function(e){
 					e.preventDefault();
 
-					if( ! window.confirm( '<?php _e( 'Please make sure to create a database backup before initiating the upgrade.', 'give'); ?>' ) ) {
+					if( ! window.confirm( '<?php _e( 'Please make sure to create a database backup before initiating the upgrade.', 'give' ); ?>' ) ) {
 						return;
 					}
 
@@ -707,7 +707,6 @@ function give_v18_upgrades_form_metadata() {
 		)
 	);
 
-
 	if ( $forms->have_posts() ) {
 		while ( $forms->have_posts() ) {
 			$forms->the_post();
@@ -730,12 +729,12 @@ function give_v18_upgrades_form_metadata() {
 			$guest_donation_newval = ( in_array( $guest_donation, array( 'yes', 'on' ) ) ? 'disabled' : 'enabled' );
 			update_post_meta( get_the_ID(), '_give_logged_in_only', $guest_donation_newval );
 
-            // Offline Donations
+			// Offline Donations
 			// See: https://github.com/WordImpress/Give/issues/1579
 			$offline_donation = get_post_meta( get_the_ID(), '_give_customize_offline_donations', true );
-			if('no' === $offline_donation ) {
+			if ( 'no' === $offline_donation ) {
 				$offline_donation_newval = 'global';
-			} elseif('yes' === $offline_donation) {
+			} elseif ( 'yes' === $offline_donation ) {
 				$offline_donation_newval = 'enabled';
 			} else {
 				$offline_donation_newval = 'disabled';
@@ -790,7 +789,6 @@ function give_v18_upgrades_form_metadata() {
 		update_option( 'give_version', preg_replace( '/[^0-9.].*/', '', GIVE_VERSION ) );
 		delete_option( 'give_doing_upgrade' );
 		give_set_upgrade_complete( 'v18_upgrades_form_metadata' );
-
 
 		wp_redirect( admin_url() );
 		exit;

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -723,12 +723,24 @@ function give_v18_upgrades_form_metadata() {
 				$field_value = ( 'none' !== $show_content ? $show_content : 'give_pre_form' );
 				update_post_meta( get_the_ID(), '_give_content_placement', $field_value );
 			}
-            
+
 			// "Disable" Guest Donation. Checkbox
 			// See: https://github.com/WordImpress/Give/issues/1470
 			$guest_donation = get_post_meta( get_the_ID(), '_give_logged_in_only', true );
 			$guest_donation_newval = ( in_array( $guest_donation, array( 'yes', 'on' ) ) ? 'disabled' : 'enabled' );
 			update_post_meta( get_the_ID(), '_give_logged_in_only', $guest_donation_newval );
+
+            // Offline Donations
+			// See: https://github.com/WordImpress/Give/issues/1579
+			$offline_donation = get_post_meta( get_the_ID(), '_give_customize_offline_donations', true );
+			if('no' === $offline_donation ) {
+				$offline_donation_newval = 'global';
+			} elseif('yes' === $offline_donation) {
+				$offline_donation_newval = 'enabled';
+			} else {
+				$offline_donation_newval = 'disabled';
+			}
+			update_post_meta( get_the_ID(), '_give_customize_offline_donations', $offline_donation_newval );
 
 			// Convert yes/no setting field to enabled/disabled.
 			$form_radio_settings = array(
@@ -743,9 +755,6 @@ function give_v18_upgrades_form_metadata() {
 
 				// Term & conditions.
 				'_give_terms_option',
-
-				// Offline donation.
-				'_give_customize_offline_donations',
 
 				// Billing fields.
 				'_give_offline_donation_enable_billing_fields_single',

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -138,7 +138,7 @@ function give_show_upgrade_notices() {
 				$upgrade_links.on( 'click', function(e){
 					e.preventDefault();
 
-					if( ! window.confirm( give_vars.upgrade_confirmation ) ) {
+					if( ! window.confirm( '<?php _e( 'Please make sure to create a database backup before initiating the upgrade.', 'give'); ?>' ) ) {
 						return;
 					}
 

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -336,7 +336,6 @@ function give_load_admin_scripts( $hook ) {
 				'resend_receipts'         => __( 'Are you sure you want to resend the emails receipt to {payment_count} recipients?', 'give' ),
 			),
 		),
-		'upgrade_confirmation' => __( 'Please make sure to create a database backup before initiating the upgrade.', 'give' ),
 		'metabox_fields' => array(
 			'media' => array(
 				'button_title' => esc_html__( 'Choose Attachment', 'give' ),


### PR DESCRIPTION
## Description
I have added an exception for the `_give_customize_offline_donations` within the 1.8 upgrade routine to fix #1579 

As well, the upgrade routine can now be ran anywhere within wp-admin and won't throw a JS error due to not being able to access the `give_vars` variable from outside Give admin pages. This fixes #1580 

## How Has This Been Tested?
1. Fresh install, pre-form upgrade within 1.8
2. Verified upgrade JS window appears.
3. Verified offline donations field is set properly

## Types of changes
<!--- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue)
<!--- New feature (non-breaking change which adds functionality) -->
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.