### PR TITLE
Filter to the set_donor_data() method

### DIFF
--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -388,6 +388,8 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 			$data[ $i ]['donation_sum'] = give_format_amount( $donor->purchase_value, array( 'sanitize' => false ) );
 		}
 
+		$data[ $i ] = apply_filters( 'give_export_set_donor_data', $data[ $i ], $donor );
+
 		return $data[ $i ];
 
 	}


### PR DESCRIPTION
## Description
Per #2170, there is a filter for columns, but not for column data.

## How Has This Been Tested?
I have been working adding custom data to the CSV export; this allows that to happen.

## Types of changes
One line change that adds `apply_filters` to the set_donor_data() method in the `Give_Batch_Donors_Export` class.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.


(CC: @topher1kenobe & @tannerm )