### PR TITLE
build(webpack): Bundle SVG files inside correct folder #2907

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ const config = {
 
 			// Font files.
 			{
-				test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
+				test: /\.(ttf|otf|eot|woff(2)?)(\?[a-z0-9]+)?$/,
 				use: [
 					{
 						loader: 'file-loader',


### PR DESCRIPTION
Closes #2907 

## Description
This fix bundles SVG images to only the `dist/images` folder.