### PR TITLE
feat(cli): add command to activate test environment for donation #2845

### DIFF
--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -1002,4 +1002,72 @@ class GIVE_CLI_COMMAND {
 	private function get_random_email( $name ) {
 		return implode( '.', explode( ' ', strtolower( $name ) ) ) . '@test.com';
 	}
+
+	/**
+	 * Toggle settings for Give's test mode.
+	 *
+	 * [--enable]
+	 * : Enable Give's test mode
+	 *
+	 * [--disable]
+	 * : Enable Give's test mode
+	 *
+	 * @when after_wp_load
+	 * @subcommand test-mode
+	 */
+	public function test_mode( $args, $assoc ) {
+
+		// Return if associative arguments are not specified.
+		if ( empty( $assoc ) ) {
+			WP_CLI::error( "--enable or --disable flag is missing." );
+			return;
+		}
+
+		$enabled_gateways = give_get_option( 'gateways' );
+		$default_gateway  = give_get_option( 'default_gateway' );
+
+
+		// Enable Test Mode.
+		if ( true === WP_CLI\Utils\get_flag_value( $assoc, 'enable' ) ) {
+
+			// Set `Test Mode` to `enabled`.
+			give_update_option( 'test_mode', 'enabled' );
+
+
+			// Enable `Test Donation` gateway.
+			$enabled_gateways['manual'] = "1";
+			give_update_option( 'gateways', $enabled_gateways );
+
+
+			// Set `Test Donation` as default gateway.
+			add_option( 'give_test_mode_default_gateway', $default_gateway );
+			give_update_option( 'default_gateway', 'manual' );
+
+
+			// Show success message on completion.
+			WP_CLI::success( 'Give Test mode enabled' );
+		}
+
+		// Disable Test Mode.
+		if ( true === WP_CLI\Utils\get_flag_value( $assoc, 'disable' ) ) {
+
+			// Set `Test Mode` to `disabled`.
+			give_update_option( 'test_mode', 'disabled' );
+
+
+			// Disable `Test Donation` gateway.
+			unset( $enabled_gateways['manual'] );
+			give_update_option( 'gateways', $enabled_gateways );
+
+
+			// Backup `Default Gateway` setting for restore on test mode disable.
+			$default_gateway_backup = get_option( 'give_test_mode_default_gateway' );
+			give_update_option( 'default_gateway', $default_gateway_backup );
+			delete_option( 'give_test_mode_default_gateway' );
+
+
+			// Show success message on completion.
+			WP_CLI::success( 'Give Test mode disabled' );
+		}
+	}
 }


### PR DESCRIPTION
Closes #2845 

## Description
Added 1 WP-CLI command with 2 configurations:

`wp give test-mode --enabled`
### And
`wp give test-mode --disabled`

Enabling test mode will set:

1. **Test Mode** to `enabled`
2. **Enabled Gateways** to `Test Donation`
3. **Default Gateway** to `Test Donation`

## How Has This Been Tested?
Manually tested.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.