### PR TITLE
Add WPML config file

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,26 @@
+<wpml-config>
+  <custom-types>
+    <custom-type translate="1">give_forms</custom-type>
+    <custom-type translate="0">give_payment</custom-type>
+    <custom-type translate="0">give_log</custom-type>
+  </custom-types>
+  <taxonomies>
+    <taxonomy translate="0">give_log_type</taxonomy>
+  </taxonomies>
+  <admin-texts>
+    <key name="give_settings">
+      <key name="success_page"/>
+      <key name="failure_page"/>
+      <key name="history_page"/>
+      <key name="global_offline_donation_content"/>
+      <key name="donation_notification"/>
+      <key name="donation_receipt"/>
+      <key name="offline_donation_subject"/>
+      <key name="global_offline_donation_email"/>
+      <key name="subscription_notification_subject"/>
+      <key name="subscription_receipt_message"/>
+      <key name="subscription_cancelled_subject"/>
+      <key name="subscription_cancelled_message"/>
+    </key>
+  </admin-texts>
+</wpml-config>


### PR DESCRIPTION
## Description
Added WPML config file.

## How Has This Been Tested?
Custom Post Types and Taxonomies translation state should be automatically selected and disabled for users to change.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [] My code follows has proper inline documentation.