### PR TITLE
Issue/1997

### DIFF
--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -94,7 +94,7 @@ class Give_i18n_Banner {
 			return;
 		}
 
-		if ( ! $this->hide_promo() ) {
+		if ( ! $this->hide_promo() && ( 'give_forms' === $_GET['post_type'] ) && ( 'give-settings' === $_GET['page'] ) ) {
 			add_action( $this->hook, array( $this, 'promo' ) );
 		}
 	}
@@ -325,6 +325,6 @@ class Give_i18n_Banner {
 }
 
 $give_i18n = new Give_i18n_Banner( array(
-		'hook'          => 'give_forms_page_give-settings',
+		'hook'          => 'admin_notices',
 		'glotpress_url' => 'https://translate.wordpress.org/api/projects/wp-plugins/give/stable/',
 	) );

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -36,6 +36,10 @@ if( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs 
 	<div class="wrap give-settings-page <?php echo self::$setting_filter_prefix . '-setting-page'; ?>">
 		<?php echo $form_open_tag; ?>
 		<h2></h2>
+		<?php
+		// Show messages.
+		self::show_messages();
+		?>
 		<div class="nav-tab-wrapper give-nav-tab-wrapper">
 			<?php
 			foreach ( $tabs as $name => $label ) {
@@ -71,11 +75,6 @@ if( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs 
 		 * @since 1.8
 		 */
 		do_action( self::$setting_filter_prefix . "_sections_{$current_tab}_page" );
-
-
-		// Show messages.
-		self::show_messages();
-
 
 		/**
 		 * Trigger Action.

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -35,65 +35,66 @@ if( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs 
 	?>
 	<div class="wrap give-settings-page <?php echo self::$setting_filter_prefix . '-setting-page'; ?>">
 		<?php echo $form_open_tag; ?>
-			<h2 class="nav-tab-wrapper give-nav-tab-wrapper">
-				<?php
-				foreach ( $tabs as $name => $label ) {
-					echo '<a href="' . admin_url( "edit.php?post_type=give_forms&page=" . self::$setting_filter_prefix . "&tab={$name}" ) . '" class="nav-tab ' . ( $current_tab == $name ? 'nav-tab-active' : '' ) . '">' . $label . '</a>';
-				}
-
-				/**
-				 * Trigger Action.
-				 *
-				 * Note: action dynamically fire on basis of setting page slug.
-				 * For example: if you register a setting page with give-settings menu slug
-				 *              then action will be give-settings_tabs
-				 *
-				 * @since 1.8
-				 */
-				do_action( self::$setting_filter_prefix . '_tabs' );
-				?>
-			</h2>
-			<div class="give-sub-nav-tab-wrapper">
-				<a href="#" id="give-show-sub-nav" class="nav-tab give-not-tab" title="<?php _e( 'View remaining setting tabs', 'give' ); ?>"><span class="dashicons dashicons-arrow-down-alt2"></span></span></a>
-				<nav class="give-sub-nav-tab give-hidden"></nav>
-			</div>
-			<h1 class="screen-reader-text"><?php echo esc_html( $tabs[ $current_tab ] ); ?></h1>
+		<h2></h2>
+		<div class="nav-tab-wrapper give-nav-tab-wrapper">
 			<?php
+			foreach ( $tabs as $name => $label ) {
+				echo '<a href="' . admin_url( "edit.php?post_type=give_forms&page=" . self::$setting_filter_prefix . "&tab={$name}" ) . '" class="nav-tab ' . ( $current_tab == $name ? 'nav-tab-active' : '' ) . '">' . $label . '</a>';
+			}
 
 			/**
 			 * Trigger Action.
 			 *
 			 * Note: action dynamically fire on basis of setting page slug.
-			 * For example: if you register a setting page with give-settings menu slug and general current tab
-			 *              then action will be give-settings_sections_general_page
+			 * For example: if you register a setting page with give-settings menu slug
+			 *              then action will be give-settings_tabs
 			 *
 			 * @since 1.8
 			 */
-			do_action( self::$setting_filter_prefix . "_sections_{$current_tab}_page" );
+			do_action( self::$setting_filter_prefix . '_tabs' );
+			?>
+		</div>
+		<div class="give-sub-nav-tab-wrapper">
+			<a href="#" id="give-show-sub-nav" class="nav-tab give-not-tab" title="<?php _e( 'View remaining setting tabs', 'give' ); ?>"><span class="dashicons dashicons-arrow-down-alt2"></span></span></a>
+			<nav class="give-sub-nav-tab give-hidden"></nav>
+		</div>
+		<h1 class="screen-reader-text"><?php echo esc_html( $tabs[ $current_tab ] ); ?></h1>
+		<?php
 
-			
-			// Show messages.
-			self::show_messages();
+		/**
+		 * Trigger Action.
+		 *
+		 * Note: action dynamically fire on basis of setting page slug.
+		 * For example: if you register a setting page with give-settings menu slug and general current tab
+		 *              then action will be give-settings_sections_general_page
+		 *
+		 * @since 1.8
+		 */
+		do_action( self::$setting_filter_prefix . "_sections_{$current_tab}_page" );
 
 
-			/**
-			 * Trigger Action.
-			 *
-			 * Note: action dynamically fire on basis of setting page slug.
-			 * For example: if you register a setting page with give-settings menu slug and general current tab
-			 *              then action will be give-settings_settings_general_page
-			 *
-			 * @since 1.8
-			 */
-			do_action( self::$setting_filter_prefix . "_settings_{$current_tab}_page" );
+		// Show messages.
+		self::show_messages();
 
-			if ( empty( $GLOBALS['give_hide_save_button'] ) ) : ?>
-				<div class="give-submit-wrap">
-					<?php wp_nonce_field( 'give-save-settings', '_give-save-settings' ); ?>
-					<input name="save" class="button-primary give-save-button" type="submit" value="<?php esc_attr_e( 'Save changes', 'give' ); ?>" />
-				</div>
-			<?php endif; ?>
+
+		/**
+		 * Trigger Action.
+		 *
+		 * Note: action dynamically fire on basis of setting page slug.
+		 * For example: if you register a setting page with give-settings menu slug and general current tab
+		 *              then action will be give-settings_settings_general_page
+		 *
+		 * @since 1.8
+		 */
+		do_action( self::$setting_filter_prefix . "_settings_{$current_tab}_page" );
+
+		if ( empty( $GLOBALS['give_hide_save_button'] ) ) : ?>
+			<div class="give-submit-wrap">
+				<?php wp_nonce_field( 'give-save-settings', '_give-save-settings' ); ?>
+				<input name="save" class="button-primary give-save-button" type="submit" value="<?php esc_attr_e( 'Save changes', 'give' ); ?>" />
+			</div>
+		<?php endif; ?>
 		<?php echo $form_close_tag; ?>
 	</div>
-	<?php else : echo '<div class="error"><p>' . __( 'Oops, this settings page does not exist.', 'give' ) . '</p></div>'; ?>
+<?php else : echo '<div class="error"><p>' . __( 'Oops, this settings page does not exist.', 'give' ) . '</p></div>'; ?>
 <?php endif; ?>


### PR DESCRIPTION
## Description
This PR is for #1997 

## How Has This Been Tested?
This issue is due to improper settings html formatting. To make all the notices above the tabs, we should place an `<h2>` above the tabs and inside `<div class="wrap">` to work properly.

@DevinWalker @ravinderk I've kept `<h2>` empty right now to solve the issue. If you would like to add some heading text then we can add that in `<h2>` as well. Let me know your thoughts.

## Screenshots (jpeg or gifs if applicable):
#### Before
![image](https://user-images.githubusercontent.com/2853040/29458123-7efa33e4-8415-11e7-93d3-27213089aa4b.png)

#### After
![image](https://user-images.githubusercontent.com/1852711/29700410-eb8c2294-8981-11e7-97c3-1f08dccc0dff.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.