### PR TITLE
fix(jquery-deprecated): remove .load() use .on('load') #2818

### DIFF
--- a/assets/js/frontend/give-donations.js
+++ b/assets/js/frontend/give-donations.js
@@ -1161,7 +1161,7 @@ jQuery(function ($) {
 	});
 });
 
-jQuery(window).load(function () {
+jQuery(window).on('load', function () {
 
 	/**
 	 * Validate cc fields on change


### PR DESCRIPTION
## Description
Swapped out deprecated jquery method for `.on()`

Resolves #2818 