### PR TITLE
fix(bug): Only show message about options if options are available #2864

### DIFF
--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -267,27 +267,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</td>
 						<td>
 							<form method="post">
-								<p class="settings-excludes-title"><?php echo __( 'Checked options from the list will not be exported', 'give' ); ?></p>
-								<ul class="settings-excludes-list">
 								<?php
 								$export_excludes = apply_filters( 'settings_export_excludes', array() );
-
 								if ( ! empty( $export_excludes ) ) {
-									foreach ( $export_excludes as $option_key => $option_label ) {
-									?>
-									<li>
-										<label for="settings_export_excludes[<?php echo $option_key?>]">
-											<input
-												type="checkbox" checked
-												name="settings_export_excludes[<?php echo $option_key?>]"
-												id="settings_export_excludes[<?php echo $option_key?>]"><?php echo esc_html( $option_label ); ?>
-										</label>
-									</li>
-									<?php
-									}
-								}
 								?>
-								</ul>
+									<i class="settings-excludes-title"><?php echo __( 'Checked options from the list will not be exported.', 'give' ); ?></i>
+									<ul class="settings-excludes-list">
+									<?php foreach ( $export_excludes as $option_key => $option_label ) { ?>
+										<li>
+											<label for="settings_export_excludes[<?php echo $option_key?>]">
+												<input
+													type="checkbox" checked
+													name="settings_export_excludes[<?php echo $option_key?>]"
+													id="settings_export_excludes[<?php echo $option_key?>]"><?php echo esc_html( $option_label ); ?>
+											</label>
+										</li>
+									<?php } ?>
+									</ul>
+								<?php } ?>
 								<input type="hidden" name="give-action" value="core_settings_export"/>
 								<input type="submit" value="<?php esc_attr_e( 'Export JSON', 'give' ); ?>" class="button-secondary"/>
 							</form>


### PR DESCRIPTION
Closes #2864 

If the exclude from export list is empty, then the message and empty container will be hidden.

## How Has This Been Tested?
Manually tested

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.