### PR TITLE
GH#2035 Added default decimal separator

### DIFF
--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -910,7 +910,7 @@ class GIVE_CLI_COMMAND {
 		/* @var Give_Payment|object $donation Payment object. */
 		foreach ( $donations as $donation ) {
 
-			if ( in_array( $donation->customer_id, $skip_donors ) ) {
+			if ( in_array( $donation->customer_id, $skip_donors ,true ) ) {
 				continue;
 			}
 

--- a/includes/install.php
+++ b/includes/install.php
@@ -299,6 +299,7 @@ function give_get_default_settings() {
 		'currency_position'                           => 'before',
 		'session_lifetime'                            => '604800',
 		'email_access'                                => 'disabled',
+		'decimal_separator'                           => '.',
 		'number_decimals'                             => 2,
 
 		// Display options.

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -419,7 +419,7 @@ final class Give_Payment {
 	public function __set( $key, $value ) {
 		$ignore = array( '_ID' );
 
-		if ( $key === 'status' ) {
+		if ( 'status' === $key ) {
 			$this->old_status = $this->status;
 		}
 
@@ -440,7 +440,7 @@ final class Give_Payment {
 	 *
 	 * @param  string $name The attribute to get
 	 *
-	 * @return boolean       If the item is set or not
+	 * @return boolean|null       If the item is set or not
 	 */
 	public function __isset( $name ) {
 		if ( property_exists( $this, $name ) ) {
@@ -646,7 +646,7 @@ final class Give_Payment {
 				$donor = new Give_Donor( get_current_user_id(), true );
 
 				// Donor is logged in but used a different email to purchase with so assign to their donor record.
-				if ( ! empty( $donor->id ) && $this->email != $donor->email ) {
+				if ( ! empty( $donor->id ) && $this->email !== $donor->email ) {
 					$donor->add_email( $this->email );
 				}
 			}
@@ -1088,7 +1088,7 @@ final class Give_Payment {
 	 *
 	 * @param  string $note The note to add
 	 *
-	 * @return void
+	 * @return bool           If the note was specified or not
 	 */
 	public function add_note( $note = false ) {
 		// Bail if no note specified.


### PR DESCRIPTION
The default value for `decimal_separator` is now set during `register_activation_hook`.
Related #2035 