### PR TITLE
Add filter when getting payment amount through give_payment_amount() function.

### DIFF
--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -550,7 +550,7 @@ function give_donor_view( $donor ) {
 				<?php foreach ( $payments as $payment ) : ?>
 					<tr>
 						<td><?php echo $payment->ID; ?></td>
-						<td><?php echo give_payment_amount( $payment->ID ); ?></td>
+						<td><?php echo give_payment_amount( $payment->ID, 'donor' ); ?></td>
 						<td><?php echo date_i18n( give_date_format(), strtotime( $payment->post_date ) ); ?></td>
 						<td><?php echo give_get_payment_status( $payment, true ); ?></td>
 						<td>

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -550,7 +550,7 @@ function give_donor_view( $donor ) {
 				<?php foreach ( $payments as $payment ) : ?>
 					<tr>
 						<td><?php echo $payment->ID; ?></td>
-						<td><?php echo give_payment_amount( $payment->ID, 'donor' ); ?></td>
+						<td><?php echo give_donation_amount( $payment->ID, 'donor' ); ?></td>
 						<td><?php echo date_i18n( give_date_format(), strtotime( $payment->post_date ) ); ?></td>
 						<td><?php echo give_get_payment_status( $payment, true ); ?></td>
 						<td>

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -30,7 +30,6 @@ function _give_load_deprecated_global_params( $give_object ) {
 add_action( 'give_init', '_give_load_deprecated_global_params' );
 
 
-
 /**
  * Checks if Guest checkout is enabled for a particular donation form
  *
@@ -541,7 +540,7 @@ function give_increase_purchase_count( $form_id = 0, $quantity = 1 ) {
  * Stores log information for a donation.
  *
  * @since 1.0
- * @global            $give_logs Give_Logging
+ * @global            $give_logs    Give_Logging
  *
  * @param int         $give_form_id Give Form ID.
  * @param int         $payment_id   Payment ID.
@@ -620,7 +619,7 @@ function give_get_purchase_summary( $purchase_data, $email = true ) {
 
 	_give_deprecated_function( __FUNCTION__, '1.8.12', 'give_payment_gateway_donation_summary', $backtrace );
 
-	give_payment_gateway_donation_summary($purchase_data, $email);
+	give_payment_gateway_donation_summary( $purchase_data, $email );
 
 }
 
@@ -647,8 +646,8 @@ function give_build_paypal_item_title( $payment_data ) {
 /**
  * Set the number of decimal places per currency
  *
- * @since 1.0
- * @since 1.6 $decimals parameter removed from function params
+ * @since      1.0
+ * @since      1.6 $decimals parameter removed from function params
  * @deprecated 1.8.15
  * *
  * @return int $decimals
@@ -682,7 +681,7 @@ function give_currency_decimal_filter() {
 /**
  * Get field custom attributes as string.
  *
- * @since 1.8
+ * @since      1.8
  * @deprecated 1.8.17
  *
  * @param $field

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -699,3 +699,21 @@ function give_get_custom_attributes( $field ) {
 
 	return $custom_attributes;
 }
+
+
+/**
+ * Get Payment Amount
+ *
+ * Get the fully formatted payment amount. The payment amount is retrieved using give_get_payment_amount() and is then
+ * sent through give_currency_filter() and  give_format_amount() to format the amount correctly.
+ *
+ * @param int $payment_id Payment ID.
+ *
+ * @since      1.0
+ * @deprecated 1.8.17
+ *
+ * @return string $amount Fully formatted payment amount.
+ */
+function give_payment_amount( $payment_id ) {
+	return give_donation_amount( $payment_id );
+}

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -25,19 +25,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.0
  *
- * @param array $args {
+ * @param array $args     {
  *                        Optional. Array of arguments passed to payments query.
  *
- * @type int $offset The number of payments to offset before retrieval.
+ * @type int    $offset   The number of payments to offset before retrieval.
  *                            Default is 0.
- * @type int $number The number of payments to query for. Use -1 to request all
+ * @type int    $number   The number of payments to query for. Use -1 to request all
  *                            payments. Default is 20.
- * @type string $mode Default is 'live'.
- * @type string $order Designates ascending or descending order of payments.
+ * @type string $mode     Default is 'live'.
+ * @type string $order    Designates ascending or descending order of payments.
  *                            Accepts 'ASC', 'DESC'. Default is 'DESC'.
- * @type string $orderby Sort retrieved payments by parameter. Default is 'ID'.
- * @type string $status The status of the payments. Default is 'any'.
- * @type string $user User. Default is null.
+ * @type string $orderby  Sort retrieved payments by parameter. Default is 'ID'.
+ * @type string $status   The status of the payments. Default is 'any'.
+ * @type string $user     User. Default is null.
  * @type string $meta_key Custom field key. Default is null.
  * }
  *
@@ -62,7 +62,7 @@ function give_get_payments( $args = array() ) {
  * @since  1.0
  *
  * @param  string $field The field to retrieve the payment with.
- * @param  mixed $value The value for $field.
+ * @param  mixed  $value The value for $field.
  *
  * @return mixed
  */
@@ -203,7 +203,7 @@ function give_insert_payment( $payment_data = array() ) {
 	 *
 	 * @since 1.0
 	 *
-	 * @param int $payment_id The payment ID.
+	 * @param int   $payment_id   The payment ID.
 	 * @param array $payment_data Arguments passed.
 	 */
 	do_action( 'give_insert_payment', $payment->ID, $payment_data );
@@ -261,7 +261,7 @@ function give_create_payment( $payment_data ) {
 /**
  * Updates a payment status.
  *
- * @param  int $payment_id Payment ID.
+ * @param  int    $payment_id Payment ID.
  * @param  string $new_status New Payment Status. Default is 'publish'.
  *
  * @since  1.0
@@ -287,11 +287,11 @@ function give_update_payment_status( $payment_id, $new_status = 'publish' ) {
 /**
  * Deletes a Donation
  *
- * @param  int $payment_id Payment ID (default: 0).
+ * @param  int  $payment_id   Payment ID (default: 0).
  * @param  bool $update_donor If we should update the donor stats (default:true).
  *
  * @since  1.0
- * @global $give_logs
+ * @global      $give_logs
  *
  * @return void
  */
@@ -608,8 +608,8 @@ function give_check_for_existing_payment( $payment_id ) {
 /**
  * Get Payment Status
  *
- * @param WP_Post|Give_Payment|int $payment Payment object or payment ID.
- * @param bool $return_label Whether to return the translated status label instead of status value. Default false.
+ * @param WP_Post|Give_Payment|int $payment      Payment object or payment ID.
+ * @param bool                     $return_label Whether to return the translated status label instead of status value. Default false.
  *
  * @since 1.0
  *
@@ -1347,7 +1347,7 @@ function give_donation_amount( $donation_id = 0, $type = '' ) {
 	 * @param string  $formatted_amount Formatted amount.
 	 * @param double  $amount           Donation amount.
 	 * @param integer $donation_id      Donation ID.
-	 * @param string  $args             String parameter which will define context of donation amount..
+	 * @param string  $type             String parameter which will define context of donation amount..
 	 */
 	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $donation_id, $type );
 }
@@ -1379,7 +1379,7 @@ function give_get_payment_amount( $payment_id ) {
  *
  * @since 1.5
  *
- * @see give_get_payment_subtotal()
+ * @see   give_get_payment_subtotal()
  *
  * @return array Fully formatted payment subtotal.
  */
@@ -1445,7 +1445,7 @@ function give_set_payment_transaction_id( $payment_id = 0, $transaction_id = '' 
 /**
  * Retrieve the donation ID based on the key
  *
- * @param string $key the key to search for.
+ * @param string  $key  the key to search for.
  *
  * @since 1.0
  * @global object $wpdb Used to query the database using the WordPress Database API.
@@ -1468,7 +1468,7 @@ function give_get_purchase_id_by_key( $key ) {
 /**
  * Retrieve the donation ID based on the transaction ID
  *
- * @param string $key The transaction ID to search for.
+ * @param string  $key  The transaction ID to search for.
  *
  * @since 1.3
  * @global object $wpdb Used to query the database using the WordPress Database API.
@@ -1563,9 +1563,9 @@ function give_insert_payment_note( $payment_id = 0, $note = '' ) {
 	/**
 	 * Fires after payment note inserted.
 	 *
-	 * @param int    $note_id Note ID.
+	 * @param int    $note_id    Note ID.
 	 * @param int    $payment_id Payment ID.
-	 * @param string $note The note.
+	 * @param string $note       The note.
 	 *
 	 * @since 1.0
 	 */
@@ -1818,9 +1818,9 @@ function give_filter_where_older_than_week( $where = '' ) {
  *
  * Retrieves the form title and appends the level name if present.
  *
- * @param array $payment_meta Payment meta data.
- * @param bool $only_level If set to true will only return the level name if multi-level enabled.
- * @param string $separator The separator between the .
+ * @param array  $payment_meta Payment meta data.
+ * @param bool   $only_level   If set to true will only return the level name if multi-level enabled.
+ * @param string $separator    The separator between the .
  *
  * @since 1.5
  *
@@ -1866,8 +1866,8 @@ function give_get_payment_form_title( $payment_meta, $only_level = false, $separ
  *
  * Retrieves the Price ID when provided a proper form ID and price (donation) total
  *
- * @param int $form_id Form ID.
- * @param string $price Price ID.
+ * @param int    $form_id Form ID.
+ * @param string $price   Price ID.
  *
  * @return string $price_id
  */
@@ -1891,7 +1891,7 @@ function give_get_price_id( $form_id, $price ) {
 			}
 		}
 
-		if( is_null( $price_id ) && give_is_custom_price_mode( $form_id ) ) {
+		if ( is_null( $price_id ) && give_is_custom_price_mode( $form_id ) ) {
 			$price_id = 'custom';
 		}
 	}

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1313,20 +1313,39 @@ function give_remove_payment_prefix_postfix( $number ) {
 /**
  * Get Payment Amount
  *
- * Get the fully formatted payment amount. The payment amount is retrieved using give_get_payment_amount() and is then
+ * Get the fully formatted donation amount. The donation amount is retrieved using give_get_donation_amount() and is then
  * sent through give_currency_filter() and  give_format_amount() to format the amount correctly.
  *
- * @param int    $payment_id Payment ID.
- * @param string $type       Indicate where it is going to be appear eg: 'donor', 'receipt'.
+ * @param int          $donation_id Donation ID.
+ * @param array|string $args        Array of arguments or you can pass string parameter which will define context of donation amount.
  *
  * @since 1.0
  * @since 1.8.17 Added filter and internally use functions.
  *
- * @return string $amount Fully formatted payment amount.
+ * @return string $amount Fully formatted donation amount.
  */
-function give_payment_amount( $payment_id = 0, $type = '' ) {
-	$amount           = give_get_payment_amount( $payment_id );
-	$formatted_amount = give_currency_filter( give_format_amount( $amount, array( 'sanitize' => false ) ), give_get_payment_currency_code( $payment_id ) );
+function give_donation_amount( $donation_id = 0, $args = array() ) {
+	// Set donation amount context.
+	if ( is_string( $args ) ) {
+		$args = array( 'type' => $args );
+	}
+
+	// Set $args.
+	$args = wp_parse_args(
+		$args,
+		array(
+			// Indicate where it is going to be appear eg: 'donor', 'receipt'
+			'type'          => '',
+
+			// Amount format settings.
+			'format_amount' => array(
+				'sanitize' => false,
+			),
+		)
+	);
+
+	$amount           = give_get_payment_amount( $donation_id );
+	$formatted_amount = give_currency_filter( give_format_amount( $amount, $args['format_amount'] ), give_get_payment_currency_code( $donation_id ) );
 
 	/**
 	 * Filter payment amount.
@@ -1334,11 +1353,11 @@ function give_payment_amount( $payment_id = 0, $type = '' ) {
 	 * @since 1.8.17
 	 *
 	 * @param string  $formatted_amount Formatted amount.
-	 * @param double  $amount           Payment amount.
-	 * @param integer $payment_id       Donation ID.
-	 * @param string  $type             Type.
+	 * @param double  $amount           Donation amount.
+	 * @param integer $donation_id      Donation ID.
+	 * @param string  $args             Array of arguments.
 	 */
-	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $payment_id, $type );
+	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $donation_id, $args );
 }
 
 /**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1337,7 +1337,7 @@ function give_payment_amount( $payment_id = 0, $type = '' ) {
 	 * @param integer $payment_id       Donation ID.
 	 * @param string  $type             Type.
 	 */
-	return apply_filters( 'give_get_payment_amount', $formatted_amount, $amount, $payment_id, $type );
+	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $payment_id, $type );
 }
 
 /**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1316,16 +1316,28 @@ function give_remove_payment_prefix_postfix( $number ) {
  * Get the fully formatted payment amount. The payment amount is retrieved using give_get_payment_amount() and is then
  * sent through give_currency_filter() and  give_format_amount() to format the amount correctly.
  *
- * @param int $payment_id Payment ID.
+ * @param int    $payment_id Payment ID.
+ * @param string $type       Indicate where it is going to be appear eg: 'donor', 'receipt'.
  *
  * @since 1.0
  *
  * @return string $amount Fully formatted payment amount.
  */
-function give_payment_amount( $payment_id = 0 ) {
-	$amount = give_get_payment_amount( $payment_id );
+function give_payment_amount( $payment_id = 0, $type = '' ) {
+	$amount           = give_get_payment_amount( $payment_id );
+	$formatted_amount = give_currency_filter( give_format_amount( $amount, array( 'sanitize' => false ) ), give_get_payment_currency_code( $payment_id ) );
 
-	return give_currency_filter( give_format_amount( $amount, array( 'sanitize' => false ) ), give_get_payment_currency_code( $payment_id ) );
+	/**
+	 * Filter payment amount.
+	 *
+	 * @since 1.8.17
+	 *
+	 * @param string  $formatted_amount Formatted amount.
+	 * @param double  $amount           Payment amount.
+	 * @param integer $payment_id       Donation ID.
+	 * @param string  $type             Type.
+	 */
+	return apply_filters( 'give_get_payment_amount', $formatted_amount, $amount, $payment_id, $type );
 }
 
 /**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1316,36 +1316,28 @@ function give_remove_payment_prefix_postfix( $number ) {
  * Get the fully formatted donation amount. The donation amount is retrieved using give_get_donation_amount() and is then
  * sent through give_currency_filter() and  give_format_amount() to format the amount correctly.
  *
- * @param int          $donation_id Donation ID.
- * @param array|string $args        Array of arguments or you can pass string parameter which will define context of donation amount.
+ * @param int    $donation_id Donation ID.
+ * @param string $type        String parameter which will define context of donation amount.
  *
  * @since 1.0
  * @since 1.8.17 Added filter and internally use functions.
  *
  * @return string $amount Fully formatted donation amount.
  */
-function give_donation_amount( $donation_id = 0, $args = array() ) {
-	// Set donation amount context.
-	if ( is_string( $args ) ) {
-		$args = array( 'type' => $args );
-	}
+function give_donation_amount( $donation_id = 0, $type = '' ) {
+	$donation_currency = give_get_payment_currency_code( $donation_id );
+	$amount            = give_get_payment_amount( $donation_id );
 
-	// Set $args.
-	$args = wp_parse_args(
-		$args,
-		array(
-			// Indicate where it is going to be appear eg: 'donor', 'receipt'
-			'type'          => '',
-
-			// Amount format settings.
-			'format_amount' => array(
+	$formatted_amount = give_currency_filter(
+		give_format_amount(
+			$amount,
+			array(
 				'sanitize' => false,
-			),
-		)
+				'currency' => $donation_currency,
+			)
+		),
+		$donation_currency
 	);
-
-	$amount           = give_get_payment_amount( $donation_id );
-	$formatted_amount = give_currency_filter( give_format_amount( $amount, $args['format_amount'] ), give_get_payment_currency_code( $donation_id ) );
 
 	/**
 	 * Filter payment amount.
@@ -1355,9 +1347,9 @@ function give_donation_amount( $donation_id = 0, $args = array() ) {
 	 * @param string  $formatted_amount Formatted amount.
 	 * @param double  $amount           Donation amount.
 	 * @param integer $donation_id      Donation ID.
-	 * @param string  $args             Array of arguments.
+	 * @param string  $args             String parameter which will define context of donation amount..
 	 */
-	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $donation_id, $args );
+	return apply_filters( 'give_get_donation_amount', $formatted_amount, $amount, $donation_id, $type );
 }
 
 /**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1320,6 +1320,7 @@ function give_remove_payment_prefix_postfix( $number ) {
  * @param string $type       Indicate where it is going to be appear eg: 'donor', 'receipt'.
  *
  * @since 1.0
+ * @since 1.8.17 Added filter and internally use functions.
  *
  * @return string $amount Fully formatted payment amount.
  */

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -48,7 +48,7 @@ $give_receipt_args['donation_receipt']['date'] = array(
 
 $give_receipt_args['donation_receipt']['total_donation'] = array(
 	'name'    => __( 'Total Donation', 'give' ),
-	'value'   => give_payment_amount( $donation_id ),
+	'value'   => give_payment_amount( $donation_id, 'receipt' ),
 	'display' => $give_receipt_args['price'],
 );
 

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -48,7 +48,7 @@ $give_receipt_args['donation_receipt']['date'] = array(
 
 $give_receipt_args['donation_receipt']['total_donation'] = array(
 	'name'    => __( 'Total Donation', 'give' ),
-	'value'   => give_payment_amount( $donation_id, 'receipt' ),
+	'value'   => give_donation_amount( $donation_id, 'receipt' ),
 	'display' => $give_receipt_args['price'],
 );
 

--- a/tests/unit-tests/tests-payments.php
+++ b/tests/unit-tests/tests-payments.php
@@ -549,9 +549,9 @@ class Tests_Payments extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * Test give_payment_amount().
+	 * Test give_donation_amount().
 	 */
-	public function test_get_donation_amount() {
+	public function test_give_donation_amount() {
 		$donation = new Give_Payment( $this->_payment_id );
 
 		$this->assertEquals( '&#36;&#x200e;20.00', give_donation_amount( $donation->ID ) );

--- a/tests/unit-tests/tests-payments.php
+++ b/tests/unit-tests/tests-payments.php
@@ -551,10 +551,16 @@ class Tests_Payments extends Give_Unit_Test_Case {
 	/**
 	 * Test give_payment_amount().
 	 */
-	public function test_payment_amount() {
-		$payment = new Give_Payment( $this->_payment_id );
+	public function test_get_donation_amount() {
+		$donation = new Give_Payment( $this->_payment_id );
 
-		$this->assertEquals( '&#36;&#x200e;20.00', give_payment_amount( $payment->ID ) );
-		$this->assertEquals( '&#36;&#x200e;20.00', give_payment_amount( $payment->ID ), 'donor' );
+		$this->assertEquals( '&#36;&#x200e;20.00', give_donation_amount( $donation->ID ) );
+		$this->assertEquals( '&#36;&#x200e;20.00', give_donation_amount( $donation->ID ), 'donor' );
+
+		$payment_meta = give_get_payment_meta( $donation->ID );
+		$payment_meta['currency'] = 'INR';
+
+		give_update_meta( $donation->ID, '_give_payment_meta', $payment_meta );
+		$this->assertEquals( '&#8377;&#x200e;20.00', give_donation_amount( $donation->ID, 'receipt' ) );
 	}
 }

--- a/tests/unit-tests/tests-payments.php
+++ b/tests/unit-tests/tests-payments.php
@@ -547,4 +547,14 @@ class Tests_Payments extends Give_Unit_Test_Case {
 			$this->assertEquals( $level_id, give_get_price_id( $form->ID, $amount ) );
 		}
 	}
+
+	/**
+	 * Test give_payment_amount().
+	 */
+	public function test_payment_amount() {
+		$payment = new Give_Payment( $this->_payment_id );
+
+		$this->assertEquals( '&#36;&#x200e;20.00', give_payment_amount( $payment->ID ) );
+		$this->assertEquals( '&#36;&#x200e;20.00', give_payment_amount( $payment->ID ), 'donor' );
+	}
 }


### PR DESCRIPTION
## Description
This PR will fix #2317 

Filtering the amount when getting payment amount through `give_payment_amount`.

## How Has This Been Tested?
- RanUnit test
- By applying filter manually.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
 New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

