### PR TITLE
Issue/2034

### DIFF
--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -19,7 +19,8 @@ if ( ! class_exists( 'Give_License' ) ) :
 	/**
 	 * Give_License Class
 	 *
-	 * This class simplifies the process of adding license information to new Give add-ons.
+	 * This class simplifies the process of adding license information
+	 * to new Give add-ons.
 	 *
 	 * @since 1.0
 	 */
@@ -200,16 +201,16 @@ if ( ! class_exists( 'Give_License' ) ) :
 		 */
 		private function hooks() {
 
-			// Register settings
+			// Register settings.
 			add_filter( 'give_settings_licenses', array( $this, 'settings' ), 1 );
 
-			// Activate license key on settings save
+			// Activate license key on settings save.
 			add_action( 'admin_init', array( $this, 'activate_license' ) );
 
-			// Deactivate license key
+			// Deactivate license key.
 			add_action( 'admin_init', array( $this, 'deactivate_license' ) );
 
-			// Updater
+			// Updater.
 			add_action( 'admin_init', array( $this, 'auto_updater' ), 0 );
 			add_action( 'admin_notices', array( $this, 'notices' ) );
 
@@ -239,7 +240,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 		 */
 		public function auto_updater() {
 
-			// Setup the updater
+			// Setup the updater.
 			$this->auto_updater_obj = new EDD_SL_Plugin_Updater(
 				$this->api_url,
 				$this->file,
@@ -362,12 +363,12 @@ if ( ! class_exists( 'Give_License' ) ) :
 			// Delete previous license key from subscription if previously added.
 			$this->__remove_license_key_from_subscriptions();
 
-			// Make sure there are no api errors
+			// Make sure there are no api errors.
 			if ( ! ( $license_data = $this->get_license_info( 'activate_license' ) ) ) {
 				return;
 			}
 
-			// Tell WordPress to look for updates
+			// Tell WordPress to look for updates.
 			set_site_transient( 'update_plugins', null );
 
 			// Add license data.
@@ -403,10 +404,10 @@ if ( ! class_exists( 'Give_License' ) ) :
 				return;
 			}
 
-			// Run on deactivate button press
+			// Run on deactivate button press.
 			if ( isset( $_POST[ $this->item_shortname . '_license_key_deactivate' ] ) ) {
 
-				// Make sure there are no api errors
+				// Make sure there are no api errors.
 				if ( ! ( $license_data = $this->get_license_info( 'deactivate_license' ) ) ) {
 					return;
 				}
@@ -451,7 +452,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				return;
 			}
 
-			// Make sure there are no api errors
+			// Make sure there are no api errors.
 			if ( ! ( $license_data = $this->get_license_info( 'check_license' ) ) ) {
 				return;
 			}
@@ -507,7 +508,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				return;
 			}
 
-			// Make sure there are no api errors
+			// Make sure there are no api errors.
 			// Do not get confused with edd_action check_subscription.
 			// By default edd software licensing api does not have api to check subscription.
 			// This is a custom feature to check subscriptions.
@@ -655,7 +656,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				$showed_subscriptions_message = true;
 			}// End if().
 
-			// Show non subscription addon messages.
+			// Show Non Subscription Give Add-on messages.
 			if (
 				! in_array( $this->license, $addon_license_key_in_subscriptions )
 				&& ! empty( $this->license )
@@ -829,7 +830,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				return false;
 			}
 
-			// Data to send to the API
+			// Data to send to the API.
 			$api_params = array(
 				'edd_action' => $edd_action, // never change from "edd_" to "give_"!
 				'license'    => $this->license,
@@ -837,7 +838,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				'url'        => home_url(),
 			);
 
-			// Call the API
+			// Call the API.
 			$response = wp_remote_post(
 				$this->api_url,
 				array(
@@ -847,7 +848,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				)
 			);
 
-			// Make sure there are no errors
+			// Make sure there are no errors.
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}
@@ -856,4 +857,4 @@ if ( ! class_exists( 'Give_License' ) ) :
 		}
 	}
 
-endif; // end class_exists check
+endif; // end class_exists check.

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -658,8 +658,9 @@ if ( ! class_exists( 'Give_License' ) ) :
 			// Show non subscription addon messages.
 			if (
 				! in_array( $this->license, $addon_license_key_in_subscriptions )
-				&& ! $this->is_valid_license()
+				&& ! empty( $this->license )
 				&& empty( $showed_invalid_message )
+				&& ! $this->is_valid_license()
 			) {
 
 				Give()->notices->register_notice( array(

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 		private $account_url = 'https://givewp.com/my-account/';
 
 		/**
-		 * Ccheckout URL
+		 * Checkout URL
 		 *
 		 * @access private
 		 * @since  1.7
@@ -157,6 +157,13 @@ if ( ! class_exists( 'Give_License' ) ) :
 			$this->checkout_url     = is_null( $_checkout_url ) ? $this->checkout_url : $_checkout_url;
 			$this->account_url      = is_null( $_account_url ) ? $this->account_url : $_account_url;
 			$this->auto_updater_obj = null;
+
+			// Add Setting for Give Add-on activation status.
+			$is_addon_activated = get_option( 'give_is_addon_activated' );
+			if( ! $is_addon_activated && is_object( $this ) && sizeof( $this ) > 0 ) {
+				update_option( 'give_is_addon_activated', true );
+				Give_Cache::set( 'give_cache_hide_license_notice_after_activation', true, 5 * MINUTE_IN_SECONDS );
+			}
 
 			// Setup hooks
 			$this->includes();
@@ -557,9 +564,14 @@ if ( ! class_exists( 'Give_License' ) ) :
 			$addon_license_key_in_subscriptions = ! empty( $addon_license_key_in_subscriptions ) ? $addon_license_key_in_subscriptions : array();
 			$messages                           = array();
 
+			// Check whether admin has Give Add-on activated since 24 hours?
+			$is_license_notice_hidden = Give_Cache::get( 'give_cache_hide_license_notice_after_activation' );
+
+			// Display Invalid License notice, if its more than 24 hours since first Give Add-on activation.
 			if (
 				empty( $this->license )
 				&& empty( $showed_invalid_message )
+				&& ( false === $is_license_notice_hidden )
 			) {
 
 				Give()->notices->register_notice( array(

--- a/tests/unit-tests/tests-payments.php
+++ b/tests/unit-tests/tests-payments.php
@@ -498,7 +498,7 @@ class Tests_Payments extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers give_get_price_id
+	 * @covers ::give_get_price_id
 	 */
 	public function test_give_get_price_id() {
 		$form = Give_Helper_Form::create_multilevel_form(


### PR DESCRIPTION
## Description
This PR is for #2034 

## How Has This Been Tested?
I have tested this issue with the scenario mentioned below:
1. Installing & activating any Give Add-on or multiple Give Add-ons then invalid license notice will not appear instantly. It will appear after 24 hours of activation of Give Add-on.
2. After activating first Give Add-on, go to `Settings > Licenses` and add dummy text as license and save settings. Then, the invalid license notice will appear instantly, breaking the rule of waiting till 24 hours.

@DevinWalker @ravinderk I have kept the invalid license notice wait time of 5 Minutes right now for testing purpose. Let me know once you are done, then i will change it to 24 hours.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.