### PR TITLE
issue-2553 Fix success message on profile edit and logout on password…

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -9,17 +9,24 @@
  */
 $current_user     = wp_get_current_user();
 
-if ( is_user_logged_in() ):
-	$user_id = get_current_user_id();
+if ( is_user_logged_in() ) :
+	$user_id      = get_current_user_id();
 	$first_name   = get_user_meta( $user_id, 'first_name', true );
 	$last_name    = get_user_meta( $user_id, 'last_name', true );
 	$display_name = $current_user->display_name;
 	$address      = give_get_donor_address( $user_id, array( 'address_type' => 'personal' ) );
 
-	if ( isset( $_GET['updated'] ) && $_GET['updated'] == true && ! give_get_errors() ): ?>
-		<p class="give_success">
-			<strong><?php esc_html_e( 'Success:', 'give' ); ?></strong> <?php esc_html_e( 'Your profile has been updated.', 'give' ); ?>
-		</p>
+	if ( isset( $_GET['updated'] ) && 'true' === $_GET['updated'] && ! give_get_errors() ) :
+		if ( isset( $_GET['update_code'] ) ) :?>
+				<?php
+				switch ( $_GET['update_code'] ) {
+					case '1':
+						printf( '<p class="give_success"><strong>%1$s</strong> %2$s</p>', esc_html__( 'Success:', 'give' ), esc_html__( 'Your profile has been updated.', 'give' ) );
+						break;
+				}
+				?>
+			</p>
+		<?php endif; ?>
 	<?php endif; ?>
 
 	<?php Give()->notices->render_frontend_notices( 0 ); ?>
@@ -182,7 +189,28 @@ if ( is_user_logged_in() ):
 	?>
 
 	<?php
-else:
-	_e( 'You need to login to edit your profile.', 'give' );
-	echo give_login_form();
+else :
+	if ( isset( $_GET['updated'] ) && 'true' === $_GET['updated'] && ! give_get_errors() ) {
+		if ( isset( $_GET['update_code'] ) ) {
+			switch ( $_GET['update_code'] ) {
+				case '2':
+					printf( '<p class="give_success"><strong>%1$s</strong> %2$s</p>', esc_html__( 'Success:', 'give' ), esc_html__( 'Your profile and password has been updated.', 'give' ) );
+					_e( 'Login with your new credentials.', 'give' );
+					echo give_login_form();
+					break;
+
+				case '3':
+					printf( '<p class="give_success"><strong>%1$s</strong> %2$s</p>', esc_html__( 'Success:', 'give' ), esc_html__( 'Your password has been updated.', 'give' ) );
+					_e( 'Login with your new credentials.', 'give' );
+					echo give_login_form();
+					break;
+
+				default:
+					break;
+			}
+		}
+	} else {
+		_e( 'You need to login to edit your profile.', 'give' );
+		echo give_login_form();
+	}
 endif;


### PR DESCRIPTION
Related #2553 

## Description

- Change of _first_name, last_name, display_name or email_  will output a success message as:
`Your profile has been updated.`
- Changing only the password will output a success message as:
`Your password has been updated`
- Change of both of the above will display a success message as:
`Your profile and password has been updated.`
- Change of password will logout and redirect to the current page with a success message corresponding 
to the type of change.

## How Has This Been Tested?
This has only been tested manually by first updating profile, then only updating password, and then updating everything all at once.

## Types of changes
Previously, on successfully updating the profile, the page redirected to:
`http://give.local/profile-editor-shortcode/?updated=true`

Now the page redirects with an additional query string parameter:
`http://give.local/profile-editor-shortcode/?updated=true&update_code={number}`

Where {number} takes values:
`0`: No change
`1`: Profile change only
`2`: Profile and password change
`3`: Password change only

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.