### PR TITLE
bug(admin-settings): Fix JS error due to redundant code #2429

### DIFF
--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -21,48 +21,6 @@ jQuery(document).ready(function ($) {
 	}
 
 	/**
-	 * Set payment gateway list under default payment gaetway option
-	 */
-	var $payment_gateway_list_item = $('input', $payment_gateways),
-		$default_gateway           = $('#default_gateway');
-	$payment_gateway_list_item.on('click', function () {
-
-		// Bailout.
-		if( $(this)[0].hasAttribute( 'readonly' ) ) {
-			return false;
-		}
-
-		// Selectors.
-		var saved_default_gateway      = $default_gateway.val(),
-			active_payment_option_html = '',
-			$active_payment_gateways   = $('input:checked', $payment_gateways);
-
-		// Set last active payment gateways to readonly.
-		if( 1 === $active_payment_gateways.length ){
-			$active_payment_gateways.prop( 'readonly', true );
-		}else{
-			$('input[readonly]:checked', $payment_gateways ).removeAttr('readonly');
-		}
-
-		// Create option html from active payment gateway list.
-		$active_payment_gateways.each(function (index, item) {
-			item           = $(item);
-			var item_value = item.attr('name').match(/\[(.*?)\]/)[1];
-
-			active_payment_option_html += '<option value="' + item_value + '"';
-
-			if (saved_default_gateway === item_value) {
-				active_payment_option_html += ' selected="selected"';
-			}
-
-			active_payment_option_html += '>' + item.data('payment-gateway') + '</option>';
-		});
-
-		// Update select html.
-		$default_gateway.html(active_payment_option_html);
-	});
-
-	/**
 	 * Change currency position symbol on changing the currency
 	 */
 	var give_settings_currency = '#give-mainform #currency';


### PR DESCRIPTION
Fixes https://github.com/WordImpress/Give/issues/2429#issuecomment-370315441

The previous code of default gateway select dropdown wasn't deleted which caused the JS error.

## How Has This Been Tested?
Manually tested

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.