### PR TITLE
New option to toggle billing details and corresponding logic #1573

### DIFF
--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -76,6 +76,17 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 							'default' => 'donation',
 						),
 						array(
+							'name'    => __( 'Billing Details', 'give' ),
+							'desc'    => __( 'This option will enable the billing details section for PayPal Standard which requires the donor\'s address to complete the donation. These fields are not required by PayPal to process the transaction, but you may have a need to collect the data.', 'give' ),
+							'id'      => 'paypal_standard_billing_details',
+							'type'    => 'radio_inline',
+							'default' => 'disabled',
+							'options' => array(
+								'enabled'  => __( 'Enabled', 'give' ),
+								'disabled' => __( 'Disabled', 'give' ),
+							)
+						),
+						array(
 							'name'    => __( 'PayPal IPN Verification', 'give' ),
 							'desc'    => __( 'If donations are not getting marked as complete, use a slightly less secure method of verifying donations.', 'give' ),
 							'id'      => 'paypal_verification',


### PR DESCRIPTION
## Description
I have added an option within _WP-Admin > Donations > Gateways > PayPal Standard_ to add the Billing Details fieldset. When enabled this field passes all data to PayPal. I checked to ensure fields are passed properly between donation and standard mode. The only field that wasn't passing was Zipcode, which I have fixed. 

Fixes #1573 

## How Has This Been Tested?
With billing fields enabled/disable - or the option not set in the db yet.

## Screenshots (jpeg or gifs if applicable):
Fields passed properly to paypal in both donation and standard transaction mode:
![2017-03-15_20-32-14](https://cloud.githubusercontent.com/assets/1571635/23980809/682a23a2-09bf-11e7-8b1e-57410adfc853.png)
![2017-03-15_20-33-23](https://cloud.githubusercontent.com/assets/1571635/23980817/744e811e-09bf-11e7-8de3-046836ea044d.png)

## Types of changes
<!--- What types of changes does your code introduce?  -->
<!--- Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.