### PR TITLE
#2581  [Give 2.0] WordPress Default Admin Email Goes Blank

### DIFF
--- a/includes/admin/emails/class-new-donor-register-email.php
+++ b/includes/admin/emails/class-new-donor-register-email.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'Give_New_Donor_Register_Email' ) ) :
 					esc_attr__( '[%s] New User Registration', 'give' ),
 					get_bloginfo( 'name' )
 				),
-				'default_email_massage' => $this->get_default_email_message(),
+				'default_email_message' => $this->get_default_email_message(),
 			) );
 
 			// Setup action hook.


### PR DESCRIPTION
**Fix issue:** Email is missing default content in 2.0+