### PR TITLE
fix(dashboard-widget): incorrect stat for this year #2847

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -101,7 +101,7 @@ function give_dashboard_sales_widget() {
 					<p class="give-dashboard-stat-total-label"><?php _e( 'Last Month', 'give' ); ?></p>
 				</td>
 				<td>
-					<p class="give-dashboard-stat-total"><?php echo give_currency_filter( give_format_amount( give_get_total_earnings(), array( 'sanitize' => false ) ) ) ?></p>
+					<p class="give-dashboard-stat-total"><?php echo give_currency_filter( give_format_amount( $stats->get_earnings( 0, 'this_year' ), array( 'sanitize' => false ) ) ) ?></p>
 
 					<p class="give-dashboard-stat-total-label"><?php _e( 'This Year', 'give' ); ?></p>
 				</td>


### PR DESCRIPTION
## Description
Resolved incorrect stat for "This Year". 

Closes #2847 

## How Has This Been Tested?
- Manually

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.