### PR TITLE
test(recurring): update donation count with amount for donor

### DIFF
--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -960,15 +960,20 @@ final class Give_Payment {
 				if ( $total_change < 0 ) {
 
 					$total_change = - ( $total_change );
+
 					// Decrease the donor's donation stats.
 					$donor->decrease_value( $total_change );
 					give_decrease_total_earnings( $total_change );
+
+					$donor->decrease_donation_count();
 
 				} elseif ( $total_change > 0 ) {
 
 					// Increase the donor's donation stats.
 					$donor->increase_value( $total_change );
 					give_increase_total_earnings( $total_change );
+
+					$donor->increase_purchase_count();
 
 				}
 			}


### PR DESCRIPTION
## Description
This PR is related to https://github.com/WordImpress/Give-Recurring-Donations/issues/429

## How Has This Been Tested?
I have noticed that on saving payment donation amount for the donor is incremented. But, donation count ( _purchase count_ ) is not incremented which affects unit tests. So, I have added an increment of donation count for a donor to make it work properly and test it with unit tests as well as by performing actual donation.

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.