### PR TITLE
Issue #2091 - Reset Form Fields on clicking browser back button

### DIFF
--- a/assets/js/frontend/give.js
+++ b/assets/js/frontend/give.js
@@ -95,6 +95,8 @@ jQuery( function( $ ) {
 	doc.on( 'change', '#give_profile_billing_address_wrap #give_address_country', update_profile_state_field );
 
 	// Reset Form Fields on clicking back button of browser.
+	// @see https://developer.mozilla.org/en-US/Firefox/Releases/1.5/Using_Firefox_1.5_caching
+	// @see https://webkit.org/blog/427/webkit-page-cache-i-the-basics/
 	window.addEventListener( 'pageshow', function( event ) {
 		var historyTraversal = event.persisted || ( typeof 'undefined' !== window.performance && 2 === window.performance.navigation.type );
 

--- a/assets/js/frontend/give.js
+++ b/assets/js/frontend/give.js
@@ -94,7 +94,15 @@ jQuery( function( $ ) {
 
 	doc.on( 'change', '#give_profile_billing_address_wrap #give_address_country', update_profile_state_field );
 
-} );
+	// Reset Form Fields on clicking back button of browser.
+	window.addEventListener( 'pageshow', function( event ) {
+		var historyTraversal = event.persisted || ( typeof 'undefined' !== window.performance && 2 === window.performance.navigation.type );
+
+		if ( historyTraversal ) {
+			$( 'body' ).find( 'form.give-form' )[0].reset();
+		}
+	});
+});
 
 /**
  * Open form modal


### PR DESCRIPTION
## Description
This PR resolves #2091 

## How Has This Been Tested?
I've tested this PR in the following browser, after completing the donation and then clicking the back button of the browser.
- Chrome
- Firefox
- Safari

## Screenshots (jpeg or gifs if applicable):

**Chrome**
![Chrome](http://g.recordit.co/RrtLWX7MJi.gif)

**Firefox**
![Firefox](http://g.recordit.co/6KLtD772k1.gif)

**Safari**
![Safari](http://g.recordit.co/7e4EJ3KY2n.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.