### PR TITLE
Hide first multi-level repeatable row's delete button

### DIFF
--- a/assets/scss/admin/forms.scss
+++ b/assets/scss/admin/forms.scss
@@ -587,6 +587,11 @@ ASIDE
 	}
 }
 
+// Hide first row remove button for multi-level.
+#_give_donation_levels_field .give-row:nth-of-type(2) .give-remove {
+  display: none !important;
+}
+
 //-------------------------------------
 // Metabox Tabs
 //-------------------------------------


### PR DESCRIPTION
## Description
Previous to this PR you could remove the first row of a multi-level form.  This would cause the PHP notices within #2451 

Admins should use "Set" configuration if they don't want levels. You shouldn't be able to remove _all_ rows within the repeater. This hides the remove row button with CSS for just the _first_ level. 

Resolves #2451

## How Has This Been Tested? 
- Manually

## Screenshots (jpeg or gifs if applicable):

![2017-12-14_11-21-03](https://user-images.githubusercontent.com/1571635/34010279-f5698bee-e0c0-11e7-880a-8a6fb0a5c2c8.gif)

## Types of changes
- UX bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.