### PR TITLE
Fix Display Notice on saving Donor Info #2181

### DIFF
--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -362,6 +362,15 @@ function _give_register_admin_notices() {
 						'show'        => true,
 					) );
 					break;
+
+				case 'profile-updated' :
+					Give()->notices->register_notice( array(
+						'id'          => 'give-donor-profile-updated',
+						'type'        => 'updated',
+						'description' => __( 'Donor information updated successfully.', 'give' ),
+						'show'        => true,
+					) );
+					break;
 			}
 		}
 	}

--- a/includes/admin/donors/donor-actions.php
+++ b/includes/admin/donors/donor-actions.php
@@ -128,7 +128,11 @@ function give_edit_donor( $args ) {
 		wp_die();
 	}
 
-	return $output;
+	if ( $output['success'] ) {
+		wp_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor_id . '&give-message=profile-updated' ) );
+	}
+
+	exit;
 
 }
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will fix #2181 

## How Has This Been Tested?
- Manually Tested.

## Screenshots (jpeg or gifs if applicable):
![donor_info_updated](https://user-images.githubusercontent.com/15060983/32002670-a28ce330-b9ba-11e7-820a-05a3ff81c613.png)


## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->
- Show success message on Donor update information.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.