### PR TITLE
fix(payments): Remove custom amount label from set donation {donation} tag #2653

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1781,11 +1781,17 @@ function give_get_donation_form_title( $donation, $args = array() ) {
 		}
 
 		$form_title_html = $form_title;
-		$donation_option  = give_get_meta( $form_id, '_give_price_option', true );
 
-		if ( 'custom' === $price_id && 'set' !== $donation_option ) {
+		if ( 'custom' === $price_id ) {
+
 			$custom_amount_text = give_get_meta( $form_id, '_give_custom_amount_text', true );
 			$level_label        = ! empty( $custom_amount_text ) ? $custom_amount_text : __( 'Custom Amount', 'give' );
+
+			// Show custom amount level only in backend otherwise hide it.
+			if( 'set' === give_get_meta( $form_id, '_give_price_option', true ) && ! is_admin()  ) {
+				$level_label = '';
+			}
+
 		} elseif ( give_has_variable_prices( $form_id ) ) {
 			$level_label = give_get_price_option_name( $form_id, $price_id, $donation->ID, false );
 		}

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1781,8 +1781,9 @@ function give_get_donation_form_title( $donation, $args = array() ) {
 		}
 
 		$form_title_html = $form_title;
+		$donation_option  = give_get_meta( $form_id, '_give_price_option', true );
 
-		if ( 'custom' === $price_id ) {
+		if ( 'custom' === $price_id && 'set' !== $donation_option ) {
 			$custom_amount_text = give_get_meta( $form_id, '_give_custom_amount_text', true );
 			$level_label        = ! empty( $custom_amount_text ) ? $custom_amount_text : __( 'Custom Amount', 'give' );
 		} elseif ( give_has_variable_prices( $form_id ) ) {


### PR DESCRIPTION
Related #2653 

## Description
If the donation option is "set" and a "Custom Amount Text" is set then it will only display in front-end(current behaviour) and will not be appended in the receipt and email.

## How Has This Been Tested?
Tested manually

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.