### PR TITLE
Issue/2728 - Resolve query issue with Donation Form Goal option in shortcode builder

### DIFF
--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -271,7 +271,7 @@ abstract class Give_Shortcode_Generator {
 	}
 
 	/**
-	 * Generate a TinyMCE listbox field for a post_type
+	 * Generate a TinyMCE listbox field for a post_type.
 	 *
 	 * @param array $field
 	 *
@@ -289,12 +289,15 @@ abstract class Give_Shortcode_Generator {
 		);
 
 		$args    = wp_parse_args( (array) $field['query_args'], $args );
-		$posts   = get_posts( $args );
+		$posts   = new WP_Query( $args );
 		$options = array();
 
-		if ( $posts ) {
-			foreach ( $posts as $post ) {
-				$options[ absint( $post->ID ) ] = ( empty( $post->post_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $post->ID ) : $post->post_title );
+		if ( $posts->have_posts() ) {
+			while ( $posts->have_posts() ) {
+				$posts->the_post();
+				$post_title = get_the_title();
+				$post_id = get_the_ID();
+				$options[ absint( $post_id ) ] = ( empty( $post_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $post_id ) : $post_title );
 			}
 
 			$field['type']    = 'listbox';

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -436,7 +436,7 @@ function give_check_for_form_price_variations() {
 	$form_id = intval( $_POST['form_id'] );
 	$form    = get_post( $form_id );
 
-	if ( 'give_forms' != $form->post_type ) {
+	if ( 'give_forms' !== $form->post_type ) {
 		die( '-2' );
 	}
 
@@ -486,7 +486,7 @@ function give_check_for_form_price_variations_html() {
 	}
 
 	$form = get_post( $form_id );
-	if ( ! empty( $form->post_type ) && 'give_forms' != $form->post_type ) {
+	if ( ! empty( $form->post_type ) && 'give_forms' !== $form->post_type ) {
 		wp_die();
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1085,8 +1085,8 @@ function give_is_add_new_form_page() {
  * Get Form/Payment meta.
  *
  * Note: This function will help you to get meta for payment and form.
- *       If you want to get meta for donor then use get_meta of Give_Donor and
- *       If you want to get meta for log then use get_meta of Give_Logging->logmeta_db
+ *       If you want to get meta for donors then use get_meta of Give_Donor and
+ *       If you want to get meta for logs then use get_meta of Give_Logging->logmeta_db.
  *
  * @since 1.8.8
  *


### PR DESCRIPTION
## Description
Problem was we were using `get_posts()` which doesn't working in 2.0+ because we moved the form meta to it's own table.

Resolves #2728 

## How Has This Been Tested?
- Manually

## Screenshots (jpeg or gifs if applicable):
![2018-01-27_19-53-00](https://user-images.githubusercontent.com/1571635/35478801-b34792b2-039b-11e8-9757-f05f06ef6737.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.