### PR TITLE
feat(admin-form): Add label for donation goal in dashboard #2338

### DIFF
--- a/assets/src/css/admin/goals.scss
+++ b/assets/src/css/admin/goals.scss
@@ -1,22 +1,26 @@
 td.column-goal {
-  .give-progress-bar {
-	height: 8px;
-	position: relative;
-	background: #EEE;
-	border-radius: 25px;
-	overflow: hidden;
-	margin: 5px 0 0;
+	.give-progress-bar {
+		height: 8px;
+		position: relative;
+		background: #EEE;
+		border-radius: 25px;
+		overflow: hidden;
+		margin: 5px 0 0;
 
-	> span {
-	  display: block;
-	  height: 100%;
-	  border-top-right-radius: 8px;
-	  border-bottom-right-radius: 8px;
-	  border-top-left-radius: 20px;
-	  border-bottom-left-radius: 20px;
-	  background-color: rgb(43, 194, 83);
-	  position: relative;
-	  overflow: hidden;
+		> span {
+			display: block;
+			height: 100%;
+			border-top-right-radius: 8px;
+			border-bottom-right-radius: 8px;
+			border-top-left-radius: 20px;
+			border-bottom-left-radius: 20px;
+			background-color: rgb(43, 194, 83);
+			position: relative;
+			overflow: hidden;
+		}
 	}
-  }
+
+	.goal-achieved {
+		color: #d54e21;
+	}
 }

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -81,7 +81,7 @@ function give_render_form_columns( $column_name, $post_id ) {
 					echo give_price_range( $post_id );
 				} else {
 					echo give_price( $post_id, false );
-					echo '<input type="hidden" class="formprice-' . $post_id . '" value="' . give_get_form_price( $post_id ) . '" />';
+					printf( '<input type="hidden" class="formprice-%1$s" value="%2$s" />', esc_attr( $post_id ), esc_attr( give_get_form_price( $post_id ) ) );
 				}
 				break;
 			case 'goal':
@@ -101,10 +101,10 @@ function give_render_form_columns( $column_name, $post_id ) {
 					);
 
 					if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
-						$html .= '<span class="goal-achieved">' .__( 'Goal achieved', 'give' ) . '</span>';
+						$html .= sprintf( '<span class="goal-achieved">%s</span>', __( 'Goal achieved', 'give' ) );
 					} else {
-						$html .= '<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . esc_attr( $goal_stats['progress'] ) . '">';
-						$html .= '<span style="width:' . esc_attr( $goal_stats['progress'] ) . '%;"></span>';
+						$html .= sprintf( '<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%s">', esc_attr( $goal_stats['progress'] ) );
+						$html .= sprintf( '<span style="width:%s%%;"></span>', esc_attr( $goal_stats['progress'] ) );
 						$html .= '</div>';
 					}
 
@@ -113,28 +113,37 @@ function give_render_form_columns( $column_name, $post_id ) {
 					esc_html_e( 'No Goal Set', 'give' );
 				}
 
-				echo '<input type="hidden" class="formgoal-' . $post_id . '" value="' . give_get_form_goal( $post_id ) . '" />';
+				printf(
+					'<input type="hidden" class="formgoal-%1$s" value="%2$s" />',
+					esc_attr( $post_id ),
+					give_get_form_goal( $post_id )
+				);
+
 				break;
 			case 'donations':
 				if ( current_user_can( 'view_give_form_stats', $post_id ) ) {
-					echo '<a href="' . esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&form_id=' . $post_id ) ) . '">';
-					echo give_get_form_sales_stats( $post_id );
-					echo '</a>';
+					printf(
+						'<a href="%1$s">%2$s</a>',
+						esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-payment-history&form_id=' . $post_id ) ),
+						give_get_form_sales_stats( $post_id )
+					);
 				} else {
 					echo '-';
 				}
 				break;
 			case 'earnings':
 				if ( current_user_can( 'view_give_form_stats', $post_id ) ) {
-					echo '<a href="' . esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-reports&tab=forms&form-id=' . $post_id ) ) . '">';
-					echo give_currency_filter( give_format_amount( give_get_form_earnings_stats( $post_id ), array( 'sanitize' => false ) ) );
-					echo '</a>';
+					printf(
+						'<a href="%1$s">%2$s</a>',
+						esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-reports&tab=forms&form-id=' . $post_id ) ),
+						give_currency_filter( give_format_amount( give_get_form_earnings_stats( $post_id ), array( 'sanitize' => false ) ) )
+					);
 				} else {
 					echo '-';
 				}
 				break;
 			case 'shortcode':
