### PR TITLE
give_sanitize_amount and give_maybe_sanitize_amount allows to sanitize amount based on currency's setting 

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -169,9 +169,8 @@ function give_sanitize_amount_for_db( $number ) {
  *
  * @since      1.8.12
  *
- * @param  int|float|string $number     Expects either a float or a string with a decimal separator only (no thousands)
- * @param  int|bool         $dp         Number of decimals
- * @param  bool             $trim_zeros From end of string
+ * @param  int|float|string $number Expects either a float or a string with a decimal separator only (no thousands)
+ * @param  array|bool       $args   It accepts 'number_decimals', 'trim_zeros', 'currency'.
  *
  * @return string $amount Newly sanitized amount
  */
@@ -271,8 +270,7 @@ function give_maybe_sanitize_amount( $number, $args = array() ) {
  * @since      1.0
  *
  * @param  int|float|string $number Expects either a float or a string with a decimal separator only (no thousands)
- * @param  int|bool         $dp Number of decimals
- * @param  bool             $trim_zeros From end of string
+ * @param  array|bool       $args   It accepts 'number_decimals', 'trim_zeros', 'currency'.
  *
  * @return string $amount Newly sanitized amount
  */

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -175,9 +175,31 @@ function give_sanitize_amount_for_db( $number ) {
  *
  * @return string $amount Newly sanitized amount
  */
-function give_maybe_sanitize_amount( $number, $dp = false, $trim_zeros = false ) {
-	$thousand_separator = give_get_price_thousand_separator();
-	$decimal_separator  = give_get_price_decimal_separator();
+function give_maybe_sanitize_amount( $number, $args = array() ) {
+	$func_args = func_get_args();
+
+	// Get the arguments.
+	if ( isset( $func_args[1] ) && is_array( $func_args[1] ) ) {
+
+		// Set default if missing value.
+		$options = wp_parse_args( $func_args[1], array(
+			'number_decimals' => false,
+			'trim_zeros'      => false,
+			'currency'        => '',
+		) );
+
+		$dp         = $options['number_decimals'];
+		$trim_zeros = $options['trim_zeros'];
+		$currency   = $options['currency'];
+
+	} else {
+		$dp         = isset( $func_args[1] ) ? $func_args[1] : false;
+		$trim_zeros = isset( $func_args[2] ) ? $func_args[2] : true;
+		$currency   = '';
+	}
+
+	$thousand_separator = give_get_price_thousand_separator( $currency );
+	$decimal_separator  = give_get_price_decimal_separator( $currency );
 	$number_decimals    = is_bool( $dp ) ? give_get_price_decimals() : $dp;
 
 	// Explode number by . decimal separator.
@@ -254,11 +276,34 @@ function give_maybe_sanitize_amount( $number, $dp = false, $trim_zeros = false )
  *
  * @return string $amount Newly sanitized amount
  */
-function give_sanitize_amount( $number, $dp = false, $trim_zeros = false ) {
+function give_sanitize_amount( $number, $args = array() ) {
 
 	// Bailout.
 	if ( empty( $number ) || ( ! is_numeric( $number ) && ! is_string( $number ) ) ) {
 		return $number;
+	}
+
+	// Get function arguments.
+	$func_args = func_get_args();
+
+	// Get the arguments.
+	if ( isset( $func_args[1] ) && is_array( $func_args[1] ) ) {
+
+		// Set default if missing value.
+		$options = wp_parse_args( $func_args[1], array(
+			'number_decimals' => false,
+			'trim_zeros'      => false,
+			'currency'        => '',
+		) );
+
+		$dp         = $options['number_decimals'];
+		$trim_zeros = $options['trim_zeros'];
+		$currency   = $options['currency'];
+
+	} else {
+		$dp         = isset( $func_args[1] ) ? $func_args[1] : false;
+		$trim_zeros = isset( $func_args[2] ) ? $func_args[2] : true;
+		$currency   = '';
 	}
 
 	// Remove slash from amount.
@@ -266,10 +311,10 @@ function give_sanitize_amount( $number, $dp = false, $trim_zeros = false ) {
 	// To prevent notices and warning remove slash from amount/number.
 	$number = wp_unslash( $number );
 
-	$thousand_separator = give_get_price_thousand_separator();
+	$thousand_separator = give_get_price_thousand_separator( $currency );
 
 	$locale   = localeconv();
-	$decimals = array( give_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
+	$decimals = array( give_get_price_decimal_separator( $currency ), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
 	// Remove locale from string
 	if ( ! is_float( $number ) ) {

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -257,7 +257,7 @@ function give_maybe_sanitize_amount( $number, $args = array() ) {
 		$number = str_replace( '.', '', $number );
 	}
 
-	return give_sanitize_amount( $number, $number_decimals, $trim_zeros );
+	return give_sanitize_amount( $number, array( 'number_decimals' => $dp, 'trim_zeros' => $trim_zeros, 'currency' => $currency ) );
 }
 
 /**
@@ -330,7 +330,7 @@ function give_sanitize_amount( $number, $args = array() ) {
 
 	// Remove non numeric entity before decimal separator.
 	$number     = preg_replace( '/[^0-9\.]/', '', $number );
-	$default_dp = give_get_price_decimals();
+	$default_dp = give_get_price_decimals( $currency );
 
 	// Reset negative amount to zero.
 	if ( 0 > $number ) {


### PR DESCRIPTION
## Description
Some currencies use a comma instead of a dot as the decimal symbol in their number of the amount, therefore it was not possible for us to sanitize the amount currency wise. (#2258 )

This PR solve this issue and allow us to pass currency.

the old way of use: 
```
give_sanitize_amount( 'amount', 'decimal_points', 'trim_zero' );
```
after this PR: 
```
give_sanitize_amount( 'amount', array(
     array(  'number_decimals'=>2, 'trim_zeros' => false, 'currency'=>'EUR' )
) );
```

same for `give_maybe_sanitize_amount()` function.

Please check from your end and let me know if there are any changes needed.

## How Has This Been Tested?
- Tested it manually 

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

\cc @DevinWalker @ravinderk 