### PR TITLE
Fix php-doc for give_update_meta

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1539,8 +1539,8 @@ function give_get_meta( $id, $meta_key, $single = false, $default = false ) {
  *
  * @param int    $id
  * @param string $meta_key
- * @param string $meta_value
- * @param string $prev_value
+ * @param mixed  $meta_value
+ * @param mixed  $prev_value
  *
  * @return mixed
  */


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Currently, `give_update_meta` has string param type so it gives us an incorrect param type when we pass an array into it. 

## Types of changes
- Pass mixed param instead of the string.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.