### PR TITLE
Fix use of give_locate_template function : wrong params

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -51,7 +51,7 @@ function give_get_template( $template_name, $args = array(), $template_path = ''
 
 	$template_names = array( $template_name . '.php' );
 
-	$located = give_locate_template( $template_names, $template_path, $default_path );
+	$located = give_locate_template( $template_names );
 
 	if ( ! file_exists( $located ) ) {
 		/* translators: %s: the template */


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
In the give_get_template function, the function calls give_locate_template function by passing two extra non required parameters $template_path and $default_path. But when we look at the give_locate_template function definition, we see that the last two parameters are not related to default path and template path, So it seems to be a little error of code.

By the way, when removing this little error, it seems that $template_path and $default_path parameters are never use in the give_get_template function except in filters, is this normal ?

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I did not test anything, just saw this error when trying to figure out if I had to use this function

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix 
