### PR TITLE
bug(downloads): Percentage value is not computed correctly in the admin page goal column #2835

### DIFF
--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -87,14 +87,15 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'goal':
 				if ( give_is_setting_enabled( give_get_meta( $post_id, '_give_goal_option', true ) ) ) {
 
-					$goal_stats = give_goal_progress_stats( $post_id );
-					$html = '';
+					$goal_stats       = give_goal_progress_stats( $post_id );
+					$percent_complete = round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100;
+					$html             = '';
 
 					$html .= sprintf(
 						( 'percentage' !== $goal_stats['format'] ) ?
 							'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a></div>' :
 							'<div class="give-goal-text"><a href="%3$s">%1$s</a></div>',
-						$goal_stats['actual'],
+						( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
 						( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
 						esc_url( admin_url( "post.php?post={$post_id}&action=edit&give_tab=donation_goal_options" ) ),
 						$goal_stats['goal']

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -918,8 +918,6 @@ function give_get_form_goal_format( $form_id = 0 ) {
  */
 function give_goal_progress_stats( $form ) {
 
-	$stats_array = array();
-
 	if ( ! $form instanceof Give_Donate_Form ) {
 		$form = new Give_Donate_Form( $form );
 	}


### PR DESCRIPTION
Closes #2835 

## Description
Percentage values under the goal column on the admin page showed incorrect values. This was because percentage wasn't calculated in the first place.

## How Has This Been Tested?
Manually Tested

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.