### PR TITLE
Issue/2612

### DIFF
--- a/includes/class-give-tooltips.php
+++ b/includes/class-give-tooltips.php
@@ -119,7 +119,6 @@ class Give_Tooltips {
 
 		// Set classes.
 		$args['attributes']['class'] = ! empty( $args['attributes']['class'] ) ? $args['attributes']['class'] : '';
-		$args['attributes']['class'] = 'give-tooltip ';
 		$args['attributes']['class'] .= " {$tooltip_pos[ $args['position'] ]}";
 		$args['attributes']['class'] .= ! empty( $args['status'] ) ? " {$tooltip_status[ $args['status'] ]}" : '';
 		$args['attributes']['class'] .= ! empty( $args['size'] ) ? " {$tooltip_size[ $args['size'] ]}" : '';


### PR DESCRIPTION
## Description
This PR resolves #2612 

## How Has This Been Tested?
I've tested it with by checking the UI/UX as well as testing the tooltip functioning.

@DevinWalker This issue was appeared due to addition of `give-tooltip` class. I think the tooltips of hint.css operates with `hint--*` classes and not `give-tooltip`. Also, `give-tooltip` class is used when Qtip is in existence. Let me know your thoughts.

## Screenshots (jpeg or gifs if applicable):
![gif](http://g.recordit.co/MjbO3GNYa2.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.