### PR TITLE
Fix: add missing fx give_get_currency_name

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -203,6 +203,28 @@ function give_currency_symbol( $currency = '' ) {
 
 
 /**
+ * Get currency name.
+ *
+ * @since 1.8.8
+ *
+ * @param string $currency_code
+ *
+ * @return string
+ */
+function give_get_currency_name( $currency_code ) {
+	$currency_name = '';
+	$currency_names = give_get_currencies();
+
+	if( $currency_code && array_key_exists( $currency_code, $currency_names ) ) {
+		$currency_name = explode( '(',  $currency_names[$currency_code] );
+		$currency_name = trim( current( $currency_name ) );
+	}
+
+	return apply_filters( 'give_currency_name', $currency_name, $currency_code );
+}
+
+
+/**
  * Get the current page URL
  *
  * @since 1.0

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @group formatting
+ */
+class Tests_MISC_Functions extends Give_Unit_Test_Case {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+
+	/**
+	 * test for give_get_currency_name
+	 *
+	 * @since         1.8.8
+	 * @access        public
+	 *
+	 * @param string $value
+	 * @param string $expected
+	 *
+	 * @cover         give_get_currency_name
+	 * @dataProvider  give_get_currency_name_data_provider
+	 */
+	public function test_give_get_currency_name( $value, $expected ) {
+		$this->assertEquals( $expected, $value );
+	}
+
+
+	/**
+	 * Data Provider
+	 * @todo  Add more currencies for testing.
+	 *
+	 * @since 1.8.8
+	 * @return array
+	 */
+	public function give_get_currency_name_data_provider() {
+		return array(
+			array( give_get_currency_name( 'USD' ), __( 'US Dollars', 'give' ) ),
+			array( give_get_currency_name( 'GBP' ), __( 'Pounds Sterling', 'give' ) ),
+			array( give_get_currency_name( 'TWD' ), __( 'Taiwan New Dollars', 'give' ) ),
+			array( give_get_currency_name( 'Wrong_Currency_Symbol' ), '' ),
+		);
+	}
+}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will fix #1670

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.