### PR TITLE
Map postal code to zip during importing

### DIFF
--- a/includes/admin/tools/import/class-give-import-donations.php
+++ b/includes/admin/tools/import/class-give-import-donations.php
@@ -460,6 +460,12 @@ if ( ! class_exists( 'Give_Import_Donations' ) ) {
 		 */
 		public function selected( $option_value, $value ) {
 			$selected = '';
+
+			// Postal Code also needs to map with zip.
+			if ( 'Postal Code' === $value ) {
+				$value = 'Zip';
+			}
+
 			if ( stristr( $value, $option_value ) ) {
 				$selected = 'selected';
 			} elseif ( strrpos( $value, '_' ) && stristr( $option_value, 'Import as Meta' ) ) {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
I changed the header from `Zip` to `Postal Code` into sample csv

## Screenshot

![give-map-zip-to-postal-code](https://user-images.githubusercontent.com/19459637/31562151-fc75f5ea-b077-11e7-9d28-e56fdfde112d.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.