### PR TITLE
Validate

### DIFF
--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -663,6 +663,7 @@ class GIVE_CLI_COMMAND {
 	 *
 	 * ## EXAMPLES
 	 *
+	 * wp give report
 	 * wp give report --date=this_month
 	 * wp give report --start-date=01/02/2014 --end-date=02/23/2014
 	 * wp give report --date=last_year
@@ -707,7 +708,7 @@ class GIVE_CLI_COMMAND {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--action=<cache_action>]
+	 * --action=<cache_action>
 	 * : Value of this parameter can be delete (in case you want to delete all stat cache).
 	 *
 	 * ## EXAMPLES

--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -348,6 +348,7 @@ class GIVE_CLI_COMMAND {
 	 *
 	 * ## EXAMPLES
 	 *
+	 * wp give donors
 	 * wp give donors --id=103
 	 * wp give donors --email=john@test.com
 	 * wp give donors --create=1 --email=john@test.com


### PR DESCRIPTION
If we use **[wp give cache]**   that time comes warning error.When we pass action=delete that time work complete.
To add action is required at this command so add --action=<cache_action> instead [--action=<cache_action>].

Another point I have added  **wp give report** to list all give the report.
