### PR TITLE
Refactor: goal template and add extra params to filters

### DIFF
--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -3,29 +3,39 @@
  * This template is used to display the goal with [give_goal]
  */
 
-$goal_option = give_get_meta( $form_id, '_give_goal_option', true );
 $form        = new Give_Donate_Form( $form_id );
-$goal        = $form->goal;
+$goal_option = give_get_meta( $form->ID, '_give_goal_option', true );
+
+//Sanity check - ensure form has pass all condition to show goal.
+if (
+	( isset( $args['show_goal'] ) &&  ! filter_var( $args['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
+	|| empty( $form->ID )
+	|| ( is_singular( 'give_forms' ) && ! give_is_setting_enabled( $goal_option ) )
+	|| ! give_is_setting_enabled( $goal_option )
+	|| 0 === $form->goal
+) {
+	return false;
+}
+
 $goal_format = give_get_meta( $form_id, '_give_goal_format', true );
-$income      = $form->get_earnings();
 $color       = give_get_meta( $form_id, '_give_goal_color', true );
 $show_text   = isset( $args['show_text'] ) ? filter_var( $args['show_text'], FILTER_VALIDATE_BOOLEAN ) : true;
 $show_bar    = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
 
-//Sanity check - respect shortcode args
-if ( isset( $args['show_goal'] ) && $args['show_goal'] === false ) {
-	return false;
-}
 
-//Sanity check - ensure form has goal set to output
-if ( empty( $form->ID )
-	|| ( is_singular( 'give_forms' ) && ! give_is_setting_enabled( $goal_option ) )
-	|| ! give_is_setting_enabled( $goal_option )
-	|| $goal == 0
-) {
-	//not this form, bail
-	return false;
-}
+/**
+ * Filter the form income
+ *
+ * @since 1.8.8
+ */
+$income = apply_filters( 'give_goal_amount_raised_output', $form->get_earnings(), $form_id, $form );
+
+/**
+ * Filter the form
+ *
+ * @since 1.8.8
+ */
+$goal = apply_filters( 'give_goal_amount_target_output', $form->goal, $form_id, $form );
 
 
 /**
@@ -35,6 +45,8 @@ if ( empty( $form->ID )
  */
 $progress = apply_filters( 'give_goal_amount_funded_percentage_output', round( ( $income / $goal ) * 100, 2 ), $form_id, $form );
 
+
+// Set progress to 100 percentage if income > goal.
 if ( $income >= $goal ) {
 	$progress = 100;
 }
@@ -48,13 +60,13 @@ if ( $income >= $goal ) {
 
 				// Get formatted amount.
 				$income = give_human_format_large_amount( give_format_amount( $income ) );
-				$goal = give_human_format_large_amount( give_format_amount( $goal ) );
+				$goal   = give_human_format_large_amount( give_format_amount( $goal ) );
 
 				echo sprintf(
 				/* translators: 1: amount of income raised 2: goal target ammount */
 					__( '%1$s of %2$s raised', 'give' ),
-					'<span class="income">' . apply_filters( 'give_goal_amount_raised_output', give_currency_filter( $income ) ) . '</span>',
-					'<span class="goal-text">' . apply_filters( 'give_goal_amount_target_output', give_currency_filter( $goal ) ) . '</span>'
+					'<span class="income">' . give_currency_filter( $income ) . '</span>',
+					'<span class="goal-text">' . give_currency_filter( $goal ) . '</span>'
 				);
 
 
@@ -73,8 +85,10 @@ if ( $income >= $goal ) {
 
 
 	<?php if ( ! empty( $show_bar ) ) : ?>
-		<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php  echo esc_attr( $progress ); ?>">
-			<span style="width: <?php  echo esc_attr( $progress ); ?>%;<?php if ( ! empty( $color ) )  echo 'background-color:' . $color; ?>"></span>
+		<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr( $progress ); ?>">
+			<span style="width: <?php echo esc_attr( $progress ); ?>%;<?php if ( ! empty( $color ) ) {
+				echo 'background-color:' . $color;
+			} ?>"></span>
 		</div><!-- /.give-progress-bar -->
 	<?php endif; ?>
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Following filter do not have `$form_id` as an argument, so the developer can feel difficult to customize it.
https://github.com/WordImpress/Give/blob/master/templates/shortcode-goal.php#L50
https://github.com/WordImpress/Give/blob/master/templates/shortcode-goal.php#L51

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.