### PR TITLE
Allow admin dashboard to 'Give Accoutant' user role even though WooCommerce is active.

### DIFF
--- a/includes/class-give-roles.php
+++ b/includes/class-give-roles.php
@@ -36,6 +36,8 @@ class Give_Roles {
 	 */
 	public function __construct() {
 		add_filter( 'give_map_meta_cap', array( $this, 'meta_caps' ), 10, 4 );
+		add_filter( 'woocommerce_disable_admin_bar', array( $this, 'manage_admin_dashboard' ), 10 );
+		add_filter( 'woocommerce_prevent_admin_access', array( $this, 'manage_admin_dashboard'), 10 );
 	}
 
 	/**
@@ -294,4 +296,25 @@ class Give_Roles {
 		}
 	}
 
+	/**
+	 * Allow admin dashboard to User with Give Accountant Role.
+	 *
+	 * Note: WooCommerce doesn't allow the user to access the WP dashboard who holds "Give Accountant" role.
+	 *
+	 * @since 1.8.14
+	 *
+	 * @return bool
+	 */
+	public function manage_admin_dashboard() {
+
+		// Get the current logged user.
+		$current_user = wp_get_current_user();
+
+		// If user with "Give Accountant" user role is logged-in .
+		if ( 0 !== $current_user->ID && in_array( 'give_accountant', (array) $current_user->roles, true ) ) {
+
+			// Return false, means no prevention.
+			return false;
+		}
+	}
 }


### PR DESCRIPTION
## Description
This PR fixes issue #2022 

## How Has This Been Tested?
- Tested the "Give Accountant" role with activated WooCommerce and without activated, in both cases, the user with "Give accountant" role can access the admin dashboard.
- Tested other user role (Give Worker, Give Manager ) to check if, it works as expected or not.
- Tested It by creating sample order ( in WooCommerce ) and donation ( in Give ).

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Added woocoommerce filter to allow the access to the wp-admin for the user who holds 'Give Accountant' user role.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.