### PR TITLE
fix(admin-tool): Fix auto mapping of import as meta column #2163

### DIFF
--- a/includes/admin/tools/import/class-give-import-donations.php
+++ b/includes/admin/tools/import/class-give-import-donations.php
@@ -507,7 +507,7 @@ if ( ! class_exists( 'Give_Import_Donations' ) ) {
 			$selected = '';
 			if ( stristr( $value, $option_value ) ) {
 				$selected = 'selected';
-			} elseif ( strrpos( $value, '_' ) && stristr( $option_value, __( 'Import as Meta', 'give' ) ) ) {
+			} elseif ( strrpos( $value, 'give_' ) && stristr( $option_value, __( 'Import as Meta', 'give' ) ) ) {
 				$selected = 'selected';
 			}
 


### PR DESCRIPTION
## Description
PR to fix #2163 

## How Has This Been Tested?
Tested by importing the CSV with passing underscore in meta column key and then check that is not being auto map to **Import as Meta**


## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFeIqnDrE4

![image](https://user-images.githubusercontent.com/22215595/37341683-46ccaa26-26e8-11e8-8b27-e56e128cc22e.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.