### PR TITLE
feat(donation): Add company name fields in donation form #2453

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -334,4 +334,30 @@ function give_update_log_form_id( $args ) {
 
 add_action( 'give_update_log_form_id', 'give_update_log_form_id' );
 
+/**
+ * Add meta in payment that store Company Name.
+ *
+ * Will add/update when user add click on the checkout page.
+ * The status of the donation doest not matter as it get change when user had made the payment successfully.
+ *
+ * @since 2.0.7
+ *
+ * @param int $payment_id Payment id for which the meta value should be updated.
+ */
+function give_donation_save_company_name( $payment_id ) {
+	$give_company = ( ! empty( $_REQUEST['give_company'] ) ? give_clean( $_REQUEST['give_company'] ) : false );
 
+	// Check $page_url is not empty.
+	if ( $give_company ) {
+		give_update_meta( $payment_id, '_give_donation_company', $give_company );
+
+		$donor_id = (int) give_get_meta( $payment_id, '_give_payment_donor_id', true );
+		if ( ! empty( $donor_id ) ) {
+			$donor = new Give_Donor( $donor_id );
+			$donor->update_meta( '_give_donor_company', $give_company );
+		}
+	}
+}
+
+// Fire when payment is save.
+add_action( 'give_insert_payment', 'give_donation_save_company_name' );

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -345,7 +345,7 @@ add_action( 'give_update_log_form_id', 'give_update_log_form_id' );
  * @param int $payment_id Payment id for which the meta value should be updated.
  */
 function give_donation_save_company_name( $payment_id ) {
-	$give_company = ( ! empty( $_REQUEST['give_company'] ) ? give_clean( $_REQUEST['give_company'] ) : false );
+	$give_company = ( ! empty( $_REQUEST['give_company_name'] ) ? give_clean( $_REQUEST['give_company_name'] ) : false );
 
 	// Check $page_url is not empty.
 	if ( $give_company ) {

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -427,6 +427,25 @@ function give_donor_view( $donor ) {
 									</span>
 							</td>
 						</tr>
+
+						<?php
+						$donor_company = $donor->get_meta( '_give_donor_company', true );
+
+						if ( ! empty( $donor_company ) ) {
+							?>
+							<tr class="alternate">
+								<th scope="col">
+									<label for="tablecell"><?php _e( 'Company Donations:', 'give' ); ?></label>
+								</th>
+								<td>
+									<?php
+									echo $donor_company;
+									?>
+								</td>
+							</tr>
+							<?php
+						}
+						?>
 						</tbody>
 					</table>
 

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -275,6 +275,20 @@ class Give_MetaBox_Form_Data {
 							'type' => 'default_gateway',
 						),
 						array(
+							'name'    => __( 'Company Donations', 'give' ),
+							'desc'    => __( 'Do you want a Company field to appear after First Name and Last Name?', 'give' ),
+							'id'      => $prefix . 'company_field',
+							'type'    => 'radio_inline',
+							'default' => 'global',
+							'options' => array(
+								'global' => __( 'Global Option', 'give' ),
+								'required' => __( 'Required', 'give' ),
+								'optional' => __( 'Optional', 'give' ),
+								'disabled' => __( 'Disabled', 'give' ),
+
+							),
+						),
+						array(
 							'name'    => __( 'Guest Donations', 'give' ),
 							'desc'    => __( 'Do you want to allow non-logged-in users to make donations?', 'give' ),
 							'id'      => $prefix . 'logged_in_only',

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 						),
 					);
 					break;
-				case 'form-settings':
+				case 'form-display':
 					$settings = array(
 						array(
 							'id'   => 'give_title_display_settings_5',
@@ -295,7 +295,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 						array(
 							'name'    => __( 'Company Donations', 'give' ),
 							'desc'    => __( 'Do you want a Company field to appear after First Name and Last Name?', 'give' ),
-							'id'      => 'company_donation',
+							'id'      => 'company_field',
 							'type'    => 'radio_inline',
 							'default' => 'disabled',
 							'options' => array(
@@ -343,7 +343,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 				'post-types'          => __( 'Post Types', 'give' ),
 				'taxonomies'          => __( 'Taxonomies', 'give' ),
 				'term-and-conditions' => __( 'Terms and Conditions', 'give' ),
-				'form-settings' => __( 'Forms', 'give' ),
+				'form-display' => __( 'Form Display', 'give' ),
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -286,6 +286,30 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 						),
 					);
 					break;
+				case 'form-settings':
+					$settings = array(
+						array(
+							'id'   => 'give_title_display_settings_5',
+							'type' => 'title',
+						),
+						array(
+							'name'    => __( 'Company Donations', 'give' ),
+							'desc'    => __( 'Do you want a Company field to appear after First Name and Last Name?', 'give' ),
+							'id'      => 'company_donation',
+							'type'    => 'radio_inline',
+							'default' => 'disabled',
+							'options' => array(
+								'disabled' => __( 'Disabled', 'give' ),
+								'required' => __( 'Required', 'give' ),
+								'optional' => __( 'Optional', 'give' ),
+							),
+						),
+						array(
+							'id'   => 'give_title_display_settings_5',
+							'type' => 'sectionend',
+						),
+					);
+					break;
 			}
 
 			/**
@@ -319,6 +343,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 				'post-types'          => __( 'Post Types', 'give' ),
 				'taxonomies'          => __( 'Taxonomies', 'give' ),
 				'term-and-conditions' => __( 'Terms and Conditions', 'give' ),
+				'form-settings' => __( 'Forms', 'give' ),
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -957,8 +957,9 @@ function give_email_tag_form_title( $tag_args ) {
 
 /**
  * Email template tag: {company_name}
- *
  * Output the donation form company name filed.
+ *
+ * @since 2.0.7
  *
  * @param array $tag_args
  *

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -409,6 +409,12 @@ function give_setup_email_tags() {
 			'context'     => 'donor',
 		),
 		array(
+			'tag'         => 'company_name',
+			'description' => esc_html__( 'The Company name.', 'give' ),
+			'function'    => 'give_email_tag_company_name',
+			'context'     => 'donation',
+		),
+		array(
 			'tag'         => 'user_email',
 			'description' => esc_html__( 'The donor\'s email address.', 'give' ),
 			'function'    => 'give_email_tag_user_email',
@@ -945,6 +951,42 @@ function give_email_tag_form_title( $tag_args ) {
 	return apply_filters(
 		'give_email_tag_form_title',
 		$donation_form_title,
+		$tag_args
+	);
+}
+
+/**
+ * Email template tag: {company_name}
+ *
+ * Output the donation form company name filed.
+ *
+ * @param array $tag_args
+ *
+ * @return string $company_name
+ */
+function give_email_tag_company_name( $tag_args ) {
+	$company_name = '';
+
+	// Backward compatibility.
+	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+
+	switch ( true ) {
+		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
+			$company_name = give_get_payment_meta( $tag_args['payment_id'], '_give_donation_company', true );
+			break;
+	}
+
+	/**
+	 * Filter the {company_name} email template tag output.
+	 *
+	 * @since 2.0
+	 *
+	 * @param string $company_name
+	 * @param array $tag_args
+	 */
+	return apply_filters(
+		'give_email_tag_company_name',
+		$company_name,
 		$tag_args
 	);
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1073,4 +1073,4 @@ function give_donation_form_company_fields( $form_id ) {
 	}
 }
 
-add_action( 'give_donation_form_before_email', 'give_donation_form_company_fields', 10, 1 );
+add_action( 'give_donation_form_before_email', 'give_donation_form_company_fields', 0, 1 );

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1047,11 +1047,11 @@ function _give_get_prefill_form_field_values( $form_id ) {
  */
 function give_donation_form_company_fields( $form_id ) {
 	if ( give_is_company_donation_show( $form_id ) ) {
-		$give_company = give_field_is_required( 'give_company', $form_id );
+		$give_company = give_field_is_required( 'give_company_name', $form_id );
 		?>
 		<p id="give-company-wrap" class="form-row form-row-wide">
 			<label class="give-label" for="give-company">
-				<?php _e( 'Company Donations', 'give' ); ?>
+				<?php _e( 'Company Name', 'give' ); ?>
 				<?php if ( $give_company ) { ?>
 					<span class="give-required-indicator">*</span>
 				<?php } ?>
@@ -1061,8 +1061,8 @@ function give_donation_form_company_fields( $form_id ) {
 			<input
 				class="give-input required"
 				type="text"
-				name="give_company"
-				placeholder="<?php _e( 'Company Donations', 'give' ); ?>"
+				name="give_company_name"
+				placeholder="<?php _e( 'Company Name', 'give' ); ?>"
 				id="give-company"
 				value=""
 				<?php echo( $give_company ? ' required aria-required="true" ' : '' ); ?>

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1037,3 +1037,40 @@ function _give_get_prefill_form_field_values( $form_id ) {
 	// Output.
 	return wp_parse_args( $give_donor_info_in_session, $logged_in_donor_info );
 }
+
+/**
+ * Add Company Name fileds in Donation Form.
+ *
+ * @since 2.0.7
+ *
+ * @param int $form_id Donation Form ID.
+ */
+function give_donation_form_company_fields( $form_id ) {
+	if ( give_is_company_donation_show( $form_id ) ) {
+		$give_company = give_field_is_required( 'give_company', $form_id );
+		?>
+		<p id="give-company-wrap" class="form-row form-row-wide">
+			<label class="give-label" for="give-company">
+				<?php _e( 'Company Donations', 'give' ); ?>
+				<?php if ( $give_company ) { ?>
+					<span class="give-required-indicator">*</span>
+				<?php } ?>
+				<?php echo Give()->tooltips->render_help( __( 'Donate on behalf of Company', 'give' ) ); ?>
+			</label>
+
+			<input
+				class="give-input required"
+				type="text"
+				name="give_company"
+				placeholder="<?php _e( 'Company Donations', 'give' ); ?>"
+				id="give-company"
+				value=""
+				<?php echo( $give_company ? ' required aria-required="true" ' : '' ); ?>
+			/>
+
+		</p>
+		<?php
+	}
+}
+
+add_action( 'give_donation_form_before_email', 'give_donation_form_company_fields', 10, 1 );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1003,7 +1003,6 @@ function give_get_plugins() {
 	return $plugins;
 }
 
-
 /**
  * Check if terms enabled or not for form.
  *
@@ -1029,7 +1028,6 @@ function give_is_terms_enabled( $form_id ) {
 		return false;
 	}
 }
-
 
 /**
  * Delete donation stats cache.
@@ -1760,5 +1758,57 @@ function give_get_total_post_type_count( $post_type = '', $args = array() ){
 function give_maybe_define_constant( $name, $value ) {
 	if ( ! defined( $name ) ) {
 		define( $name, $value );
+	}
+}
+
+/**
+ * Check if Company Donations enabled or not for form.
+ *
+ * @since 2.0.7
+ *
+ * @param $form_id
+ *
+ * @return bool
+ */
+function give_is_company_donation_enabled( $form_id ) {
+	$form_option = give_get_meta( $form_id, '_give_company_field', true );
+
+	if (
+		give_is_setting_enabled( $form_option, array( 'global', 'required' ) )
+		&& give_is_setting_enabled( give_get_option( 'company_field' ), array( 'required' ) )
+	) {
+		return true;
+
+	} elseif ( give_is_setting_enabled( $form_option, array( 'required' ) ) ) {
+		return true;
+
+	} else {
+		return false;
+	}
+}
+
+/**
+ * Check if Company Donations show or not for form.
+ *
+ * @since 2.0.7
+ *
+ * @param $form_id
+ *
+ * @return bool
+ */
+function give_is_company_donation_show( $form_id ) {
+	$form_option = give_get_meta( $form_id, '_give_company_field', true );
+
+	if (
+		give_is_setting_enabled( $form_option, array( 'global', 'required', 'optional' ) )
+		&& give_is_setting_enabled( give_get_option( 'company_field' ), array( 'required', 'optional' ) )
+	) {
+		return true;
+
+	} elseif ( give_is_setting_enabled( $form_option, array( 'required', 'optional' ) ) ) {
+		return true;
+
+	} else {
+		return false;
 	}
 }

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -521,6 +521,13 @@ function give_get_required_fields( $form_id ) {
 		}
 	}
 
+	if ( give_is_company_donation_enabled( $form_id ) ) {
+		$required_fields['give_company'] = array(
+			'error_id'      => 'invalid_company',
+			'error_message' => __( 'Please enter Company Name.', 'give' ),
+		);
+	}
+
 	/**
 	 * Filters the donation form required field.
 	 *

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -522,7 +522,7 @@ function give_get_required_fields( $form_id ) {
 	}
 
 	if ( give_is_company_donation_enabled( $form_id ) ) {
-		$required_fields['give_company'] = array(
+		$required_fields['give_company_name'] = array(
 			'error_id'      => 'invalid_company',
 			'error_message' => __( 'Please enter Company Name.', 'give' ),
 		);

--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -10,11 +10,15 @@
 $current_user     = wp_get_current_user();
 
 if ( is_user_logged_in() ) :
-	$user_id      = get_current_user_id();
+	$user_id = get_current_user_id();
 	$first_name   = get_user_meta( $user_id, 'first_name', true );
+	$last_name    = get_user_meta( $user_id, 'last_name', true );
 	$last_name    = get_user_meta( $user_id, 'last_name', true );
 	$display_name = $current_user->display_name;
 	$address      = give_get_donor_address( $user_id, array( 'address_type' => 'personal' ) );
+
+	$donor        = new Give_Donor( $user_id, true );
+	$company_name = $donor->get_meta( '_give_donor_company', true );
 
 	if ( isset( $_GET['updated'] ) && 'true' === $_GET['updated'] && ! give_get_errors() ) :
 		if ( isset( $_GET['update_code'] ) ) :?>
@@ -61,6 +65,17 @@ if ( is_user_logged_in() ) :
 				<label for="give_last_name"><?php _e( 'Last Name', 'give' ); ?></label>
 				<input name="give_last_name" id="give_last_name" class="text give-input" type="text" value="<?php echo esc_attr( $last_name ); ?>"/>
 			</p>
+
+			<?php
+			if ( ! empty( $company_name ) ) {
+				?>
+				<p id="give_profile_company_name_wrap" class="form-row form-row-wide">
+					<label for="give_company_name"><?php _e( 'Company Name', 'give' ); ?></label>
+					<input name="give_company_name" id="give_company_name" class="text give-input" type="text" value="<?php echo esc_attr( $company_name ); ?>"/>
+				</p>
+				<?php
+			}
+			?>
 
 			<p id="give_profile_display_name_wrap" class="form-row form-row-first form-row-responsive">
 				<label for="give_display_name"><?php _e( 'Display Name', 'give' ); ?></label>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -25,6 +25,7 @@ $user         = give_get_payment_meta_user_info( $donation_id );
 $email        = give_get_payment_user_email( $donation_id );
 $status       = $payment->post_status;
 $status_label = give_get_payment_status( $payment, true );
+$company_name      = give_get_payment_meta( $donation_id, '_give_donation_company', true );
 
 /**
  * Generate Donation Receipt Arguments.
@@ -39,6 +40,23 @@ $give_receipt_args['donation_receipt']['donor'] = array(
 	'value'   => $user['first_name'] . ' ' . $user['last_name'],
 	'display' => $give_receipt_args['donor'],
 );
+
+/**
+ * Show Company name on Donation receipt Page
+ *
+ * @since 2.0.7
+ *
+ * @param bool show/hide company name in donation receipt page.
+ *
+ * @return bool show/hide company name in donation receipt page.
+ */
+if ( ! empty( $company_name ) && apply_filters( 'give_show_company_name_receipt_page', false )) {
+	$give_receipt_args['donation_receipt']['company'] = array(
+		'name'    => __( 'Company Donation', 'give' ),
+		'value'   => esc_attr( $company_name ),
+		'display' => $give_receipt_args['donor'],
+	);
+}
 
 $give_receipt_args['donation_receipt']['date'] = array(
 	'name'    => __( 'Date', 'give' ),


### PR DESCRIPTION
## Description
PR to fix #2453 

## How Has This Been Tested?
- [x] Added global `Company Donations` radio buttons setting with `Disabled|Required|Optional` options where the Default option will be Disabled
- [x] Added form `Company Donations` radio buttons setting with `Disabled|Required|Optional|Global` options. where the Default option will be Global
- [x] Include description `Do you want a Company field to appear after First Name and Last Name?`
- [x] Ensure `Company` field appears on the front-end form if the setting is enabled. The `Company` field should be a full-width field that appears below `First Name` and `Last Name`. The name fields must always be present even if a company field is displayed, too.
- [x] Save `Company` field to payment meta as `_give_donation_company` so it is permanently preserved.
- [x] Save `Company` field to donor meta as `_give_donor_company` and update the donor meta if a company was previously entered for that donor.
- [x] Display `Company` field in Donor details screen if it is populated.
- [x] Add company for the field on donor profile shortcode page.
- [x] Add feature to show company name on a receipt ( by default hide )
- [x] Add feature to show company name in email receipts.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/37520575-9d6b952e-2943-11e8-9ebf-2cb5a3b80211.png)

![image](https://user-images.githubusercontent.com/22215595/37520596-b1e8738c-2943-11e8-9f50-63f66f5dee8a.png)

![image](https://user-images.githubusercontent.com/22215595/37520609-bd2805b4-2943-11e8-9a8f-fc4f442dc6f9.png)

![image](https://user-images.githubusercontent.com/22215595/37520645-ddf12b22-2943-11e8-8f0f-2b5e74156bdd.png)

![image](https://user-images.githubusercontent.com/22215595/37520664-efc0f85a-2943-11e8-98bd-7e1b8c2a9d1b.png)



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.