### PR TITLE
fix(form): display actual goal progress even after goal is met #2638

### DIFF
--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -62,9 +62,9 @@ $form_currency = apply_filters( 'give_goal_form_currency', give_get_currency( $f
 
 // Set progress to 100 percentage if income > goal or completed donations > donation goal count.
 if ( 'donation' === $goal_format ) {
-	$progress = $donations_completed >= $donations_goal ? 100 : $progress;
+	$progress_bar_value = $donations_completed >= $donations_goal ? 100 : $progress;
 } else {
-	$progress = $income >= $goal ? 100 : $progress;
+	$progress_bar_value = $income >= $goal ? 100 : $progress;
 }
 ?>
 <div class="give-goal-progress">
@@ -128,8 +128,8 @@ if ( 'donation' === $goal_format ) {
 
 	<?php if ( ! empty( $show_bar ) ) : ?>
 		<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-		     aria-valuenow="<?php echo esc_attr( $progress ); ?>">
-			<span style="width: <?php echo esc_attr( $progress ); ?>%;<?php if ( ! empty( $color ) ) {
+		     aria-valuenow="<?php echo esc_attr( $progress_bar_value ); ?>">
+			<span style="width: <?php echo esc_attr( $progress_bar_value ); ?>%;<?php if ( ! empty( $color ) ) {
 				echo 'background-color:' . $color;
 			} ?>"></span>
 		</div><!-- /.give-progress-bar -->


### PR DESCRIPTION
Closes #2638 

## Description
Donation forms which were over-funded showed 100% as the maximum progress value. Now it shows the actual value.

If the user wants to limit the progress value for 100%, then they have to use the following filter:
```php
function limit_donation_exceed_to_100( $progress, $form_id, $form ) {
	$goal_format         = give_get_meta( $form_id, '_give_goal_format', true );
	$income              = $form->get_earnings();
	$goal                = $form->goal;
	$donations_goal      = give_get_meta( $form_id, '_give_number_of_donation_goal', true );
	$donations_completed = give_get_form_sales_stats( $form_id );

	return 'donation' === $goal_format ? (
		$donations_completed >= $donations_goal ? 100 : $progress
	) : (
		$income >= $goal ? 100 : $progress
	);
};

add_filter( 'give_goal_amount_funded_percentage_output', 'limit_donation_exceed_to_100', 10, 3 );
```

## How Has This Been Tested?
This has been tested with all 3 goal formats - **Amount, Percentages** and **Number of Donations**
with donations lesser than the goal and more than the goal in all combinations.


## Checklist:
- [x]  My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.