### PR TITLE
Changed the layout of the donation receipt for offline payment. #1396

### DIFF
--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -100,6 +100,51 @@ $give_receipt_args['donation_receipt']['payment_method'] = array(
  */
 $give_receipt_args['donation_receipt'] = apply_filters( 'give_donation_receipt_args', $give_receipt_args['donation_receipt'], $donation_id, $form_id );
 
+// When the donation were made through offline donation, We won't show receipt and payment status though.
+if ( 'offline' === give_get_payment_gateway( $payment->ID ) && 'pending' === $status ) {
+
+	/**
+	 * Before the offline donation receipt content starts.
+	 *
+	 * @since 1.8.14
+	 *
+	 * @param Give_Payment $payment           Donation payment object.
+	 * @param array        $give_receipt_args Receipt Arguments.
+	 */
+	do_action( 'give_receipt_before_offline_payment', $payment, $give_receipt_args );
+	?>
+	<h2><?php echo apply_filters( 'give_receipt_offline_payment_heading', __( 'Your Donation is Almost Complete!', 'give' ) ); ?></h2>
+	<div id="give_donation_receipt" class="<?php echo esc_attr( apply_filters( 'give_receipt_offline_payment_classes', 'give_receipt_offline_payment' ) ); ?>">
+		<?php
+		// Instruction for offline donation.
+		$offline_instruction = give_get_offline_payment_instruction( $form_id, true );
+
+		/**
+		 * Instruction for the offline donation.
+		 *
+		 * @since 1.8.14
+		 *
+		 * @param string       $offline_instruction Offline instruction content.
+		 * @param Give_Payment $payment             Payment object.
+		 * @param integer      $form_id             Donation form id.
+		 */
+		echo apply_filters( 'give_receipt_offline_payment_instruction', $offline_instruction, $payment, $form_id );
+		?>
+	</div>
+	<?php
+	/**
+	 * After the offline donation content ends.
+	 *
+	 * @since 1.8.14
+	 *
+	 * @param Give_Payment $payment           Donation payment object.
+	 * @param array        $give_receipt_args Receipt Arguments.
+	 */
+	do_action( 'give_receipt_after_offline_payment', $payment, $give_receipt_args );
+
+	return;
+}
+
 // Show payment status notice based on shortcode attribute.
 if ( filter_var( $give_receipt_args['status_notice'], FILTER_VALIDATE_BOOLEAN ) ) {
 	$notice_message = '';


### PR DESCRIPTION
## Description
This PR fixes issue #1396 

As discussed with @ravinderk on call and as @mathetos [comment](https://github.com/WordImpress/Give/issues/1396#issuecomment-273643033), I have made changes for the offline donation only, these changes will add the heading "Your Donation is Almost Complete!" and below of it the Instruction for the offline donation would be shown.

Let me know if any changes are required.

## How Has This Been Tested?
- Tested by creating donation through offline payment and other test payment gateway.
- Tested through Donation history page.
- Tested the filter used inside this PR.

## Screenshots (jpeg or gifs if applicable):
![offline-donation](https://user-images.githubusercontent.com/14994452/30593889-c0c8ac7a-9d69-11e7-9b06-0ac9c8314898.png)

## Types of changes
- Changes for offline donation in Donation Receipt page.
- Added filters to allow the developer or third-party plugins modify the content.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.