### PR TITLE
Goals without decimals and added filters: issue/2372

### DIFF
--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -8,7 +8,7 @@ $goal_option = give_get_meta( $form->ID, '_give_goal_option', true );
 
 //Sanity check - ensure form has pass all condition to show goal.
 if (
-	( isset( $args['show_goal'] ) &&  ! filter_var( $args['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
+	( isset( $args['show_goal'] ) && ! filter_var( $args['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
 	|| empty( $form->ID )
 	|| ( is_singular( 'give_forms' ) && ! give_is_setting_enabled( $goal_option ) )
 	|| ! give_is_setting_enabled( $goal_option )
@@ -64,9 +64,12 @@ if ( $income >= $goal ) {
 			<?php
 			if ( $goal_format !== 'percentage' ) :
 
+				$income_format_args = apply_filters( 'give_goal_income_format_args', array( 'sanitize' => false, 'currency' => $form_currency, 'decimal' => false ), $form_id );
+				$goal_format_args   = apply_filters( 'give_goal_amount_format_args', array( 'sanitize' => false, 'currency' => $form_currency, 'decimal' => false ), $form_id );
+
 				// Get formatted amount.
-				$income = give_human_format_large_amount( give_format_amount( $income, array( 'sanitize' => false, 'currency' => $form_currency ) ) );
-				$goal   = give_human_format_large_amount( give_format_amount( $goal, array( 'sanitize' => false, 'currency' => $form_currency ) ) );
+				$income = give_human_format_large_amount( give_format_amount( $income, $income_format_args ) );
+				$goal   = give_human_format_large_amount( give_format_amount( $goal, $goal_format_args ) );
 
 				echo sprintf(
 				/* translators: 1: amount of income raised 2: goal target amount. */


### PR DESCRIPTION
## Description

1. Filter goal and income args
2. Don't output currency decimals by default - Resolves https://github.com/WordImpress/Give/issues/2372


## How Has This Been Tested
- Manually

## Screenshots (jpeg or gifs if applicable):
![2017-11-21_19-38-14](https://user-images.githubusercontent.com/1571635/33108963-bccf2fb6-cef3-11e7-98c1-cad8b8231028.png)

## Types of changes
- UX update
- New filters

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.