### PR TITLE
fix(admin-tool): fix duplicate issues when importing donation from CSV #2921

### DIFF
--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -808,7 +808,7 @@ function give_check_import_donation_duplicate( $payment_data, $data, $form, $don
 					'compare' => '=',
 				),
 				array(
-					'key'     => '_give_payment_customer_id',
+					'key'     => '_give_payment_donor_id',
 					'value'   => $donor_data->id,
 					'compare' => '=',
 				),


### PR DESCRIPTION
## Description
PR to fix #2921 

This issue was coming because `_give_payment_customer_id ` key is being replaced with `_give_payment_donor_id` and that change was not being made in this functions

## How Has This Been Tested?

- [ ] Manually tested by creating new CSV and then importing donation from that CSV
CSV Link: https://docs.google.com/spreadsheets/d/18AFqxipUgvkeDJ0uozzRCgJqKxH0WffVR7CzaUFpDmA/edit?usp=sharing

- [ ] Also, try to import the default CSV that we have created twice and check for the duplicate of the donations

## Video/Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFe2iOD3O9

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.