### PR TITLE
feat(export): Provide users with options on settings export. #2716

### DIFF
--- a/assets/src/css/admin/reports.scss
+++ b/assets/src/css/admin/reports.scss
@@ -204,6 +204,16 @@ body.give_forms_page_give-reports table.export-options-table {
 
 }
 
+.settings-excludes-list {
+  max-height: 120px;
+  overflow: auto;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+}
+
+.settings-excludes-list li {
+  margin: 3px 0;
+}
 //---------------------------------------------------------
 //Recount Stats Form
 //---------------------------------------------------------

--- a/includes/admin/tools/export/class-core-settings-export.php
+++ b/includes/admin/tools/export/class-core-settings-export.php
@@ -54,7 +54,18 @@ class Give_Core_Settings_Export extends Give_Export {
 	 * @since 1.8.17
 	 */
 	public function json_core_settings_export() {
-		echo wp_json_encode( get_option( 'give_settings' ) );
+		$settings_excludes = $_POST['settings_export_excludes'];
+		$give_settings     = get_option( 'give_settings' );
+
+		if ( is_array( $settings_excludes ) && ! empty( $settings_excludes ) ) {
+			foreach ( $settings_excludes as $key => $value ) {
+				if ( 'on' === $value ) {
+					unset( $give_settings[ $key ] );
+				}
+			}
+		}
+
+		echo wp_json_encode( $give_settings );
 	}
 
 	/**

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -278,7 +278,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<li>
 										<label for="settings_export_excludes[<?php echo $option_key?>]">
 											<input
-												type="checkbox"
+												type="checkbox" checked
 												name="settings_export_excludes[<?php echo $option_key?>]"
 												id="settings_export_excludes[<?php echo $option_key?>]"><?php echo esc_html( $option_label ); ?>
 										</label>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -267,6 +267,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</td>
 						<td>
 							<form method="post">
+								<p class="settings-excludes-title"><?php echo __( 'Checked options from the list will not be exported', 'give' ); ?></p>
+								<ul class="settings-excludes-list">
+								<?php
+								$export_excludes = apply_filters( 'settings_export_excludes', array() );
+
+								if ( ! empty( $export_excludes ) ) {
+									foreach ( $export_excludes as $option_key => $option_label ) {
+									?>
+									<li>
+										<label for="settings_export_excludes[<?php echo $option_key?>]">
+											<input
+												type="checkbox"
+												name="settings_export_excludes[<?php echo $option_key?>]"
+												id="settings_export_excludes[<?php echo $option_key?>]"><?php echo esc_html( $option_label ); ?>
+										</label>
+									</li>
+									<?php
+									}
+								}
+								?>
+								</ul>
 								<input type="hidden" name="give-action" value="core_settings_export"/>
 								<input type="submit" value="<?php esc_attr_e( 'Export JSON', 'give' ); ?>" class="button-secondary"/>
 							</form>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -270,6 +270,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<p class="settings-excludes-title"><?php echo __( 'Checked options from the list will not be exported', 'give' ); ?></p>
 								<ul class="settings-excludes-list">
 								<?php
+
+								/**
+								 * Fire the filter to exclude fields from exporting.
+								 *
+								 * @since 2.0.5
+								 */
 								$export_excludes = apply_filters( 'settings_export_excludes', array() );
 
 								if ( ! empty( $export_excludes ) ) {


### PR DESCRIPTION
Closes #2716 

## Description
After discussing with @ravinderk, it was concluded that the burden to exclude the fields for export should fall on the add-ons instead of Give Core, since different addons (payment gateways) have different fields depending on their API.

## Current implementation
Since the addons currently don't have a feature to select which fields to export, I have provided a filter which can be put in the plugins, for example, 

### In Stripe
You can add:
```php
add_filter( 'settings_export_excludes', function( $excludes ) {
	$excludes['plaid_client_id']  = 'Plaid Client ID';
	$excludes['plaid_public_key'] = 'Plaid Public Key';

	return $excludes;
});
```

### In PayPal Pro
You can add:
```php
add_filter( 'settings_export_excludes', function( $excludes ) {
	$excludes['paypal_email']              = 'PayPal email';
	$excludes['payflow_paypal_vendor']     = 'PayPal Vendor ID';
	$excludes['payflow_paypal_user']       = 'PayPal User';
	$excludes['payflow_paypal_password']   = 'PayPal Password';
	$excludes['live_paypal_api_client_id'] = 'Live REST API Client ID';

	return $excludes;
});
```

which will give you an interface in _**Donation > Tools > Export > Export Give Settings**_ as shown below:

![image](https://snag.gy/ydCLBU.jpg)

Checking the options from the list will prevent them from excluding.

## Future Implementation
In add-ons, we can let users check boxes inside the addon settings to exclude the fields from exporting.

## How Has This Been Tested?
Manually Tested

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.