### PR TITLE
feat(admin): Not able to tell differences between payment gateways due to same labels #2429

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -197,15 +197,24 @@ div.give-field-description,
 
 	.gateway-enabled-settings-title {
 		display: grid;
-		grid-template-columns: .5fr 2fr 5fr .5fr .5fr;
+		grid-template-columns: .5fr 2.5fr 5fr 1fr 1fr;
 		grid-gap: 20px;
 		border-bottom: 1px solid #e5e5e5;
 		padding: 1rem;
 		font-weight: 600;
 	}
 
-	.justify-end {
-		justify-self: end;
+	.ui-sortable-placeholder {
+		visibility: visible !important;
+		border: 2px dashed #e5e5e5;
+		transition: all 0.2s ease;
+	}
+
+	.ui-sortable-helper {
+		background-color: #fafafa;
+		box-shadow: 0 4px 20px -5px rgba(0, 0, 0, 0.25);
+		border: 1px solid #e5e5e5;
+		padding: .5rem .5rem !important;
 	}
 }
 
@@ -217,25 +226,27 @@ div.give-field-description,
 .give-payment-gatways-list li.ui-sortable-handle {
 
 	display: grid;
-	grid-template-columns: .5fr 2fr 5fr .5fr .5fr;
+	grid-template-columns: .5fr 2.5fr 5fr 1fr 1fr;
 	align-items: center;
 	grid-gap: 20px;
-	margin: 15px 0;
+	margin: 0;
+	padding: .5rem 0;
 
 	&:first-child {
-		margin-top: 0;
+		padding-top: 0;
 	}
 
 	&:last-child {
-		margin-bottom: 0;
+		padding-bottom: 0;
 	}
 
 	.checkout-label {
 		padding: .5rem .75rem;
 	}
 
-	.gateways-checkbox {
-		justify-self: end;
+	.gateways-checkbox,
+	.gateways-radio {
+		justify-self: center;
 	}
 
   span.give-drag-handle {

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -190,7 +190,53 @@ div.give-field-description,
 //--------------------------------------------------------------
 // Payment Gateways
 //--------------------------------------------------------------
+
+.gateway-enabled-wrap {
+	background-color: #f7f7f7;
+	border: 1px solid #e5e5e5;
+
+	.gateway-enabled-settings-title {
+		display: grid;
+		grid-template-columns: .5fr 2fr 5fr 1.5fr;
+		grid-gap: 20px; 	
+		border-bottom: 1px solid #e5e5e5;
+		padding: 1rem;
+		font-weight: 600;
+	}
+
+	.justify-end {
+		justify-self: end;
+	}
+}
+
+.give-payment-gatways-list {
+	margin: 0;
+	padding: 1rem;
+}
+
 .give-payment-gatways-list li.ui-sortable-handle {
+
+	display: grid;
+	grid-template-columns: .5fr 2fr 5fr 1.5fr;
+	align-items: center;
+	grid-gap: 20px;
+	margin: 15px 0;
+
+	&:first-child {
+		margin-top: 0;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	.checkout-label {
+		padding: .5rem .75rem;
+	}
+
+	.gateways-checkbox {
+		justify-self: end;
+	}
 
   span.give-drag-handle {
 	padding: 3px 4px 0 0;

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -197,8 +197,8 @@ div.give-field-description,
 
 	.gateway-enabled-settings-title {
 		display: grid;
-		grid-template-columns: .5fr 2fr 5fr 1.5fr;
-		grid-gap: 20px; 	
+		grid-template-columns: .5fr 2fr 5fr .5fr .5fr;
+		grid-gap: 20px;
 		border-bottom: 1px solid #e5e5e5;
 		padding: 1rem;
 		font-weight: 600;
@@ -217,7 +217,7 @@ div.give-field-description,
 .give-payment-gatways-list li.ui-sortable-handle {
 
 	display: grid;
-	grid-template-columns: .5fr 2fr 5fr 1.5fr;
+	grid-template-columns: .5fr 2fr 5fr .5fr .5fr;
 	align-items: center;
 	grid-gap: 20px;
 	margin: 15px 0;

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -55,7 +55,7 @@ jQuery(document).ready(function ($) {
 				active_payment_option_html += ' selected="selected"';
 			}
 
-			active_payment_option_html += '>' + item.next('label').text() + '</option>';
+			active_payment_option_html += '>' + item.data('payment-gateway') + '</option>';
 		});
 
 		// Update select html.

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -734,21 +734,6 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						</tr><?php
 						break;
 
-					// Custom: Enable gateways setting field.
-					case 'enabled_gateways' :
-						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
-						?>
-					<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
-							<?php give_enabled_gateways_callback( $value, $option_value ); ?>
-							<?php echo $description; ?>
-						</td>
-						</tr><?php
-						break;
-
 					// Custom: Email preview buttons field.
 					case 'email_preview_buttons' :
 						?>

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -705,20 +705,6 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						</tr><?php
 						break;
 
-					// Custom: System setting field.
-					case 'system_info' :
-						?>
-					<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp">
-							<?php give_system_info_callback(); ?>
-							<?php echo $description; ?>
-						</td>
-						</tr><?php
-						break;
-
 					// Custom: Default gateways setting field.
 					case 'default_gateway' :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );

--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -983,13 +983,6 @@ function give_enabled_gateways_callback( $field_arr, $saved_values = array() ) {
 	$id       = $field_arr['id'];
 	$gateways = give_get_ordered_payment_gateways( give_get_payment_gateways() );
 
-	echo '<div class="gateway-enabled-wrap">';
-	echo '<div class="gateway-enabled-settings-title">';
-	printf( '<span>%s</span>', __( 'Order', 'give' ) );
-	printf( '<span>%s</span>', __( 'Gateway', 'give' ) );
-	printf( '<span>%s</span>', __( 'Label', 'give' ) );
-	printf( '<span class="justify-end">%s</span>', __( 'Enabled', 'give' ) );
-	echo '</div>';
 	echo '<ul class="give-checklist-fields give-payment-gatways-list">';
 
 	foreach ( $gateways as $key => $option ) :
@@ -1000,25 +993,12 @@ function give_enabled_gateways_callback( $field_arr, $saved_values = array() ) {
 			$enabled = null;
 		}
 
-		echo '<li>';
-		printf( '<span class="give-drag-handle"><span class="dashicons dashicons-menu"></span></span>' );
-		printf( '<span class="admin-label">%s</span>', esc_html( $option['admin_label'] ) );
-
-		if ( empty( $saved_values[ $key . '-label' ] ) ) {
-			$label = '';
-		} else {
-			$label = $saved_values[ $key . '-label' ];
-		}
-
-		printf( '<input class="checkout-label" type="text" id="%1$s[%2$s-label]" name="%1$s[%2$s-label]" value="%3$s" placeholder="%4$s"/>', esc_attr( $id ), esc_attr( $key ), esc_html( $label ), esc_html( $option['checkout_label'] ) );
-		printf( '<input class="gateways-checkbox" name="%1$s[%2$s]" id="%1$s[%2$s]" type="checkbox" value="1" %3$s data-payment-gateway="%4$s"/>', esc_attr( $id ), esc_attr( $key ), checked( '1', $enabled, false ), esc_html( $option['admin_label'] ) );
-		echo '</li>';
-
+		echo '<li><span class="give-drag-handle"><span class="dashicons dashicons-menu"></span></span><input name="' . $id . '[' . $key . ']" id="' . $id . '[' . $key . ']" type="checkbox" value="1" ' . checked( '1', $enabled, false ) . '/>&nbsp;';
+		echo '<label for="' . $id . '[' . $key . ']">' . $option['admin_label'] . '</label></li>';
 
 	endforeach;
 
 	echo '</ul>';
-	echo '</div>'; // end gateway-enabled-wrap.
 }
 
 /**

--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -1003,7 +1003,14 @@ function give_enabled_gateways_callback( $field_arr, $saved_values = array() ) {
 		echo '<li>';
 		printf( '<span class="give-drag-handle"><span class="dashicons dashicons-menu"></span></span>' );
 		printf( '<span class="admin-label">%s</span>', esc_html( $option['admin_label'] ) );
-		printf( '<input class="checkout-label" type="text" id="%1$s[%2$s-label]" name="%1$s[%2$s-label]" value="%3$s" placeholder="%4$s"/>', esc_attr( $id ), esc_attr( $key ), esc_html( $saved_values[ $key . '-label' ] ), esc_html( $option['checkout_label'] ) );
+
+		if ( empty( $saved_values[ $key . '-label' ] ) ) {
+			$label = '';
+		} else {
+			$label = $saved_values[ $key . '-label' ];
+		}
+
+		printf( '<input class="checkout-label" type="text" id="%1$s[%2$s-label]" name="%1$s[%2$s-label]" value="%3$s" placeholder="%4$s"/>', esc_attr( $id ), esc_attr( $key ), esc_html( $label ), esc_html( $option['checkout_label'] ) );
 		printf( '<input class="gateways-checkbox" name="%1$s[%2$s]" id="%1$s[%2$s]" type="checkbox" value="1" %3$s data-payment-gateway="%4$s"/>', esc_attr( $id ), esc_attr( $key ), checked( '1', $enabled, false ), esc_html( $option['admin_label'] ) );
 		echo '</li>';
 

--- a/includes/admin/class-give-settings.php
+++ b/includes/admin/class-give-settings.php
@@ -983,6 +983,13 @@ function give_enabled_gateways_callback( $field_arr, $saved_values = array() ) {
 	$id       = $field_arr['id'];
 	$gateways = give_get_ordered_payment_gateways( give_get_payment_gateways() );
 
+	echo '<div class="gateway-enabled-wrap">';
+	echo '<div class="gateway-enabled-settings-title">';
+	printf( '<span>%s</span>', __( 'Order', 'give' ) );
+	printf( '<span>%s</span>', __( 'Gateway', 'give' ) );
+	printf( '<span>%s</span>', __( 'Label', 'give' ) );
+	printf( '<span class="justify-end">%s</span>', __( 'Enabled', 'give' ) );
+	echo '</div>';
 	echo '<ul class="give-checklist-fields give-payment-gatways-list">';
 
 	foreach ( $gateways as $key => $option ) :
@@ -993,12 +1000,18 @@ function give_enabled_gateways_callback( $field_arr, $saved_values = array() ) {
 			$enabled = null;
 		}
 
-		echo '<li><span class="give-drag-handle"><span class="dashicons dashicons-menu"></span></span><input name="' . $id . '[' . $key . ']" id="' . $id . '[' . $key . ']" type="checkbox" value="1" ' . checked( '1', $enabled, false ) . '/>&nbsp;';
-		echo '<label for="' . $id . '[' . $key . ']">' . $option['admin_label'] . '</label></li>';
+		echo '<li>';
+		printf( '<span class="give-drag-handle"><span class="dashicons dashicons-menu"></span></span>' );
+		printf( '<span class="admin-label">%s</span>', esc_html( $option['admin_label'] ) );
+		printf( '<input class="checkout-label" type="text" id="%1$s[%2$s-label]" name="%1$s[%2$s-label]" value="%3$s" placeholder="%4$s"/>', esc_attr( $id ), esc_attr( $key ), esc_html( $saved_values[ $key . '-label' ] ), esc_html( $option['checkout_label'] ) );
+		printf( '<input class="gateways-checkbox" name="%1$s[%2$s]" id="%1$s[%2$s]" type="checkbox" value="1" %3$s data-payment-gateway="%4$s"/>', esc_attr( $id ), esc_attr( $key ), checked( '1', $enabled, false ), esc_html( $option['admin_label'] ) );
+		echo '</li>';
+
 
 	endforeach;
 
 	echo '</ul>';
+	echo '</div>'; // end gateway-enabled-wrap.
 }
 
 /**

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -185,7 +185,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 
 						/**
 						 * "Enabled Gateways" setting field contains gateways label setting but when you save gateway settings then label will not save
-						 *  because they are not registered setting API because code will not recognize them.
+						 *  because this is not registered setting API and code will not recognize them.
 						 *
 						 * This setting will not render on admin setting screen but help internal code to recognize "gateways_label"  setting and add them to give setting when save.
 						 */
@@ -196,12 +196,19 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 							'type' => 'gateways_label_hidden'
 						),
 
+						/**
+						 * "Enabled Gateways" setting field contains default gateway setting but when you save gateway settings then this setting will not save
+						 *  because this is not registered setting API and code will not recognize them.
+						 *
+						 * This setting will not render on admin setting screen but help internal code to recognize "default_gateway"  setting and add them to give setting when save.
+						 */
 						array(
 							'name' => __( 'Default Gateway', 'give' ),
 							'desc' => __( 'The gateway that will be selected by default.', 'give' ),
 							'id'   => 'default_gateway',
-							'type' => 'default_gateway'
+							'type' => 'default_gateway_hidden'
 						),
+
 						array(
 							'name'  => __( 'Gateways Docs Link', 'give' ),
 							'id'    => 'gateway_settings_docs_link',
@@ -263,9 +270,10 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 		 * @param $settings
 		 */
 		public function render_enabled_gateways( $field, $settings ) {
-			$id             = $field['id'];
-			$gateways       = give_get_ordered_payment_gateways( give_get_payment_gateways() );
-			$gateways_label = give_get_option( 'gateways_label', array() );
+			$id              = $field['id'];
+			$gateways        = give_get_ordered_payment_gateways( give_get_payment_gateways() );
+			$gateways_label  = give_get_option( 'gateways_label', array() );
+			$default_gateway = give_get_option( 'default_gateway', current( array_keys( $gateways ) ) );
 
 			ob_start();
 
@@ -277,10 +285,12 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 						<span></span>
 						<span>%1$s</span>
 						<span>%2$s</span>
-						<span class="justify-end">%3$s</span>
+						<span>%3$s</span>
+						<span class="justify-end">%4$s</span>
 						',
 				__( 'Gateway', 'give' ),
 				__( 'Label', 'give' ),
+				__( 'Default', 'give' ),
 				__( 'Enabled', 'give' )
 			);
 			echo '</div>';
@@ -307,6 +317,13 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 					esc_attr( $key ),
 					esc_html( $label ),
 					esc_html( $option['checkout_label'] )
+				);
+
+				printf(
+					'<input type="radio" name="%1$s" value="%2$s" %3$s>',
+					'default_gateway',
+					$key,
+					checked( $key, $default_gateway, false )
 				);
 
 				printf(

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 						<span>%1$s</span>
 						<span>%2$s</span>
 						<span>%3$s</span>
-						<span class="justify-end">%4$s</span>
+						<span>%4$s</span>
 						',
 				__( 'Gateway', 'give' ),
 				__( 'Label', 'give' ),
@@ -320,7 +320,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 				);
 
 				printf(
-					'<input type="radio" name="%1$s" value="%2$s" %3$s>',
+					'<input class="gateways-radio" type="radio" name="%1$s" value="%2$s" %3$s>',
 					'default_gateway',
 					$key,
 					checked( $key, $default_gateway, false )

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -182,12 +182,20 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 							'id'   => 'gateways',
 							'type' => 'enabled_gateways'
 						),
+
+						/**
+						 * "Enabled Gateways" setting field contains gateways label setting but when you save gateway settings then label will not save
+						 *  because they are not registered setting API because code will not recognize them.
+						 *
+						 * This setting will not render on admin setting screen but help internal code to recognize "gateways_label"  setting and add them to give setting when save.
+						 */
 						array(
 							'name' => __( 'Gateways Label', 'give' ),
 							'desc' => '',
 							'id'   => 'gateways_label',
 							'type' => 'gateways_label_hidden'
 						),
+
 						array(
 							'name' => __( 'Default Gateway', 'give' ),
 							'desc' => __( 'The gateway that will be selected by default.', 'give' ),

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1362,6 +1362,8 @@ function give_payment_mode_select( $form_id ) {
 				 * Loop through the active payment gateways.
 				 */
 				$selected_gateway  = give_get_chosen_gateway( $form_id );
+				$give_settings = give_get_settings();
+				$gateway_settings = $give_settings['gateways'];
 
 				foreach ( $gateways as $gateway_id => $gateway ) :
 					//Determine the default gateway.
@@ -1371,9 +1373,17 @@ function give_payment_mode_select( $form_id ) {
 						<input type="radio" name="payment-mode" class="give-gateway"
 							   id="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
 							   value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
+
+						<?php
+						if ( empty( $gateway_settings[ $gateway_id . '-label' ] ) ) {
+							$label = $gateway['checkout_label'];
+						} else {
+							$label = $gateway_settings[ $gateway_id . '-label' ];
+						}
+						?>
 						<label for="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
 							   class="give-gateway-option"
-							   id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $gateway['checkout_label'] ); ?></label>
+							   id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $label ); ?></label>
 					</li>
 					<?php
 				endforeach;

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1361,9 +1361,9 @@ function give_payment_mode_select( $form_id ) {
 				/**
 				 * Loop through the active payment gateways.
 				 */
-				$selected_gateway  = give_get_chosen_gateway( $form_id );
-				$give_settings = give_get_settings();
-				$gateway_settings = $give_settings['gateways'];
+				$selected_gateway = give_get_chosen_gateway( $form_id );
+				$give_settings    = give_get_settings();
+				$gateways_label   = $give_settings['gateways_label'];
 
 				foreach ( $gateways as $gateway_id => $gateway ) :
 					//Determine the default gateway.
@@ -1375,10 +1375,9 @@ function give_payment_mode_select( $form_id ) {
 							   value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
 
 						<?php
-						if ( empty( $gateway_settings[ $gateway_id . '-label' ] ) ) {
-							$label = $gateway['checkout_label'];
-						} else {
-							$label = $gateway_settings[ $gateway_id . '-label' ];
+						$label = $gateway['checkout_label'];
+						if ( ! empty( $gateways_label[ $gateway_id  ] ) ) {
+							$label = $gateways_label[ $gateway_id ];
 						}
 						?>
 						<label for="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"


### PR DESCRIPTION
Closes #2429 

Under **_Donation > Settings > Payment Gateways > Enabled Gateways_**, input fields are added to set custom checkout labels on the front end.

## How Has This Been Tested?
Manually tested

## Screenshots
### Admin
![admin](https://snag.gy/qrd2BA.jpg)


### Front
![front](https://snag.gy/7USWfu.jpg)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.