### PR TITLE
Issues/1680

### DIFF
--- a/includes/price-functions.php
+++ b/includes/price-functions.php
@@ -56,6 +56,28 @@ function give_get_variable_prices( $form_id = 0 ) {
 
 }
 
+/**
+ * Retrieves the variable price ids for a form
+ *
+ * @since 1.8.8
+ *
+ * @param int $form_id ID of the Give form
+ *
+ * @return array Variable prices
+ */
+function give_get_variable_price_ids( $form_id = 0 ) {
+	if( ! ( $prices = give_get_variable_prices( $form_id ) ) ) {
+		return array();
+	}
+
+	$price_ids = array();
+	foreach ( $prices as $price ){
+		$price_ids[] = $price['_give_id']['level_id'];
+	}
+
+	return $price_ids;
+}
+
 
 /**
  * Get the default amount for multi-level forms

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -377,10 +377,10 @@ function give_verify_minimum_price() {
 
 	$amount          = give_sanitize_amount( $_REQUEST['give-amount'] );
 	$form_id         = isset( $_REQUEST['give-form-id'] ) ? $_REQUEST['give-form-id'] : 0;
-	$price_id        = isset( $_REQUEST['give-price-id'] ) ? $_REQUEST['give-price-id'] : 0;
+	$price_id        = isset( $_REQUEST['give-price-id'] ) ? $_REQUEST['give-price-id'] : null;
 	$variable_prices = give_has_variable_prices( $form_id );
 
-	if ( $variable_prices && ! empty( $price_id ) ) {
+	if ( $variable_prices && in_array( $price_id, give_get_variable_price_ids( $form_id ) ) ) {
 
 		$price_level_amount = give_get_price_option_amount( $form_id, $price_id );
 
@@ -389,9 +389,7 @@ function give_verify_minimum_price() {
 		}
 	}
 
-	$minimum = give_get_form_minimum_price( $form_id );
-
-	if ( $minimum > $amount ) {
+	if ( give_get_form_minimum_price( $form_id ) > $amount ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will #1680 

@DevinWalker Removing `$price_id` check from `give_verify_minimum_price()` function is not a good solution. for ref: https://github.com/WordImpress/Give/pull/1728/commits/00e7130d684275a9d0ff52f7b05d3d0f3176067c because in the case of `custom` price it will check minimum amount with form minimum amount and price levels amount. It should only check for form minimum amount in case of `custom` amount.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.