### PR TITLE
Fix multiple form tag on form detail report page

### DIFF
--- a/includes/admin/reports/class-forms-report.php
+++ b/includes/admin/reports/class-forms-report.php
@@ -49,6 +49,11 @@ if ( ! class_exists( 'Give_Forms_Report' ) ) :
 			add_action( "give-reports_settings_{$this->id}_page", array( $this, 'output' ) );
 			add_action( 'give_admin_field_report_forms', array( $this, 'render_report_forms_field' ), 10, 2 );
 
+			// Do not use main form for this tab.
+			if( give_get_current_setting_tab() === $this->id ) {
+				add_action( 'give-reports_open_form', '__return_empty_string' );
+				add_action( 'give-reports_close_form', '__return_empty_string' );
+			}
 		}
 
 		/**


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will fix multiple form tag on form detail report page which is not as W3C standard as well as it cause alignment issue in the top navigation.

## How Has This Been Tested?
Manually tested

## Screenshots (jpeg or gifs if applicable):
1) Issue: multiple form tag issue:
![multiple_form_tag](https://user-images.githubusercontent.com/15060983/31944955-641dafc8-b8eb-11e7-9ed1-2c08a344084c.png)

2) Alignment issue: 
![per_form_report](https://user-images.githubusercontent.com/15060983/31945009-8debdd34-b8eb-11e7-87ee-df25faf3f396.png)

3) Fix: Alignment issue fixed after pre
![fix_alignment](https://user-images.githubusercontent.com/15060983/31945139-e844a572-b8eb-11e7-92a6-09763567a6a4.png)
venting main form tag:


## Types of changes
<!-- What types of changes does your code introduce?  -->
- Prevent main form tag to show in Form detail report page.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.