### PR TITLE
Tabs, not spaces

### DIFF
--- a/give.php
+++ b/give.php
@@ -372,9 +372,9 @@ if ( ! class_exists( 'Give' ) ) :
 			require_once GIVE_PLUGIN_DIR . 'includes/emails/template.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/emails/actions.php';
 
-            if( defined( 'WP_CLI' ) && WP_CLI ) {
-                require_once GIVE_PLUGIN_DIR . 'includes/class-give-cli-commands.php';
-            }
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				require_once GIVE_PLUGIN_DIR . 'includes/class-give-cli-commands.php';
+			}
 
 			if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 


### PR DESCRIPTION
There were spaces instead of tabs, and the code didn't line up with the rest of the code in the function.

## Description
I converted spaces to tabs to adhere to proper WordPress coding standards.

## How Has This Been Tested?
No need to test. This was just a small coding style change.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Coding style change.

## Checklist:
- [ x ] My code is tested. (N/A)
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows has proper inline documentation. (N/A)