### PR TITLE
Code updates to PR #1730

### DIFF
--- a/includes/admin/welcome.php
+++ b/includes/admin/welcome.php
@@ -204,7 +204,7 @@ class Give_Welcome {
 
                     <h4>Find Out More:</h4>
                     <ul class="ul-disc">
-                        <li><a href="https://givewp.com/features/" target="_blank"><?php esc_html_e( 'Visit the Give Website', 'give' ); ?></a></li>
+                        <li><a href="https://givewp.com/" target="_blank"><?php esc_html_e( 'Visit the Give Website', 'give' ); ?></a></li>
                         <li><a href="https://givewp.com/features/" target="_blank"><?php esc_html_e( 'View the Give Features', 'give' ); ?></a></li>
                         <li><a href="https://givewp.com/documentation/" target="_blank"><?php esc_html_e( 'Read the Documentation', 'give' ); ?></a></li>
                     </ul>

--- a/includes/api/class-give-api.php
+++ b/includes/api/class-give-api.php
@@ -215,7 +215,7 @@ class Give_API {
 	 *
 	 * @access public
 	 * @since  1.1
-	 * @return string
+	 * @return array
 	 */
 	public function get_versions() {
 		return $this->versions;

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -73,7 +73,7 @@ function give_purchase_form_validate_agree_to_terms() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_agree_to_terms', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_agree_to_terms();
@@ -90,7 +90,7 @@ function give_purchase_form_validate_logged_in_user() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_logged_in_user', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_logged_in_user();
@@ -107,7 +107,7 @@ function give_purchase_form_validate_gateway() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_gateway', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_gateway();
@@ -124,7 +124,7 @@ function give_purchase_form_validate_fields() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_fields', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_fields();
@@ -141,7 +141,7 @@ function give_purchase_form_validate_cc() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_cc', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_cc();
@@ -158,7 +158,7 @@ function give_get_purchase_cc_info() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_get_donation_cc_info', $backtrace );
 
 	// Call new renamed function.
 	give_get_donation_cc_info();
@@ -179,7 +179,7 @@ function give_purchase_form_validate_cc_zip( $zip = 0, $country_code = '' ) {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_cc_zip', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_cc_zip( $zip, $country_code );
@@ -196,7 +196,7 @@ function give_purchase_form_validate_user_login() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_user_login', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_user_login();
@@ -213,7 +213,7 @@ function give_purchase_form_validate_guest_user() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_guest_user', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_guest_user();
@@ -230,7 +230,7 @@ function give_purchase_form_validate_new_user() {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_donation_form_validate_new_user', $backtrace );
 
 	// Call new renamed function.
 	give_donation_form_validate_new_user();
@@ -250,7 +250,7 @@ function give_get_purchase_form_user( $valid_data = array() ) {
 
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_get_donation_form_user', $backtrace );
 
 	// Call new renamed function.
 	give_get_donation_form_user( $valid_data );
@@ -272,16 +272,8 @@ function give_get_purchase_form_user( $valid_data = array() ) {
 function give_checkout_button_purchase( $form_id ) {
 	$backtrace = debug_backtrace();
 
-	_give_deprecated_function( __FUNCTION__, '1.8.8', null, $backtrace );
+	_give_deprecated_function( __FUNCTION__, '1.8.8', 'give_get_donation_form_submit_button', $backtrace );
 
-	$display_label_field = give_get_meta( $form_id, '_give_checkout_label', true );
-	$display_label       = ( ! empty( $display_label_field ) ? $display_label_field : esc_html__( 'Donate Now', 'give' ) );
-	ob_start(); ?>
-	<div class="give-submit-button-wrap give-clearfix">
-		<input type="submit" class="give-submit give-btn" id="give-purchase-button" name="give-purchase"
-		       value="<?php echo $display_label; ?>"/>
-		<span class="give-loading-animation"></span>
-	</div>
-	<?php
-	return apply_filters( 'give_checkout_button_purchase', ob_get_clean(), $form_id );
+	return give_get_donation_form_submit_button( $form_id );
+
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -563,7 +563,7 @@ function _give_deprecated_function( $function, $version, $replacement = null, $b
 
 	$show_errors = current_user_can( 'manage_options' );
 
-	// Allow plugin to filter the output error trigger
+	// Allow plugin to filter the output error trigger.
 	if ( WP_DEBUG && apply_filters( 'give_deprecated_function_trigger_error', $show_errors ) ) {
 		if ( ! is_null( $replacement ) ) {
 			trigger_error( sprintf( __( '%1$s is <strong>deprecated</strong> since Give version %2$s! Use %3$s instead.', 'give' ), $function, $version, $replacement ) );


### PR DESCRIPTION
## Description
1. Using renamed function within deprecated function
2. Providing the `replacement` param within `_give_deprecated_function()`