### PR TITLE
GH#2053 Fixes thousands separator in reports

### DIFF
--- a/includes/admin/reports/class-give-graph.php
+++ b/includes/admin/reports/class-give-graph.php
@@ -250,8 +250,11 @@ class Give_Graph {
 							mode        : "<?php echo $this->options['y_mode']; ?>",
 							timeFormat  : "<?php echo $this->options['y_mode'] == 'time' ? $this->options['time_format'] : ''; ?>",
 							<?php if( $this->options['y_mode'] != 'time' ) : ?>
-							tickDecimals: <?php echo $this->options['y_decimals']; ?>
+							tickDecimals: <?php echo $this->options['y_decimals']; ?>,
 							<?php endif; ?>
+							tickFormatter: function(val) {
+								return val.toString().replace(/\B(?=(?:\d{3})+(?!\d))/g, give_vars.thousands_separator);
+							},
 						}
 					}
 				);


### PR DESCRIPTION
See #2053 

## Description
Added a regex to add thousands separator to the amounts along the Y-axis in the Reports > Income graph.


## Screenshots (jpeg or gifs if applicable):
![Image](https://cdn.pbrd.co/images/GKbnhgh.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.