### PR TITLE
Hotfix/graph

### DIFF
--- a/includes/admin/reporting/class-give-graph.php
+++ b/includes/admin/reporting/class-give-graph.php
@@ -77,10 +77,13 @@ class Give_Graph {
 	 * Get things started
 	 *
 	 * @since 1.0
+	 *
+	 * @param array $_data
+	 * @param array $options
 	 */
-	public function __construct( $_data ) {
+	public function __construct( $_data, $options = array() ) {
 
-		$this->data = $_data;
+		$this->data      = $_data;
 
 		// Generate unique ID
 		$this->id = md5( rand() );
@@ -102,9 +105,11 @@ class Give_Graph {
 			'borderwidth'     => 1,
 			'bars'            => true,
 			'lines'           => false,
-			'points'          => true
+			'points'          => true,
+			'dataType'        => array()
 		) );
 
+		$this->options = wp_parse_args( $options, $this->options );
 	}
 
 	/**
@@ -190,6 +195,7 @@ class Give_Graph {
 						{
 							label : "<?php echo esc_attr( $label ); ?>",
 							id    : "<?php echo sanitize_key( $label ); ?>",
+							dataType  : '<?php echo ( ! empty( $this->options['dataType'][$order] ) ? $this->options['dataType'][$order] : '' ); ?>',
 							// data format is: [ point on x, value on y ]
 							data  : [<?php foreach( $data as $point ) { echo '[' . implode( ',', $point ) . '],'; } ?>],
 							points: {
@@ -269,15 +275,15 @@ class Give_Graph {
 					$( "#x" ).text( pos.x.toFixed( 2 ) );
 					$( "#y" ).text( pos.y.toFixed( 2 ) );
 					if ( item ) {
-						if ( previousPoint != item.dataIndex ) {
+						if ( previousPoint !== item.dataIndex ) {
 							previousPoint = item.dataIndex;
 							$( "#give-flot-tooltip" ).remove();
 							var x = item.datapoint[0].toFixed( 2 ),
                                 y = accounting.formatMoney( item.datapoint[1].toFixed( give_vars.currency_decimals ), '', give_vars.currency_decimals, give_vars.thousands_separator, give_vars.decimal_separator );
 
-							if ( item.series.id == 'income' ) {
+							if ( item.series.dataType.length &&  item.series.dataType === 'amount' ) {
 
-								if ( give_vars.currency_pos == 'before' ) {
+								if ( give_vars.currency_pos === 'before' ) {
 
 									give_flot_tooltip( item.pageX, item.pageY, item.series.label + ' ' + give_vars.currency_sign + y );
 								} else {

--- a/includes/admin/reporting/class-give-graph.php
+++ b/includes/admin/reporting/class-give-graph.php
@@ -195,7 +195,7 @@ class Give_Graph {
 						{
 							label : "<?php echo esc_attr( $label ); ?>",
 							id    : "<?php echo sanitize_key( $label ); ?>",
-							dataType  : '<?php echo ( ! empty( $this->options['dataType'][$order] ) ? $this->options['dataType'][$order] : '' ); ?>',
+							dataType  : '<?php echo ( ! empty( $this->options['dataType'][$order] ) ? $this->options['dataType'][$order] : 'count' ); ?>',
 							// data format is: [ point on x, value on y ]
 							data  : [<?php foreach( $data as $point ) { echo '[' . implode( ',', $point ) . '],'; } ?>],
 							points: {

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -191,7 +191,7 @@ function give_reports_graph() {
 				<div class="inside">
 					<?php give_reports_graph_controls(); ?>
 					<?php
-					$graph = new Give_Graph( $data );
+					$graph = new Give_Graph( $data, array( 'dataType' => array( 'amount', 'count' ) ) );
 					$graph->set( 'x_mode', 'time' );
 					$graph->set( 'multiple_y_axes', true );
 					$graph->display();
@@ -441,7 +441,7 @@ function give_reports_graph_of_form( $form_id = 0 ) {
 				<div class="inside">
 					<?php give_reports_graph_controls(); ?>
 					<?php
-					$graph = new Give_Graph( $data );
+					$graph = new Give_Graph( $data, array( 'dataType' => array( 'amount', 'count' ) ) );
 					$graph->set( 'x_mode', 'time' );
 					$graph->set( 'multiple_y_axes', true );
 					$graph->display();


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Currently, graph code is hard coded around income report, so if we use `Graph` class to generate a graph for other data it will not render proper amount formatting.
for ref: https://github.com/WordImpress/Give-Fee-Recovery/issues/40

Currently, I allow the developer to define their own option values for the graph in which developer can define `dataType` which helps in rendering correct formatting for the amount.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. View income for different dates
2. View income for specific donation form

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.