### PR TITLE
Fix #1801

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -577,6 +577,11 @@ class Give_Payment_History_Table extends WP_List_Table {
 			$ids = array( $ids );
 		}
 
+		// Return if donation id is set as false.
+		if ( is_array( $ids ) && false === $ids[0] ) {
+			return;
+		}
+
 		if ( empty( $action ) ) {
 			return;
 		}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
@DevinWalker , @ravinderk I have Fixed #1801 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
I have tested with select bulk option with status and not checked any donation as per describe issue, new donation was created but after fix no new donation will create,
<!-- Include details of your testing environment, tests ran to see how -->
Tested with WordPress 4.8 and Give lateste release 1.8.9 branch.
<!-- your change affects other areas of the code, etc. -->
I have tested with all cases and it will not affect.

## Types of changes
<!-- What types of changes does your code introduce?  -->
In current version it was passed donation id = array(false); while choose any bulk action with no donation select so it will create new donation. 
I have fixed it with checking if id false then return it.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.