### PR TITLE
MinorFix/2034

### DIFF
--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 			$is_addon_activated = get_option( 'give_is_addon_activated' );
 			if( ! $is_addon_activated && is_object( $this ) && sizeof( $this ) > 0 ) {
 				update_option( 'give_is_addon_activated', true );
-				Give_Cache::set( 'give_cache_hide_license_notice_after_activation', true, 5 * MINUTE_IN_SECONDS );
+				Give_Cache::set( 'give_cache_hide_license_notice_after_activation', true, DAY_IN_SECONDS );
 			}
 
 			// Setup hooks


### PR DESCRIPTION
## Description
This PR is for #2034 

## How Has This Been Tested?
I have mentioned in the main PR https://github.com/WordImpress/Give/pull/2044 that I have kept the wait time for license notice to be 5 minutes which requires change after testing. 

@DevinWalker @ravinderk  In this PR, I have changed wait time from 5 minutes to 24 hours for invalid license notice.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.