### PR TITLE
Passing form's currency while format the amount.

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -407,7 +407,7 @@ function give_format_amount( $amount, $args = array() ) {
 	if ( ! empty( $amount ) ) {
 		// Sanitize amount before formatting.
 		$amount = ! empty( $args['sanitize'] ) ?
-			give_maybe_sanitize_amount( $amount, $decimals ) :
+			give_maybe_sanitize_amount( $amount, array( 'number_decimals' => $decimals, 'currency' => $currency ) ) :
 			number_format( $amount, $decimals, '.', '' );
 
 		switch ( $currency ) {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -389,7 +389,7 @@ function give_output_donation_amount_top( $form_id = 0, $args = array() ) {
 	$currency_position   = isset( $give_options['currency_position'] ) ? $give_options['currency_position'] : 'before';
 	$symbol              = give_currency_symbol( give_get_currency( $form_id, $args ) );
 	$currency_output     = '<span class="give-currency-symbol give-currency-position-' . $currency_position . '">' . $symbol . '</span>';
-	$default_amount      = give_format_amount( give_get_default_form_amount( $form_id ), array( 'sanitize' => false ) );
+	$default_amount      = give_format_amount( give_get_default_form_amount( $form_id ), array( 'sanitize' => false, 'currency' => give_get_currency( $form_id ) ) );
 	$custom_amount_text  = give_get_meta( $form_id, '_give_custom_amount_text', true );
 
 	/**


### PR DESCRIPTION
## Description
This PR will fix #2197

Donation amount was not showing/sanitizing in form based currency format.

@ravinderk please check and do not merge, I will add more commit related to this if I get while working.

## How Has This Been Tested?
Manually.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
