### PR TITLE
Issue/2677|2533 - MySQL error after updating on Email Preview

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -137,6 +137,11 @@ $give_updates = Give_Updates::get_instance();
 			</tr>
 		<?php endif;?>
 		<tr>
+			<td data-export-label="Table Prefix Length"><?php _e( 'Table Prefix', 'give' ); ?>:</td>
+			<td class="help"><?php echo Give()->tooltips->render_help( __( 'The table prefix used in your WordPress database.', 'give' ) ); ?></td>
+			<td><?php echo esc_html( $wpdb->prefix ); ?></td>
+		</tr>
+		<tr>
 			<td data-export-label="Table Prefix Length"><?php _e( 'Table Prefix Length', 'give' ); ?>:</td>
 			<td class="help"><?php echo Give()->tooltips->render_help( __( 'The length of the table prefix used in your WordPress database.', 'give' ) ); ?></td>
 			<td><?php echo esc_html( strlen( $wpdb->prefix ) ); ?></td>

--- a/includes/class-give-db-logs.php
+++ b/includes/class-give-db-logs.php
@@ -289,7 +289,7 @@ class Give_DB_Logs extends Give_DB {
 		$this->validate_params( $args );
 
 		if ( $args['number'] < 1 ) {
-			$args['number'] = 999999999999;
+			$args['number'] = 99999999999;
 		}
 
 		// Where clause for primary table.

--- a/includes/donors/class-give-donors-query.php
+++ b/includes/donors/class-give-donors-query.php
@@ -189,7 +189,7 @@ class Give_Donors_Query {
 		global $wpdb;
 
 		if ( $this->args['number'] < 1 ) {
-			$this->args['number'] = 999999999999;
+			$this->args['number'] = 99999999999;
 		}
 
 		$where = $this->get_where_query();

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -844,7 +844,7 @@ class Give_Payments_Query extends Give_Stats {
 		$sql = $wpdb->prepare(
 			"SELECT {$fields} FROM {$wpdb->posts} LIMIT %d,%d;",
 			absint( $this->args['offset'] ),
-			( empty( $this->args['nopaging'] ) ? absint( $this->args['posts_per_page'] ) : 999999999999999 )
+			( empty( $this->args['nopaging'] ) ? absint( $this->args['posts_per_page'] ) : 99999999999 )
 		);
 
 		// $where, $orderby and order already prepared query they can generate notice if you re prepare them in above.

--- a/tests/unit-tests/tests-donor-query.php
+++ b/tests/unit-tests/tests-donor-query.php
@@ -70,7 +70,7 @@ class Tests_Give_Donors_Query extends Give_Unit_Test_Case {
 			),
 			array(
 				array( 'number' => - 1 ),
-				'SELECT wptests_give_donors.* FROM wptests_give_donors WHERE 1=1 ORDER BY wptests_give_donors.id+0 DESC LIMIT 0,999999999999;',
+				'SELECT wptests_give_donors.* FROM wptests_give_donors WHERE 1=1 ORDER BY wptests_give_donors.id+0 DESC LIMIT 0,99999999999;',
 			),
 
 			/**


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR fixes #2677 #2533 

- In Windows OS integer number should not exceed the limits of PHP_INT_MAX 
- We can face this issue in the Windows/Apache local environment only. because most of the servers are running on the Linux OS.
- I guess none of the donation websites would have 999999999999999 number of donations/donors, so decreasing the value to 99999999999 should not affect anything. 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

## Screenshots (jpeg or gifs if applicable):
![screenshot-localhost-2018-01-19-12-27-37-951](https://user-images.githubusercontent.com/14994452/35138363-2b05e7d8-fd14-11e7-9f7d-1a2cf1b34d30.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.