### PR TITLE
Issues/1816

### DIFF
--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -1318,7 +1318,17 @@ function give_license_key_callback( $field_object, $escaped_value, $object_id, $
 					$license_status = 'license-' . $class;
 					break;
 			}
-		} else {
+
+		} elseif ( empty( $license->success ) ){
+			$class          = $license->error;
+			$messages[]     = sprintf(
+				__( 'Your %1$s is not active for this URL. Please <a href="%2$s" target="_blank" title="Visit account page">visit your account page</a> to manage your license key URLs.', 'give' ),
+				$addon_name,
+				$account_page_link . '?utm_campaign=admin&utm_source=licenses&utm_medium=invalid'
+			);
+			$license_status = 'license-' . $class;
+
+		}else {
 			switch ( $license->license ) {
 				case 'valid' :
 				default:

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -504,22 +504,26 @@ if ( ! class_exists( 'Give_License' ) ) :
 			// Do not get confused with edd_action check_subscription.
 			// By default edd software licensing api does not have api to check subscription.
 			// This is a custom feature to check subscriptions.
-			if ( ! ( $subscription_data = $this->get_license_info( 'check_subscription' ) ) ) {
+			if ( ! ( $subscription_data = $this->get_license_info( 'check_subscription', true ) ) ) {
 				return;
 			}
 
-			if ( ! empty( $subscription_data->success ) && absint( $subscription_data->success ) ) {
+
+			if ( ! empty( $subscription_data['success'] ) && absint( $subscription_data['success'] ) ) {
 				$subscriptions = get_option( 'give_subscriptions', array() );
 
 				// Update subscription data only if subscription does not exist already.
-				if ( ! array_key_exists( $subscription_data->id, $subscriptions ) ) {
-					$subscriptions[ $subscription_data->id ]             = $subscription_data;
-					$subscriptions[ $subscription_data->id ]['licenses'] = array();
+				$subscriptions[ $subscription_data['id'] ]            = $subscription_data;
+
+
+				// Initiate default set of license for subscription.
+				if( ! isset( $subscriptions[ $subscription_data['id'] ]['licenses'] ) ) {
+					$subscriptions[ $subscription_data['id']]['licenses'] = array();
 				}
 
 				// Store licenses for subscription.
-				if ( ! in_array( $this->license, $subscriptions[ $subscription_data->id ]['licenses'] ) ) {
-					$subscriptions[ $subscription_data->id ]['licenses'][] = $this->license;
+				if ( ! in_array( $this->license, $subscriptions[ $subscription_data['id'] ]['licenses'] ) ) {
+					$subscriptions[ $subscription_data['id']]['licenses'][] = $this->license;
 				}
 
 				update_option( 'give_subscriptions', $subscriptions );
@@ -837,8 +841,8 @@ if ( ! class_exists( 'Give_License' ) ) :
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}
-
-			return json_decode( wp_remote_retrieve_body( $response ) );
+			
+			return json_decode( wp_remote_retrieve_body( $response ), $response_in_array );
 		}
 	}
 

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -826,7 +826,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 
 			// Call the API
 			$response = wp_remote_post(
-				'http://edd.dev/',
+				$this->api_url,
 				array(
 					'timeout'   => 15,
 					'sslverify' => false,

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -597,47 +597,44 @@ if ( ! class_exists( 'Give_License' ) ) :
 						continue;
 					}
 
-					if ( ( 'active' !== $subscription['status'] ) ) {
-
-						// Check if license already expired.
-						if ( strtotime( $subscription['expires'] ) < current_time( 'timestamp', 1 ) ) {
-							Give()->notices->register_notice( array(
-								'id'               => "give-expired-subscription-{$subscription['id']}",
-								'type'             => 'error',
-								'description'      => sprintf(
-									__( 'Your Give add-on license expired for payment <a href="%1$s" target="_blank">#%2$d</a>. <a href="%3$s" target="_blank">Click to renew an existing license</a> or %4$s.', 'give' ),
-									urldecode( $subscription['invoice_url'] ),
-									$subscription['payment_id'],
-									"{$this->checkout_url}?edd_license_key={$subscription['license_key']}&utm_campaign=admin&utm_source=licenses&utm_medium=expired",
-									Give()->notices->get_dismiss_link(array(
-										'title' => __( 'Click here if already renewed', 'give' ),
-										'dismissible_type'      => 'user',
-										'dismiss_interval'      => 'permanent',
-									))
-								),
-								'dismissible_type' => 'user',
-								'dismiss_interval' => 'shortly',
-							) );
-						} else {
-							Give()->notices->register_notice( array(
-								'id'               => "give-expires-subscription-{$subscription['id']}",
-								'type'             => 'error',
-								'description'      => sprintf(
-									__( 'Your Give add-on license will expire in %1$s for payment <a href="%2$s" target="_blank">#%3$d</a>. <a href="%4$s" target="_blank">Click to renew an existing license</a> or %5$s.', 'give' ),
-									human_time_diff( current_time( 'timestamp', 1 ), strtotime( $subscription['expires'] ) ),
-									urldecode( $subscription['invoice_url'] ),
-									$subscription['payment_id'],
-									"{$this->checkout_url}?edd_license_key={$subscription['license_key']}&utm_campaign=admin&utm_source=licenses&utm_medium=expired",
-									Give()->notices->get_dismiss_link(array(
-										'title' => __( 'Click here if already renewed', 'give' ),
-										'dismissible_type'      => 'user',
-										'dismiss_interval'      => 'permanent',
-									))
-								),
-								'dismissible_type' => 'user',
-								'dismiss_interval' => 'shortly',
-							) );
-						}
+					// Check if license already expired.
+					if ( strtotime( $subscription['expires'] ) < current_time( 'timestamp', 1 ) ) {
+						Give()->notices->register_notice( array(
+							'id'               => "give-expired-subscription-{$subscription['id']}",
+							'type'             => 'error',
+							'description'      => sprintf(
+								__( 'Your Give add-on license expired for payment <a href="%1$s" target="_blank">#%2$d</a>. <a href="%3$s" target="_blank">Click to renew an existing license</a> or %4$s.', 'give' ),
+								urldecode( $subscription['invoice_url'] ),
+								$subscription['payment_id'],
+								"{$this->checkout_url}?edd_license_key={$subscription['license_key']}&utm_campaign=admin&utm_source=licenses&utm_medium=expired",
+								Give()->notices->get_dismiss_link(array(
+									'title' => __( 'Click here if already renewed', 'give' ),
+									'dismissible_type'      => 'user',
+									'dismiss_interval'      => 'permanent',
+								))
+							),
+							'dismissible_type' => 'user',
+							'dismiss_interval' => 'shortly',
+						) );
+					} else {
+						Give()->notices->register_notice( array(
+							'id'               => "give-expires-subscription-{$subscription['id']}",
+							'type'             => 'error',
+							'description'      => sprintf(
+								__( 'Your Give add-on license will expire in %1$s for payment <a href="%2$s" target="_blank">#%3$d</a>. <a href="%4$s" target="_blank">Click to renew an existing license</a> or %5$s.', 'give' ),
+								human_time_diff( current_time( 'timestamp', 1 ), strtotime( $subscription['expires'] ) ),
+								urldecode( $subscription['invoice_url'] ),
+								$subscription['payment_id'],
+								"{$this->checkout_url}?edd_license_key={$subscription['license_key']}&utm_campaign=admin&utm_source=licenses&utm_medium=expired",
+								Give()->notices->get_dismiss_link(array(
+									'title' => __( 'Click here if already renewed', 'give' ),
+									'dismissible_type'      => 'user',
+									'dismiss_interval'      => 'permanent',
+								))
+							),
+							'dismissible_type' => 'user',
+							'dismiss_interval' => 'shortly',
+						) );
 					}
 
 					// Stop validation for these license keys.
@@ -829,7 +826,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 
 			// Call the API
 			$response = wp_remote_post(
-				$this->api_url,
+				'http://edd.dev/',
 				array(
 					'timeout'   => 15,
 					'sslverify' => false,
@@ -841,7 +838,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}
-			
+
 			return json_decode( wp_remote_retrieve_body( $response ), $response_in_array );
 		}
 	}

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -806,10 +806,11 @@ if ( ! class_exists( 'Give_License' ) ) :
 		 * @access public
 		 *
 		 * @param string $edd_action
+		 * @param bool   $response_in_array
 		 *
 		 * @return mixed
 		 */
-		public function get_license_info( $edd_action = '' ) {
+		public function get_license_info( $edd_action = '', $response_in_array = false ) {
 			if( empty( $edd_action ) ) {
 				return false;
 			}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will resolve #1816 .
Generally, we get `error` property in EDD API response for any invalid license but in Mehul case, `error` property was not included even if the license was `invalid`. He was not able to reproduce that maybe it is a bug in EDD response but we fixed it in Give core :)

**Wrong response**
```
stdClass Object
(
    [success] => 
    [license] => invalid
    [item_name] => Fee+Recovery
    [checksum] => 8f408dc9a4fec6215a10b27573b25983
)
```

**Correct response**
```
stdClass Object
(
    [success] => 
    [license] => invalid
    [item_name] => Fee+Recovery
    [error] => missing
    [checksum] => 8e270dc98a6d7bd06de63aa59f0214f8
)
```
Now we are handling a case where license does not get success reposnse for a invalid license without error explaination.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Adding various license keys with the combination of multiple subscriptions and single license.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.