-				echo '<input onclick="this.setSelectionRange(0, this.value.length)" type="text" class="shortcode-input" readonly="" value="[give_form id=&#34;' . absint( $post_id ) . '&#34;]">';
+				printf( '<input onclick="this.setSelectionRange(0, this.value.length)" type="text" class="shortcode-input" readonly="" value="[give_form id=&#34;%s&#34;]"', absint( $post_id ) );
 				break;
 		}// End switch().
 	}// End if().

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -87,9 +87,9 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'goal':
 				if ( give_is_setting_enabled( give_get_meta( $post_id, '_give_goal_option', true ) ) ) {
 
-					$goal_stats = give_goal_progress_stats( $post_id );
-
+					$goal_stats = give_goal_progress_stats( $post_id, true );
 					$html = '';
+
 					$html .= sprintf(
 						( 'percentage' !== $goal_stats['format'] ) ?
 							'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a></div>' :
@@ -99,9 +99,14 @@ function give_render_form_columns( $column_name, $post_id ) {
 						esc_url( admin_url( "post.php?post={$post_id}&action=edit&give_tab=donation_goal_options" ) ),
 						$goal_stats['goal']
 					);
-					$html .= '<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . esc_attr( $goal_stats['progress'] ) . '">';
-					$html .= '<span style="width:' . esc_attr( $goal_stats['progress'] ) . '%;"></span>';
-					$html .= '</div>';
+
+					if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
+						$html .= '<span class="goal-achieved">' .__( 'Goal achieved', 'give' ) . '</span>';
+					} else {
+						$html .= '<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' . esc_attr( $goal_stats['progress'] ) . '">';
+						$html .= '<span style="width:' . esc_attr( $goal_stats['progress'] ) . '%;"></span>';
+						$html .= '</div>';
+					}
 
 					echo $html;
 				} else {

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -87,7 +87,7 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'goal':
 				if ( give_is_setting_enabled( give_get_meta( $post_id, '_give_goal_option', true ) ) ) {
 
-					$goal_stats = give_goal_progress_stats( $post_id, true );
+					$goal_stats = give_goal_progress_stats( $post_id );
 					$html = '';
 
 					$html .= sprintf(

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -916,7 +916,9 @@ function give_get_form_goal_format( $form_id = 0 ) {
  *
  * @return array
  */
-function give_goal_progress_stats( $form ) {
+function give_goal_progress_stats( $form, $raw_values = false ) {
+
+	$stats_array = array();
 
 	if ( ! $form instanceof Give_Donate_Form ) {
 		$form = new Give_Donate_Form( $form );
@@ -949,6 +951,11 @@ function give_goal_progress_stats( $form ) {
 	$actual   = 'donation' !== $goal_format ? $income : $sales;
 	$progress = round( ( $actual / $total_goal ) * 100, 2 );
 
+	if ( $raw_values ) {
+		$stats_array['raw_actual'] = $actual;
+		$stats_array['raw_goal']   = $total_goal;
+	}
+
 	/**
 	 * Filter the goal progress output
 	 *
@@ -970,12 +977,12 @@ function give_goal_progress_stats( $form ) {
 		$total_goal = give_currency_filter( give_format_amount( $total_goal ) );
 	}
 
-	return apply_filters( 'give_goal_progress_stats', array(
-		'progress' => $progress,
-		'actual'   => $actual,
-		'goal'     => $total_goal,
-		'format'   => $goal_format,
-	) );
+	$stats_array['progress'] = $progress;
+	$stats_array['actual']   = $actual;
+	$stats_array['goal']     = $total_goal;
+	$stats_array['format']   = $goal_format;
+
+	return apply_filters( 'give_goal_progress_stats', $stats_array );
 
 }
 

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -911,13 +911,12 @@ function give_get_form_goal_format( $form_id = 0 ) {
  * Display/Return a formatted goal for a donation form
  *
  * @param int|Give_Donate_Form  $form       Form ID or Form Object.
- * @param bool|Give_Donate_Form $raw_values True to return stats without currency values.
  *
  * @since 2.1
  *
  * @return array
  */
-function give_goal_progress_stats( $form, $raw_values = false ) {
+function give_goal_progress_stats( $form ) {
 
 	$stats_array = array();
 
@@ -952,10 +951,10 @@ function give_goal_progress_stats( $form, $raw_values = false ) {
 	$actual   = 'donation' !== $goal_format ? $income : $sales;
 	$progress = round( ( $actual / $total_goal ) * 100, 2 );
 
-	if ( $raw_values ) {
-		$stats_array['raw_actual'] = $actual;
-		$stats_array['raw_goal']   = $total_goal;
-	}
+	$stats_array = array(
+		'raw_actual' => $actual,
+		'raw_goal'   => $total_goal
+	);
 
 	/**
 	 * Filter the goal progress output
@@ -978,11 +977,21 @@ function give_goal_progress_stats( $form, $raw_values = false ) {
 		$total_goal = give_currency_filter( give_format_amount( $total_goal ) );
 	}
 
-	$stats_array['progress'] = $progress;
-	$stats_array['actual']   = $actual;
-	$stats_array['goal']     = $total_goal;
-	$stats_array['format']   = $goal_format;
+	$stats_array = array_merge(
+		array(
+			'progress' => $progress,
+			'actual'   => $actual,
+			'goal'     => $total_goal,
+			'format'   => $goal_format,
+		),
+		$stats_array
+	);
 
+	/**
+	 * Filter the goal stats
+	 *
+	 * @since 2.1
+	 */
 	return apply_filters( 'give_goal_progress_stats', $stats_array );
 
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -910,7 +910,8 @@ function give_get_form_goal_format( $form_id = 0 ) {
 /**
  * Display/Return a formatted goal for a donation form
  *
- * @param int|Give_Donate_Form $form Form ID or Form Object.
+ * @param int|Give_Donate_Form  $form       Form ID or Form Object.
+ * @param bool|Give_Donate_Form $raw_values True to return stats without currency values.
  *
  * @since 2.1
  *


### PR DESCRIPTION
Closes #2338

When a goal is achieved, the goal column in the forms listing page will display 'Goal achieved'

## Description
Goal column displays a message 'Goal achieved' if the goal is achieved. 

## How Has This Been Tested?
Manually tested.

## Screenshots:
![goalachieved](https://snag.gy/ESR5DZ.jpg)

## Types of changes
To make this work in the best possible way, I have slightly modified the built in function `give_goal_progress_stats( $form )` in the following way:

Earlier the above function only accepted 1 argument, which is the form ID and it returned goal stats with **currency symbols**, which made it difficult to perform mathematical operations on the return value.. Now the modification takes another argument called `$raw_values` which has a default value set to `false`. If set to `true`, the function will **also** return stats without currency symbols.

Here is the [modification](https://github.com/WordImpress/Give/pull/2837/files#diff-5dc4dc4bea94c3fc87bf516e98ef7e38R919) to the function.


## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.