### PR TITLE
fix(shortcode): display form title even if form is closed #2800

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -85,9 +85,11 @@ function give_get_donation_form( $args = array() ) {
 
 		<?php if ( $form->is_close_donation_form() ) {
 
+			$form_title = ! is_singular( 'give_forms' ) ? apply_filters( 'give_form_title', '<h2 class="give-form-title">' . get_the_title( $form_id ) . '</h2>' ) : '';
+
 			// Get Goal thank you message.
 			$goal_achieved_message = get_post_meta( $form->ID, '_give_form_goal_achieved_message', true );
-			$goal_achieved_message = ! empty( $goal_achieved_message ) ? apply_filters( 'the_content', $goal_achieved_message ) : '';
+			$goal_achieved_message = ! empty( $goal_achieved_message ) ? $form_title . apply_filters( 'the_content', $goal_achieved_message ) : '';
 
 			// Print thank you message.
 			echo apply_filters( 'give_goal_closed_output', $goal_achieved_message, $form->ID, $form );


### PR DESCRIPTION
Closes #2800 

## Description
If a goal-based form achieves its goal and closes it, then the Thank you message will be shown along with the Form title.

## How Has This Been Tested?
This has been tested with the shortcode of a form as well as on the donation form's singular page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.