### PR TITLE
fix(compat): Change hook that load give text domain #2784

### DIFF
--- a/give.php
+++ b/give.php
@@ -275,7 +275,11 @@ if ( ! class_exists( 'Give' ) ) :
 		 */
 		private function init_hooks() {
 			register_activation_hook( GIVE_PLUGIN_FILE, 'give_install' );
+
 			add_action( 'plugins_loaded', array( $this, 'init' ), 0 );
+
+			// Set up localization on init Hook.
+			add_action( 'init', array( $this, 'load_textdomain' ), 0 );
 		}
 
 		/**
@@ -291,9 +295,6 @@ if ( ! class_exists( 'Give' ) ) :
 			 * @since 1.8.9
 			 */
 			do_action( 'before_give_init' );
-
-			// Set up localization.
-			$this->load_textdomain();
 
 			$this->roles              = new Give_Roles();
 			$this->api                = new Give_API();


### PR DESCRIPTION
## Description
PR to fix #2784 
Change the hook that used to load the text domain to make it Compatibility with Other Add-on ( Polylang )

## How Has This Been Tested?
Manually Tested See the video for more information 

## Video/Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFn0X2oWeM

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.