### PR TITLE
Issue 2141 - Adjusted the download "System Settings" notice to prevent it moving

### DIFF
--- a/assets/scss/admin/system-info.scss
+++ b/assets/scss/admin/system-info.scss
@@ -19,60 +19,78 @@
   margin-bottom: 1em;
 
   h2 {
-    font-size: 14px;
-    margin: 0;
+	font-size: 14px;
+	margin: 0;
   }
 
   tr {
-    &:nth-child(2n) {
-      th,
-      td {
-        background: #fcfcfc;
-      }
-    }
+	&:nth-child(2n) {
+	  th,
+	  td {
+		background: #fcfcfc;
+	  }
+	}
   }
 
   th {
-    font-weight: 700;
-    padding: 9px;
+	font-weight: 700;
+	padding: 9px;
   }
 
   td:first-child {
-    width: 33%;
+	width: 33%;
   }
 
   td.help {
-    width: 1em;
+	width: 1em;
   }
 
   td {
-    padding: 9px;
-    font-size: 1.1em;
+	padding: 9px;
+	font-size: 1.1em;
 
-    mark {
-      background: transparent none;
-    }
+	mark {
+	  background: transparent none;
+	}
 
-    mark.yes {
-      color: $green;
-    }
+	mark.yes {
+	  color: $green;
+	}
 
-    mark.no {
-      color: #999;
-    }
+	mark.no {
+	  color: #999;
+	}
 
-    mark.error {
-      color: $red;
-    }
+	mark.error {
+	  color: $red;
+	}
 
-    ul {
-      margin: 0;
-    }
+	ul {
+	  margin: 0;
+	}
   }
 }
 
+/* System info download header */
 .wrap div.give-debug-report-wrapper {
-  margin-top: 1em;
+  p {
+	font-size: 18px;
+	margin: 1em 0 0.7em;
+	padding: 0;
+  }
+
+  .give-debug-report-actions {
+	margin: 0 0 1.7em;
+	.js-give-debug-report-button {
+	  margin-right:10px;
+	}
+	.dashicons {
+	  font-size: 16px;
+	  position: relative;
+	  top: 4px;
+	  left: -2px;
+	}
+  }
 }
 
 .give-debug-report {
@@ -82,17 +100,17 @@
   position: relative;
 
   textarea {
-    font-family: monospace;
-    width: 100%;
-    margin: 0;
-    height: 300px;
-    padding: 20px;
-    -moz-border-radius: 0;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    resize: none;
-    font-size: 12px;
-    line-height: 20px;
-    outline: 0;
+	font-family: monospace;
+	width: 100%;
+	margin: 0;
+	height: 300px;
+	padding: 20px;
+	-moz-border-radius: 0;
+	-webkit-border-radius: 0;
+	border-radius: 0;
+	resize: none;
+	font-size: 12px;
+	line-height: 20px;
+	outline: 0;
   }
 }

--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -21,12 +21,12 @@ $give_options = give_get_settings();
 $plugins      = give_get_plugins();
 ?>
 
-<div class="give-debug-report-wrapper updated">
-	<p><?php _e( 'Please copy and paste this information in your ticket when contacting support:', 'give' ); ?> </p>
-	<p class="submit">
+<div class="give-debug-report-wrapper">
+	<p class="give-debug-report-text"><?php sprintf(_e( 'Please copy and paste this information in your ticket when contacting support:', 'give' )); ?> </p>
+	<div class="give-debug-report-actions">
 		<a class="button-primary js-give-debug-report-button" href="#"><?php _e( 'Get System Report', 'give' ); ?></a>
-		<a class="button-secondary docs" href="http://docs.givewp.com/settings-system-info" target="_blank"><?php _e( 'Understanding the System Report', 'give' ); ?></a>
-	</p>
+		<a class="button-secondary docs" href="http://docs.givewp.com/settings-system-info" target="_blank"><?php _e( 'Understanding the System Report', 'give' ); ?> <span class="dashicons dashicons-external"></span></a>
+	</div>
 	<div class="give-debug-report js-give-debug-report">
 		<textarea readonly="readonly"></textarea>
 	</div>


### PR DESCRIPTION
## Description
The notice is now gone and it looks like it does in #2141 without the white box.

Resolves #2141 
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Screenshots (jpeg or gifs if applicable):
See issue

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- UX improvement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.