### PR TITLE
Remove give-message parameter #2100

### DIFF
--- a/assets/js/admin/admin-scripts.js
+++ b/assets/js/admin/admin-scripts.js
@@ -14,6 +14,46 @@ var give_setting_edit = false;
 ( function( $ ) {
 
 	/**
+	 * Onclick remove give-message parameter from url
+	 *
+	 * @ since 1.8.14
+	 */
+	var give_dismiss_notice = function(){
+		$( 'body' ).on( 'click', 'button.notice-dismiss', function () {
+			if ( 'give-invalid-license' !== jQuery( this ).closest( 'div.give-notice' ).data( 'notice-id' ) ) {
+				give_remove_give_message();
+			}
+		} );
+	};
+
+	/**
+	 * Remove give-message parameter from URL.
+	 *
+	 * @since 1.8.14
+	 */
+	var give_remove_give_message = function () {
+		var parameter = 'give-message',
+			url = document.location.href,
+			urlparts = url.split( '?' );
+
+		if ( urlparts.length >= 2 ) {
+			var urlBase = urlparts.shift();
+			var queryString = urlparts.join( "?" );
+
+			var prefix = encodeURIComponent( parameter ) + '=';
+			var pars = queryString.split( /[&;]/g );
+			for ( var i = pars.length; i-- > 0; ) {
+				if ( pars[ i ].lastIndexOf( prefix, 0 ) !== -1 ) {
+					pars.splice( i, 1 );
+				}
+			}
+			url = urlBase + '?' + pars.join( '&' );
+			window.history.pushState( '', document.title, url ); // added this line to push the new url directly to url bar .
+		}
+		return url;
+	};
+
+	/**
 	 * Setup Admin Datepicker
 	 * @since: 1.0
 	 */
@@ -2057,6 +2097,7 @@ var give_setting_edit = false;
 	// On DOM Ready.
 	$( function() {
 
+		give_dismiss_notice();
 		enable_admin_datepicker();
 		form_edit_alert();
 		handle_status_change();

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -325,7 +325,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 
 				$views[ $key ] = sprintf(
 					'<a href="%s" %s >%s&nbsp;<span class="count">(%s)</span></a>',
-					esc_url( ( 'all' === (string) $key ) ? remove_query_arg( array( 'status', 'paged' ) ) : add_query_arg( array( 'status' => $key, 'paged' => false ) ) ),
+					esc_url( ( 'all' === (string) $key ) ? remove_query_arg( array( 'status', 'paged' ) ) : add_query_arg( array( 'status' => $key, 'paged' => false ), admin_url( 'edit.php?post_type=give_forms&page=give-payment-history' ) ) ),
 					( ( 'all' === $key && empty( $current ) ) ) ? 'class="current"' : ( $current == $key ) ? 'class="current"' : '',
 					$name,
 					$count


### PR DESCRIPTION
## Description
PR for comment: https://github.com/WordImpress/Give/issues/2100#issuecomment-332620642
Remove the give-message parameter from url once user click on the remove notices button

## How Has This Been Tested?
Mannualy Tested

## Types of changes
Bug fix (non-breaking change which fixes an issue)
