### PR TITLE
i18n: Avoid using HTML tags in translation strings

### DIFF
--- a/includes/admin/upgrades/class-give-updates.php
+++ b/includes/admin/upgrades/class-give-updates.php
@@ -234,8 +234,11 @@ class Give_Updates {
 			}
 
 			$menu[ $index ][0] = sprintf(
-				__( 'Donations <span class="update-plugins count-%1$d"><span class="plugin-count">%1$d</span></span>', 'give' ),
-				$this->get_update_count()
+				__( 'Donations %s', 'give' ),
+				sprintf(
+					'<span class="update-plugins count-%1$d"><span class="plugin-count">%1$d</span></span>',
+					$this->get_update_count()
+				)
 			);
 
 			break;


### PR DESCRIPTION
## Description

Replace:

* `Donations <span class="update-plugins count-%1$d"><span class="plugin-count">%1$d</span></span>`

With:

* `Donations %s`

Moving the HTML tags outside of the translation string.
