### PR TITLE
Issue/2700 - Don't use fallback in give_get_price_option_name() to simplify UX

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1786,7 +1786,7 @@ function give_get_donation_form_title( $donation, $args = array() ) {
 			$custom_amount_text = give_get_meta( $form_id, '_give_custom_amount_text', true );
 			$level_label        = ! empty( $custom_amount_text ) ? $custom_amount_text : __( 'Custom Amount', 'give' );
 		} elseif ( give_has_variable_prices( $form_id ) ) {
-			$level_label = give_get_price_option_name( $form_id, $price_id );
+			$level_label = give_get_price_option_name( $form_id, $price_id, 0, false );
 		}
 
 		// Only add separator if there is a form title.

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1786,7 +1786,7 @@ function give_get_donation_form_title( $donation, $args = array() ) {
 			$custom_amount_text = give_get_meta( $form_id, '_give_custom_amount_text', true );
 			$level_label        = ! empty( $custom_amount_text ) ? $custom_amount_text : __( 'Custom Amount', 'give' );
 		} elseif ( give_has_variable_prices( $form_id ) ) {
-			$level_label = give_get_price_option_name( $form_id, $price_id, 0, false );
+			$level_label = give_get_price_option_name( $form_id, $price_id, $donation->ID, false );
 		}
 
 		// Only add separator if there is a form title.


### PR DESCRIPTION
## Description
Removes price level displaying when the level text is blank in various places in wp-admin and the frontend. - Resolves #2700 

## Screenshots (jpeg or gifs if applicable):
![2018-01-23_17-11-12](https://user-images.githubusercontent.com/1571635/35310265-6a2583c0-0065-11e8-8d37-923a82ec1af3.png)


## Types of changes
- UX