### PR TITLE
Added additional conditional check for $field[‘desc’] #1668

### DIFF
--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -758,8 +758,18 @@ function give_get_field_value( $field, $postid ) {
  */
 function give_get_field_description( $field ) {
 	$field_desc_html = '';
-	if ( ! empty( $field['description'] ) ) {
-		$field_desc_html = '<span class="give-field-description">' . wp_kses_post( $field['description'] ) . '</span>';
+	$description     = '';
+
+	// Check for both `description` and `desc`.
+	if ( isset( $field['description'] ) ) {
+		$description = $field['description'];
+	} elseif ( isset( $field['desc'] ) ) {
+		$description = $field['desc'];
+	}
+
+	// Set if there is a description.
+	if ( ! empty( $description ) ) {
+		$field_desc_html = '<span class="give-field-description">' . wp_kses_post( $description ) . '</span>';
 	}
 
 	return $field_desc_html;


### PR DESCRIPTION
## Description
Give now supports `desc` along with `description` via the `give_get_field_description()` function. 

Fixesd #1668 