### PR TITLE
Wrong text domain

### DIFF
--- a/includes/admin/class-blank-slate.php
+++ b/includes/admin/class-blank-slate.php
@@ -260,7 +260,7 @@ class Give_Blank_Slate {
 			'cta_text'  => __( 'Create Donation Form', 'give' ),
 			'cta_link'  => admin_url( 'post-new.php?post_type=give_forms' ),
 			'help'      => sprintf(
-				__( 'Need help? Get started with %sGive 101%s.', 'wbpr' ),
+				__( 'Need help? Get started with %sGive 101%s.', 'give' ),
 				'<a href="http://docs.givewp.com/give101/" target="_blank">',
 				'</a>'
 			),
@@ -278,7 +278,7 @@ class Give_Blank_Slate {
 				'cta_text' => __( 'View All Forms', 'give' ),
 				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
 				'help'     => sprintf(
-					__( 'Need help? Learn more about %sDonations%s.', 'wbpr' ),
+					__( 'Need help? Learn more about %sDonations%s.', 'give' ),
 					'<a href="http://docs.givewp.com/core-donations/">',
 					'</a>'
 				),
@@ -293,7 +293,7 @@ class Give_Blank_Slate {
 				'cta_text' => __( 'View All Forms', 'give' ),
 				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
 				'help'     => sprintf(
-					__( 'Need help? Learn more about %sDonors%s.', 'wbpr' ),
+					__( 'Need help? Learn more about %sDonors%s.', 'give' ),
 					'<a href="http://docs.givewp.com/core-donors/">',
 					'</a>'
 				),


### PR DESCRIPTION
Strings were missing in translations. Text domain for three strings were set to 'wbpr' in stead of 'give'.

![schermafbeelding 2018-02-15 om 15 40 37](https://user-images.githubusercontent.com/867632/36262054-a9c800bc-1266-11e8-9f08-929c68b52d82.png)
