### PR TITLE
Issues/2136

### DIFF
--- a/assets/js/admin/admin-scripts.js
+++ b/assets/js/admin/admin-scripts.js
@@ -1483,6 +1483,16 @@ var give_setting_edit = false;
 
 					// Set input field value.
 					$input_field.val(fvalue);
+
+					// Update attachment id field value if fvalue is not set to id.
+					if( 'id' !== $give_upload_button.data('fvalue') ) {
+						var attachment_id_field_name = 'input[name="' + $input_field.attr('name') + '_id"]',
+							id_field = $input_field.closest('tr').next('tr').find( attachment_id_field_name );
+
+						if( id_field.length ){
+							$input_field.closest('tr').next('tr').find( attachment_id_field_name ).val( attachment.id );
+						}
+					}
 				});
 
 				// Open the uploader dialog

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -389,11 +389,12 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 
 					// Standard text inputs and subtypes like 'number'.
 					case 'colorpicker':
+					case 'hidden' :
+						$value['wrapper_class'] = empty( $value['wrapper_class'] ) ? 'give-hidden' : trim( $value['wrapper_class'] ) . ' give-hidden';
 					case 'text':
 					case 'email':
 					case 'number':
 					case 'password' :
-
 						$type = $value['type'];
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 						?>

--- a/includes/admin/tools/import/class-give-import-donations.php
+++ b/includes/admin/tools/import/class-give-import-donations.php
@@ -781,48 +781,7 @@ if ( ! class_exists( 'Give_Import_Donations' ) ) {
 
 			return $has_error;
 		}
-
-		/**
-		 * Get settings array.
-		 *
-		 * @since  1.8.14
-		 * @return array
-		 */
-		public function get_settings() {
-			// Hide save button.
-			$GLOBALS['give_hide_save_button'] = true;
-
-			/**
-			 * Filter the settings.
-			 *
-			 * @since  1.8.14
-			 *
-			 * @param  array $settings
-			 */
-			$settings = apply_filters(
-				'give_get_settings_' . $this->id,
-				array(
-					array(
-						'id'         => 'give_tools_import',
-						'type'       => 'title',
-						'table_html' => false,
-					),
-					array(
-						'id'   => 'import',
-						'name' => __( 'Import', 'give' ),
-						'type' => 'tools_import',
-					),
-					array(
-						'id'         => 'give_tools_import',
-						'type'       => 'sectionend',
-						'table_html' => false,
-					),
-				)
-			);
-
-			// Output.
-			return $settings;
-		}
+		
 
 		/**
 		 * Render report import field


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This Pr will fix #2136 

Core support id hidden field for attachment ( non `id` fvalue ). You just have to define hidden field next to media field with `{media_field_id}_id`

```
                array(
					'id'          => 'csv',
					'name'        => __( 'Choose a CSV file:', 'give' ),
					'type'        => 'file',
					'attributes'  => array( 'editing' => 'false', 'library' => 'text' ),
					'description' => __( 'The file must be a Comma Seperated Version (CSV) file type only.', 'give' ),
					'fvalue'      => 'url',
					'default'     => $csv,
				),
				array(
					'id'          => 'csv_id',
					'type'        => 'hidden',
				),
```



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.