### PR TITLE
Ensure Give() function is run on `plugin_loaded` action hook so other…

### DIFF
--- a/give.php
+++ b/give.php
@@ -489,5 +489,4 @@ function Give() {
 	return Give::instance();
 }
 
-// Get Give Running
-Give();
+add_action('plugins_loaded', 'Give');


### PR DESCRIPTION
## Description
Resolved compatibility issue with WPML #1609 by ensuring `Give()` is ran on `plugins_loaded` rather than earlier.

## How Has This Been Tested?
As described in issue. Also tested with add-ons to ensure compatibility. 

## Types of changes
- Compatibility update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.