### PR TITLE
Fix - Displays Upgrade Notice on Fresh Installs

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -141,7 +141,11 @@ function give_run_install() {
 			'v20_rename_donor_tables',
 			'v20_upgrades_donor_name',
 			'v20_upgrades_user_address',
-			'v20_upgrades_payment_metadata'
+			'v20_upgrades_payment_metadata',
+			'v201_upgrades_payment_metadata',
+			'v201_add_missing_donors',
+			'v201_move_metadata_into_new_table',
+			'v201_logs_upgrades'
 		);
 
 		foreach ( $upgrade_routines as $upgrade ) {


### PR DESCRIPTION
## Description
This PR is related to issue on fresh installs with release 2.0.1

## How Has This Been Tested?
I've tested this manually.
1. Activated Give Plugin with this branch containing fix.
2. Meta Tables are created as expected.
3. No Upgrade notice displayed on fresh install.
4. Display Upgrade notice when tested on existing install with Give 1.8.19

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.