### PR TITLE
Issue/1772 - Give initialization improvement and resolving install issue

### DIFF
--- a/give.php
+++ b/give.php
@@ -217,7 +217,7 @@ if ( ! class_exists( 'Give' ) ) :
 		 */
 		private function init_hooks() {
 			register_activation_hook( __FILE__, 'give_install' );
-			add_action( 'init', array( $this, 'init' ), 0 );
+			add_action( 'plugins_loaded', array( $this, 'init' ), 0 );
 		}
 		/**
 		 * Init Give when WordPress Initializes.

--- a/give.php
+++ b/give.php
@@ -33,10 +33,10 @@
  * Give is a tribute to the spirit and philosophy of Open Source. We at WordImpress gladly embrace the Open Source philosophy both
  * in how Give itself was developed, and how we hope to see others build more from our code base.
  *
- * Give would not have been possible without the tireless efforts of WordPress and the surrounding Open Source projects and their talented developers. Thank you all for your contribution to WordPress.
+ * Give would not have been possible without the tireless efforts of WordPress and the surrounding Open Source projects and their talented developers. Thank you all for your
+ * contribution to WordPress.
  *
  * - The WordImpress Team
- *
  */
 
 // Exit if accessed directly.
@@ -52,6 +52,7 @@ if ( ! class_exists( 'Give' ) ) :
 	 * @since 1.0
 	 */
 	final class Give {
+
 		/** Singleton *************************************************************/
 
 		/**
@@ -62,7 +63,7 @@ if ( ! class_exists( 'Give' ) ) :
 		 *
 		 * @var    Give() The one true Give
 		 */
-		private static $instance;
+		protected static $_instance;
 
 		/**
 		 * Give Roles Object
@@ -179,53 +180,83 @@ if ( ! class_exists( 'Give' ) ) :
 		/**
 		 * Main Give Instance
 		 *
-		 * Insures that only one instance of Give exists in memory at any one
+		 * Ensures that only one instance of Give exists in memory at any one
 		 * time. Also prevents needing to define globals all over the place.
 		 *
 		 * @since     1.0
 		 * @access    public
 		 *
 		 * @static
-		 * @staticvar array $instance
-		 * @uses      Give::setup_constants() Setup the constants needed.
-		 * @uses      Give::includes() Include the required files.
-		 * @uses      Give::load_textdomain() load the language files.
 		 * @see       Give()
 		 *
 		 * @return    Give
 		 */
 		public static function instance() {
-			if ( ! isset( self::$instance ) && ! ( self::$instance instanceof Give ) ) {
-				self::$instance = new Give();
-				self::$instance->setup_constants();
-
-				add_action( 'plugins_loaded', array( self::$instance, 'load_textdomain' ) );
-
-				self::$instance->includes();
-				self::$instance->roles           = new Give_Roles();
-				self::$instance->api             = new Give_API();
-				self::$instance->give_settings   = new Give_Admin_Settings();
-				self::$instance->session         = new Give_Session();
-				self::$instance->html            = new Give_HTML_Elements();
-				self::$instance->emails          = new Give_Emails();
-				self::$instance->email_tags      = new Give_Email_Template_Tags();
-				self::$instance->donors          = new Give_DB_Donors();
-				self::$instance->donor_meta   = new Give_DB_Donor_Meta();
-				self::$instance->template_loader = new Give_Template_Loader();
-				self::$instance->email_access    = new Give_Email_Access();
-
-
-				/**
-				 * Fire the action after Give core loads.
-				 *
-				 * @param class Give class instance.
-				 * @since 1.8.7
-				 */
-				do_action( 'give_init', self::$instance );
-
+			if ( is_null( self::$_instance ) ) {
+				self::$_instance = new self();
 			}
 
-			return self::$instance;
+			return self::$_instance;
+		}
+
+		/**
+		 * Give Constructor.
+		 */
+		public function __construct() {
+			$this->setup_constants();
+			$this->includes();
+			$this->init_hooks();
+
+			do_action( 'give_loaded' );
+		}
+
+		/**
+		 * Hook into actions and filters.
+		 *
+		 * @since  1.8.9
+		 */
+		private function init_hooks() {
+			register_activation_hook( __FILE__, 'give_install' );
+			add_action( 'init', array( $this, 'init' ), 0 );
+		}
+		/**
+		 * Init Give when WordPress Initializes.
+		 *
+		 * @since 1.8.9
+		 */
+		public function init() {
+
+			/**
+			 * Fires before the Give core is initialized.
+			 *
+			 * @since 1.8.9
+			 */
+			do_action( 'before_give_init' );
+
+			// Set up localization.
+			$this->load_textdomain();
+
+			$this->roles           = new Give_Roles();
+			$this->api             = new Give_API();
+			$this->give_settings   = new Give_Admin_Settings();
+			$this->session         = new Give_Session();
+			$this->html            = new Give_HTML_Elements();
+			$this->emails          = new Give_Emails();
+			$this->email_tags      = new Give_Email_Template_Tags();
+			$this->donors          = new Give_DB_Donors();
+			$this->donor_meta      = new Give_DB_Donor_Meta();
+			$this->template_loader = new Give_Template_Loader();
+			$this->email_access    = new Give_Email_Access();
+
+			/**
+			 * Fire the action after Give core loads.
+			 *
+			 * @param class Give class instance.
+			 *
+			 * @since 1.8.7
+			 */
+			do_action( 'give_init', $this );
+
 		}
 
 		/**
@@ -428,7 +459,7 @@ if ( ! class_exists( 'Give' ) ) :
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
 				require_once GIVE_PLUGIN_DIR . 'includes/admin/upgrades/upgrades.php';
 
-			}
+			}// End if().
 
 			require_once GIVE_PLUGIN_DIR . 'includes/install.php';
 
@@ -489,4 +520,4 @@ function Give() {
 	return Give::instance();
 }
 
-add_action('plugins_loaded', 'Give');
+Give();

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -61,7 +61,7 @@ function give_post_actions() {
 	$_post_action = ! empty( $_POST['give_action'] ) ? $_POST['give_action'] : null;
 
 
-	// Add backward compatibility to give-action param ( $_POST )
+	// Add backward compatibility to give-action param ( $_POST ).
 	if(  empty( $_post_action ) ) {
 		$_post_action = ! empty( $_POST['give-action'] ) ? $_POST['give-action'] : null;
 	}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -468,8 +468,11 @@ add_action( 'admin_init', 'give_v152_cleanup_users' );
  * @return void
  */
 function give_v16_upgrades() {
-	@Give()->donors->create_table();
-	@Give()->donor_meta->create_table();
+	// Create the donor databases.
+	$donors_db = new Give_DB_Donors();
+	$donors_db->create_table();
+	$donor_meta = new Give_DB_Donor_Meta();
+	$donor_meta->create_table();
 }
 
 /**

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -262,7 +262,7 @@ function give_load_email_tags() {
 	do_action( 'give_add_email_tags' );
 }
 
-add_action( 'init', 'give_load_email_tags', - 999 );
+add_action( 'init', 'give_load_email_tags' );
 
 /**
  * Add default Give email template tags.

--- a/includes/install.php
+++ b/includes/install.php
@@ -48,8 +48,6 @@ function give_install( $network_wide = false ) {
 
 }
 
-register_activation_hook( GIVE_PLUGIN_FILE, 'give_install' );
-
 /**
  * Run the Give Install process.
  *
@@ -157,11 +155,14 @@ function give_run_install() {
 	update_option( 'give_default_api_version', 'v' . $api->get_version() );
 
 	// Create the donor databases.
-	@Give()->donors->create_table();
-	@Give()->donor_meta->create_table();
+	$donors_db = new Give_DB_Donors();
+	$donors_db->create_table();
+	$donor_meta = new Give_DB_Donor_Meta();
+	$donor_meta->create_table();
 
 	// Check for PHP Session support, and enable if available.
-	Give()->session->use_php_sessions();
+	$give_sessions = new Give_Session();
+	$give_sessions->use_php_sessions();
 
 	// Add a temporary option to note that Give pages have been created.
 	Give_Cache::set( '_give_installed', $options, 30, true );
@@ -193,8 +194,6 @@ function give_run_install() {
 	Give_Cache::set( '_give_activation_redirect', true, 30, true );
 
 }
-
-register_activation_hook( GIVE_PLUGIN_FILE, 'give_install' );
 
 /**
  * Network Activated New Site Setup.

--- a/tests/unit-tests/tests-give.php
+++ b/tests/unit-tests/tests-give.php
@@ -19,7 +19,7 @@ class Tests_Give extends Give_Unit_Test_Case {
 	 * @covers Give
 	 */
 	public function test_give_instance() {
-		$this->assertClassHasStaticAttribute( 'instance', 'Give' );
+		$this->assertClassHasStaticAttribute( '_instance', 'Give' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
I refactored how Give is initialized so that we're loading it at the proper point of time when WP is ready. 

### Highlights
- `$instance` is now `protected static $_instance` 
- New `private function init_hooks()`
- Additional hooks added for `before_give_init` and `give_loaded`
- Fixed issues with using `@Give` within `install.php` 

**Note:** A lot of the code is inspired by WooCommerce's method of loading which is quite clean and efficient. If you take a look at their main file, you'll see what I mean.

## How Has This Been Tested?
Manually and PHPunit tests.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code optimization

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.