### PR TITLE
fix(admin-tool): Disable cache at the time of Importing Donation from CSV #2879

### DIFF
--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -509,6 +509,10 @@ add_action( 'give_payments_page_top', 'give_import_page_link_callback', 11 );
  * @return json $json_data
  */
 function give_donation_import_callback() {
+
+	// Disable Give cache
+	Give_Cache::get_instance()->disable();
+
 	$import_setting = array();
 	$fields         = isset( $_POST['fields'] ) ? $_POST['fields'] : null;
 
@@ -600,6 +604,9 @@ function give_donation_import_callback() {
 
 	$percentage              = ( 100 / ( $total_ajax + 1 ) ) * $current;
 	$json_data['percentage'] = $percentage;
+
+	// Enable Give cache
+	Give_Cache::get_instance()->enable();
 
 	$json_data = apply_filters( 'give_import_ajax_responces', $json_data, $fields );
 	wp_die( json_encode( $json_data ) );

--- a/includes/admin/tools/import/class-give-import-donations.php
+++ b/includes/admin/tools/import/class-give-import-donations.php
@@ -433,7 +433,7 @@ if ( ! class_exists( 'Give_Import_Donations' ) ) {
 								<span class="give-import-donation-required-symbol dashicons dashicons-no-alt"></span>
 								<span class="give-import-donation-required-text">
 									<?php
-									_e( 'Email Access', 'give' );
+									_e( 'Email Address', 'give' );
 									?>
 								</span>
 							</li>


### PR DESCRIPTION
## Description
PR to fix #2879 

**Notes: Not able to regenerate the issues that are mention in the description of the issue but fix another two issues that are being mentioned in https://github.com/WordImpress/Give/issues/2879#issuecomment-371649510**

## How Has This Been Tested?
Mannualy by uploading Donation from CSV and then check all the donation and the donation form that they are created properly or not.
Please see the video, To check on how I have tested this out.

## Video/Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFeQixDDpF

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.