### PR TITLE
Add post type meta data related functions

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1104,3 +1104,67 @@ function give_delete_donation_stats( $date_range = '', $args = array() ) {
 
 	return $status;
 }
+
+
+/**
+ * Get Form/Payment meta.
+ * @todo: implement in core
+ *
+ * @since 1.8.8
+ *
+ * @param int    $id
+ * @param string $meta_key
+ * @param bool   $single
+ * @param bool   $default
+ *
+ * @return mixed
+ */
+function give_get_meta( $id, $meta_key, $single = false, $default = false ) {
+	$meta_value = get_post_meta( $id, $meta_key, $single );
+
+	if (
+		( empty( $meta_key ) || empty( $meta_value ) )
+		&& $default
+	) {
+		$meta_value = $default;
+	}
+
+
+	return apply_filters( 'give_get_meta', $meta_value, $id, $meta_key, $default );
+}
+
+/**
+ * Update Form/Payment meta.
+ * @todo: implement in core
+ *
+ * @since 1.8.8
+ *
+ * @param int    $id
+ * @param string $meta_key
+ * @param string $meta_value
+ *
+ * @return mixed
+ */
+function give_update_meta( $id, $meta_key, $meta_value ) {
+	$status = update_post_meta( $id, $meta_key, $meta_value );
+
+	return apply_filters( 'give_update_meta', $status, $id, $meta_key, $meta_value );
+}
+
+/**
+ * Delete Form/Payment meta.
+ * @todo: implement in core
+ *
+ * @since 1.8.8
+ *
+ * @param int    $id
+ * @param string $meta_key
+ * @param string $meta_value
+ *
+ * @return mixed
+ */
+function give_delete_meta( $id, $meta_key, $meta_value = '' ) {
+	$status = delete_post_meta( $id, $meta_key, $meta_value );
+
+	return apply_filters( 'give_delete_meta', $status, $id, $meta_key, $meta_value );
+}

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -32,6 +32,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 
 	/**
 	 * Data Provider
+	 *
 	 * @todo  Add more currencies for testing.
 	 *
 	 * @since 1.8.8
@@ -44,5 +45,37 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 			array( give_get_currency_name( 'TWD' ), __( 'Taiwan New Dollars', 'give' ) ),
 			array( give_get_currency_name( 'Wrong_Currency_Symbol' ), '' ),
 		);
+	}
+
+	/**
+	 * test for give post type meta related functions
+	 *
+	 * @since         1.8.8
+	 * @access        public
+	 *
+	 * @cover         give_get_meta
+	 * @cover         give_update_meta
+	 * @cover         give_delete_meta
+	 */
+	public function test_give_meta_helpers() {
+		$payment = Give_Helper_Payment::create_simple_payment();
+
+		$value = give_get_meta( $payment, 'testing_meta', true, 'TEST1' );
+		$this->assertEquals( 'TEST1', $value );
+
+		$status = give_update_meta( $payment, 'testing_meta', 'TEST' );
+		$this->assertEquals( true, (bool) $status );
+
+		$status = give_update_meta( $payment, 'testing_meta', 'TEST' );
+		$this->assertEquals( false, (bool) $status );
+
+		$value = give_get_meta( $payment, 'testing_meta', true );
+		$this->assertEquals( 'TEST', $value );
+
+		$status = give_delete_meta( $payment, 'testing_meta', 'TEST2' );
+		$this->assertEquals( false, $status );
+
+		$status = give_delete_meta( $payment, 'testing_meta' );
+		$this->assertEquals( true, $status );
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
@DevinWalker I think it will be good to have wrapper function around WordPress post meta related functions. It will help us to provide backward compatibility easily in future.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Added New functions
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.