### PR TITLE
Issues/2561

### DIFF
--- a/includes/class-give-db-meta.php
+++ b/includes/class-give-db-meta.php
@@ -273,10 +273,21 @@ class Give_DB_Meta extends Give_DB {
 			$clause = str_replace( $wpdb->postmeta, $this->table_name, $clause );
 
 			if( false !== strpos( $clause, 'INNER JOIN' ) ) {
-				preg_match( '/INNER JOIN wp_give_paymentmeta AS (.*) ON/', $clause, $alias_table_name );
-				if( isset( $alias_table_name[1] ) ) {
-					$clause = str_replace( "{$alias_table_name[1]}.post_id", "{$this->table_name}.{$this->meta_type}_id", $clause );
+				$clause = explode( 'INNER JOIN', $clause );
+
+				foreach ( $clause as $key => $clause_part ) {
+					if( empty( $clause_part ) ) {
+						continue;
+					}
+
+					preg_match( '/wp_give_paymentmeta AS (.*) ON/', $clause_part, $alias_table_name );
+
+					if( isset( $alias_table_name[1] ) ) {
+						$clause[$key] = str_replace( "{$alias_table_name[1]}.post_id", "{$alias_table_name[1]}.{$this->meta_type}_id", $clause_part );
+					}
 				}
+				
+				$clause = implode( 'INNER JOIN ', $clause );
 			}
 		}
 

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -708,12 +708,11 @@ class Give_Payments_Query extends Give_Stats {
 		}
 
 		$this->__set(
-			'meta_query', array(
-				array(
-					'key'     => '_give_payment_form_id',
-					'value'   => $this->args['give_forms'],
-					'compare' => $compare,
-				),
+			'meta_query',
+			array(
+				'key'     => '_give_payment_form_id',
+				'value'   => $this->args['give_forms'],
+				'compare' => $compare,
 			)
 		);
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will resolve #2561 

@DevinWalker Custom meta table support is tricky. Previously I was handling only one `INNER JOIN` but `meta_query` with `EXIST` compare can cause of multiple `INNER JOIN`. I updated logic to handle such case.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually doing some custom queries and donation listing page with filters.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.