### PR TITLE
Minorfix/2356

### DIFF
--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -247,9 +247,10 @@ function give_bc_1817_cleanup_user_roles( $caps ){
 
 	if (
 		! give_has_upgrade_completed( 'v1817_cleanup_user_roles' ) &&
-		! isset( $caps['view_give_payments'] )
+		! isset( $caps['view_give_payments'] ) &&
+		current_user_can( 'manage_options' )
 	) {
-		give_v1817_process_cleanup_user_roles();
+		$caps['view_give_payments'] = true;
 	}
 
 	return $caps;

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -247,10 +247,9 @@ function give_bc_1817_cleanup_user_roles( $caps ){
 
 	if (
 		! give_has_upgrade_completed( 'v1817_cleanup_user_roles' ) &&
-		! isset( $caps['view_give_payments'] ) &&
-		current_user_can( 'manage_options' )
+		! isset( $caps['view_give_payments'] )
 	) {
-		$caps['view_give_payments'] = true;
+		give_v1817_process_cleanup_user_roles();
 	}
 
 	return $caps;

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1249,7 +1249,7 @@ function give_v1817_process_cleanup_user_roles() {
 
 	global $wp_roles;
 
-	if( ! ( $wp_roles instanceof  WP_Role ) ) {
+	if( ! ( $wp_roles instanceof  WP_Roles ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
This PR resolved #2356 

## How Has This Been Tested?
There was a minor issue regarding the naming convention. I've tested it creating a new WP instance and then changed version from release 1.8.16 to 1.8.17 and make sure it works.

Check the below screenshot which shows that upgrade routine is not executed but the change to administrator user role is reflected until user executes the upgrade routine to make sure administrator has all the rights.

## Screenshots
![image](https://user-images.githubusercontent.com/1852711/33642938-52d7b108-da62-11e7-9846-d9b16525cb7c.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.