### PR TITLE
fix(admin-shortcode): Shortcode generator issue with inserting Donation Form goal #2728

### DIFF
--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -283,22 +283,21 @@ abstract class Give_Shortcode_Generator {
 
 		$args = array(
 			'post_type'      => 'post',
-			'post_status'    => 'publish',
 			'orderby'        => 'title',
 			'order'          => 'ASC',
-			'posts_per_page' => 500,
+			'posts_per_page' => 30,
 		);
 
 		$args    = wp_parse_args( (array) $field['query_args'], $args );
-		$posts   = get_posts( $args );
+		$posts   = new WP_Query( $args );
 		$options = array();
 
-		if ( ! empty( $posts ) ) {
-			/* @var WP_Post $post */
-			foreach ( $posts as $post ) {
-				$options[ absint( $post->ID ) ] = empty( $post->post_title ) ?
-					sprintf( __( 'Untitled (#%s)', 'give' ), $post->ID ) :
-					apply_filters( 'the_title', $post->post_title );
+		if ( $posts->have_posts() ) {
+			while ( $posts->have_posts() ) {
+				$posts->the_post();
+				$post_title = get_the_title();
+				$post_id = get_the_ID();
+				$options[ absint( $post_id ) ] = ( empty( $post_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $post_id ) : $post_title );
 			}
 
 			$field['type']    = 'listbox';


### PR DESCRIPTION
Closes #2728 

## Description
Fixed the 'No forms found' error caused by using get_posts()

## How Has This Been Tested?
Manually Tested

## Screenshots (jpeg or gifs if applicable):
![donationform](https://snag.gy/Mk53fo.jpg)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.