### PR TITLE
i18n Banner Displays Per User's Locale

### DIFF
--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -72,32 +72,33 @@ class Give_i18n_Banner {
 			return;
 		}
 
+		foreach ( $args as $key => $arg ) {
+			$this->$key = $arg;
+		}
+
+		add_action( 'admin_init', array( $this, 'init' ) );
+
+
+	}
+
+	/**
+	 * Initialize i18n banner.
+	 */
+	function init() {
+
+		// First get user's locale (4.7+).
+		$this->locale = function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale();
+
 		// This plugin is en_US native.
-		$this->locale = get_locale();
 		if ( 'en_US' === $this->locale ) {
 			return;
 		}
-
-		$this->init( $args );
 
 		if ( ! $this->hide_promo() ) {
 			add_action( $this->hook, array( $this, 'promo' ) );
 		}
 	}
 
-	/**
-	 * This is where you decide where to display the messages and where you set the plugin specific variables.
-	 *
-	 * @access private
-	 *
-	 * @param array $args
-	 */
-	private function init( $args ) {
-		foreach ( $args as $key => $arg ) {
-			$this->$key = $arg;
-		}
-
-	}
 
 	/**
 	 * Check whether the promo should be hidden or not.
@@ -209,15 +210,17 @@ class Give_i18n_Banner {
 				body.rtl .give-i18n-notice-content {
 					margin: 0 125px 0 30px;
 				}
+
 				body.rtl div.give-addon-alert .dismiss {
-					left:20px;
-					right:auto;
+					left: 20px;
+					right: auto;
 				}
 
 			</style>
 			<div id="give-i18n-notice" class="give-addon-alert updated" style="">
 
-				<a href="https://wordpress.org/support/register.php" class="alignleft give-i18n-icon" style="margin:0" target="_blank"><span class="dashicons dashicons-translation" style="font-size: 110px; text-decoration: none;"></span></a>
+				<a href="https://wordpress.org/support/register.php" class="alignleft give-i18n-icon" style="margin:0" target="_blank"><span class="dashicons dashicons-translation"
+				                                                                                                                             style="font-size: 110px; text-decoration: none;"></span></a>
 
 				<div class="give-i18n-notice-content">
 					<a href="<?php echo esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ); ?>" class="dismiss"><span class="dashicons dashicons-dismiss"></span></a>
@@ -321,9 +324,7 @@ class Give_i18n_Banner {
 	}
 }
 
-$give_i18n = new Give_i18n_Banner(
-	array(
+$give_i18n = new Give_i18n_Banner( array(
 		'hook'          => 'give_forms_page_give-settings',
 		'glotpress_url' => 'https://translate.wordpress.org/api/projects/wp-plugins/give/stable/',
-	)
-);
+	) );


### PR DESCRIPTION
## PR Overview
1. Added `init` method to properly get user's locale (it was loading before WP was ready prior).
2. Removed unnecessary arg method

## How Has This Been Tested?
Manually

## Types of changes
<!-- What types of changes does your code introduce?  -->
- i18n improvement for 4.7+ `get_users_locale()` function
- Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.