### PR TITLE
refactor(activation-banner): show activated add-on in tab view.

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -104,7 +104,7 @@ class Give_Addon_Activation_Banner {
 	 *
 	 * @since 2.0.7
 	 *
-	 * @param array $plugin_file Plugin filename.
+	 * @param string $plugin_file Plugin filename.
 	 */
 	public function give_addon_activation( $plugin_file ) {
 		if ( strpos( $plugin_file, 'Give-' ) !== false ) {

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -68,9 +68,6 @@ class Give_Addon_Activation_Banner {
 			// If multiple add-on are activated then show activation banner in tab view.
 			add_action( 'admin_notices', array( $this, 'addon_activation_banner_notices' ), 10 );
 		}
-
-		// Remove the flag of the dimissed notice when any Give's add-on activated.
-		add_action( 'activate_plugin', array( $this, 'give_addon_activation' ), 10, 1 );
 	}
 
 	/**
@@ -96,19 +93,6 @@ class Give_Addon_Activation_Banner {
 
 		if ( ! empty( $file_name ) ) {
 			add_action( 'deactivate_' . $file_name, array( $this, 'remove_addon_activate_meta' ) );
-		}
-	}
-
-	/**
-	 * Delete meta from the user meta table when any Give's Add-on activated.
-	 *
-	 * @since 2.0.7
-	 *
-	 * @param string $plugin_file Plugin filename.
-	 */
-	public function give_addon_activation( $plugin_file ) {
-		if ( strpos( $plugin_file, 'Give-' ) !== false ) {
-			delete_user_meta( $this->user_id, 'give_addon_activation_ignore_all' );
 		}
 	}
 

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -94,6 +94,52 @@ class Give_Addon_Activation_Banner {
 		}
 	}
 
+	/**
+	 * Get plugin file name.
+	 *
+	 * @since   1.8
+	 * @access  private
+	 * @return mixed
+	 */
+	private function get_plugin_file_name() {
+		$active_plugins = get_option( 'active_plugins' );
+		$file_name      = '';
+
+		try {
+
+			// Check addon file path.
+			if ( ! empty( $this->banner_details['file'] ) ) {
+				$file_name = '';
+				if ( $file_path = explode( '/plugins/', $this->banner_details['file'] ) ) {
+					$file_path = array_pop( $file_path );
+					$file_name = current( explode( '/', $file_path ) );
+				}
+
+				if ( empty( $file_name ) ) {
+					return false;
+				}
+
+				foreach ( $active_plugins as $plugin ) {
+					if ( false !== strpos( $plugin, $file_name ) ) {
+						$file_name = $plugin;
+						break;
+					}
+				}
+			} elseif ( WP_DEBUG ) {
+				throw new Exception( __( "File path must be added within the {$this->banner_details['name']} add-on in the banner details.", 'give' ) );
+			}
+
+			// Check plugin path calculated by addon file path.
+			if ( empty( $file_name ) && WP_DEBUG ) {
+				throw new Exception( __( "Empty add-on plugin path for {$this->banner_details['name']} add-on.", 'give' ) );
+			}
+
+		} catch ( Exception $e ) {
+			echo $e->getMessage();
+		}
+
+		return $file_name;
+	}
 
 	/**
 	 * Check if current page is plugin page or not.
@@ -336,53 +382,4 @@ class Give_Addon_Activation_Banner {
 			delete_option( $this->activate_by_meta_key );
 		}
 	}
-
-
-	/**
-	 * Get plugin file name.
-	 *
-	 * @since   1.8
-	 * @access  private
-	 * @return mixed
-	 */
-	private function get_plugin_file_name() {
-		$active_plugins = get_option( 'active_plugins' );
-		$file_name      = '';
-
-		try {
-
-			// Check addon file path.
-			if ( ! empty( $this->banner_details['file'] ) ) {
-				$file_name = '';
-				if ( $file_path = explode( '/plugins/', $this->banner_details['file'] ) ) {
-					$file_path = array_pop( $file_path );
-					$file_name = current( explode( '/', $file_path ) );
-				}
-
-				if ( empty( $file_name ) ) {
-					return false;
-				}
-
-				foreach ( $active_plugins as $plugin ) {
-					if ( false !== strpos( $plugin, $file_name ) ) {
-						$file_name = $plugin;
-						break;
-					}
-				}
-			} elseif ( WP_DEBUG ) {
-				throw new Exception( __( "File path must be added within the {$this->banner_details['name']} add-on in the banner details.", 'give' ) );
-			}
-
-			// Check plugin path calculated by addon file path.
-			if ( empty( $file_name ) && WP_DEBUG ) {
-				throw new Exception( __( "Empty add-on plugin path for {$this->banner_details['name']} add-on.", 'give' ) );
-			}
-
-		} catch ( Exception $e ) {
-			echo $e->getMessage();
-		}
-
-		return $file_name;
-	}
-
 }

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -68,6 +68,9 @@ class Give_Addon_Activation_Banner {
 			// If multiple add-on are activated then show activation banner in tab view.
 			add_action( 'admin_notices', array( $this, 'addon_activation_banner_notices' ), 10 );
 		}
+
+		// Remove the flag of the dimissed notice when any Give's add-on activated.
+		add_action( 'activate_plugin', array( $this, 'give_addon_activation' ), 10, 1 );
 	}
 
 	/**
@@ -87,13 +90,25 @@ class Give_Addon_Activation_Banner {
 
 		//Get the current page to add the notice to
 		add_action( 'current_screen', array( $this, 'give_addon_notice_ignore' ) );
-		add_action( 'admin_notices', array( $this, 'give_addon_activation_admin_notice' ) );
 
 		// File path of addon must be included in banner detail other addon activate meta will not delete.
 		$file_name = $this->get_plugin_file_name();
 
 		if ( ! empty( $file_name ) ) {
 			add_action( 'deactivate_' . $file_name, array( $this, 'remove_addon_activate_meta' ) );
+		}
+	}
+
+	/**
+	 * Delete meta from the user meta table when any Give's Add-on activated.
+	 *
+	 * @since 2.0.7
+	 *
+	 * @param array $plugin_file Plugin filename.
+	 */
+	public function give_addon_activation( $plugin_file ) {
+		if ( strpos( $plugin_file, 'Give-' ) !== false ) {
+			delete_user_meta( $this->user_id, 'give_addon_activation_ignore_all' );
 		}
 	}
 

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -430,7 +430,6 @@ class Give_Addon_Activation_Banner {
 				display: block;
 				font-weight: bold;
 				color: #a3a3a3;
-				text-transform: capitalize;
 				text-decoration: none;
 				padding: 15px 10px 15px;
 				box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -308,42 +308,41 @@ class Give_Addon_Activation_Banner {
 	}
 
 	/**
-	 * Add activation banner css.
+	 * Add activation banner css and js .
 	 *
-	 * @since 1.8.16
+	 * @since  1.8.16
+	 * @since  2.0.7 Added JS code for multiple add-on.
 	 * @access private
 	 */
-	private function print_css(){
+	private function print_css_js() {
 		?>
 		<style>
 			div.give-addon-alert.updated {
 				padding: 20px;
 				position: relative;
 				border-color: #66BB6A;
+				min-height: 85px;
 			}
 
 			div.give-alert-message {
-				margin-left: 70px;
+				margin-left: 108px;
 			}
 
 			div.give-addon-alert img.give-logo {
-				max-width: 50px;
+				max-width: 85px;
 				float: left;
 			}
 
 			div.give-addon-alert h3 {
 				margin: -5px 0 10px;
 				font-size: 22px;
-				font-weight: 300;
+				font-weight: 400;
 				line-height: 30px;
 			}
 
 			div.give-addon-alert h3 span {
 				font-weight: 700;
 				color: #66BB6A;
-			}
-
-			div.give-addon-alert .alert-actions {
 			}
 
 			div.give-addon-alert a {
@@ -369,6 +368,18 @@ class Give_Addon_Activation_Banner {
 
 			div.give-addon-alert .dismiss {
 				position: absolute;
+				right: 0px;
+				height: 99%;
+				top: 23%;
+				margin-top: -10px;
+				outline: none;
+				box-shadow: none;
+				text-decoration: none;
+				color: #AAA;
+			}
+
+			div.give-addon-alert .dismiss {
+				position: absolute;
 				right: 20px;
 				height: 100%;
 				top: 50%;
@@ -379,8 +390,129 @@ class Give_Addon_Activation_Banner {
 				color: #AAA;
 			}
 
+			.give-alert-tab-wrapper .dismiss {
+				right: 0px !important;
+				height: 99% !important;
+				top: 23% !important;
+			}
+
 			div.give-addon-alert .dismiss:hover {
 				color: #333;
+			}
+
+			ul.give-alert-addon-list {
+				min-width: 220px;
+				display: inline-block;
+				float: left;
+				max-width: 250px;
+				padding: 0;
+				margin: 0;
+			}
+
+			.give-addon-alert .give-addon-description {
+				padding: 1px;
+				display: inline-block;
+				color: #777;
+				margin-bottom: 12px;
+			}
+
+			.give-alert-tab-wrapper .give-right-side-block {
+				width: calc(100% - 250px);
+				display: inline-block;
+				float: left;
+				background: #fff;
+				height: 100%;
+				position: relative;
+			}
+
+			.give-vertical-tab {
+				width: 100%;
+			}
+
+			ul.give-alert-addon-list li {
+				display: block;
+				border: 1px solid #d1d1d18f;
+				border-width: 1px 0px 0px 0px;
+				margin: 0;
+			}
+
+			ul.give-alert-addon-list li a {
+				display: block;
+				font-weight: bold;
+				color: #a3a3a3;
+				text-transform: capitalize;
+				text-decoration: none;
+				padding: 15px 10px 15px;
+				box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);
+				-moz-box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);
+				-webkit-box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);
+				-ms-box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);
+				-o-box-shadow: inset -6px 0px 18px 0px rgba(204, 204, 204, 0.36);
+			}
+
+			ul.give-alert-addon-list li.give-tab-list.active a {
+				color: #5f6c74;
+				box-shadow: none;
+			}
+
+			.updated.give-addon-alert.give-notice.give-alert-tab-wrapper {
+				display: inline-block;
+				width: 100%;
+			}
+
+			.give-tab-details {
+				display: none;
+				min-height: 100px;
+				position: absolute;
+				top: 0;
+				left: 0;
+				padding: 20px 20px 20px 40px;
+			}
+
+			.give-tab-details.active {
+				display: block;
+				z-index: 1;
+				position: relative;
+			}
+
+			.give-alert-tab-wrapper.give-addon-alert img.give-logo {
+				max-width: 80px;
+			}
+
+			.give-alert-tab-wrapper .give-alert-message {
+				margin-left: 100px;
+				padding-top: 10px;
+			}
+
+			ul.give-alert-addon-list li.give-tab-list.active {
+				background: #fff;
+			}
+
+			ul.give-alert-addon-list li.give-tab-list:last-child {
+				border-bottom: 0px solid #ccc;
+			}
+
+			ul.give-alert-addon-list li.give-tab-list:first-child {
+				border-top: 0 none;
+			}
+
+			.give-alert-tab-wrapper {
+				padding: 0 !important;
+			}
+
+			/** Responsiveness */
+			@media screen and (max-width: 767px) {
+				.give-alert-tab-wrapper .give-tab-details {
+					padding: 20px 40px 20px 20px;
+				}
+
+				.give-alert-tab-wrapper .give-right-side-block {
+					width: 100%;
+				}
+
+				.give-alert-tab-wrapper ul.give-alert-addon-list {
+					min-width: 100%;
+				}
 			}
 		</style>
 		<?php

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -519,7 +519,9 @@ class Give_Addon_Activation_Banner {
 		<!-- Start of the Give Add-on tab JS -->
 		<script type="text/javascript">
 					jQuery( document ).ready( function( $ ) {
-						$( '.give-alert-tab-wrapper' ).on( 'click', '.give-tab-list', function() {
+						$( '.give-alert-tab-wrapper' ).on( 'click', '.give-tab-list', function( e ) {
+							e.preventDefault();
+
 							var clicked_tab = $( this ).attr( 'id' ),
 								addon_tab_wrapper = $( this ).closest( '.give-alert-tab-wrapper' );
 
@@ -530,6 +532,8 @@ class Give_Addon_Activation_Banner {
 							// Remove 'active' class from the details.
 							addon_tab_wrapper.find( '.give-tab-details' ).removeClass( 'active' );
 							addon_tab_wrapper.find( '.give-right-side-block .give-tab-details#' + clicked_tab ).addClass( 'active' );
+
+							return false;
 						} );
 					} );
 		</script>

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -217,21 +217,23 @@ class Give_Addon_Activation_Banner {
 				if ( false === $is_single ) {
 					?>
 					<div class="give-vertical-tab">
-						<ul class="give-alert-addon-list">
-							<?php
-							$is_first = true;
-							foreach ( $give_addons as $banner ) {
-								?>
-								<li class="give-tab-list <?php echo ( true === $is_first ) ? ' active' : ''; ?>"
-								    id="give-addon-<?php echo esc_html( basename( $banner['file'], '.php' ) ); ?>">
-									<a href="#"><?php echo esc_html( $banner['name'] ); ?></a>
-								</li>
+						<div class="give-addon-tab-list">
+							<ul class="give-alert-addon-list">
 								<?php
-								$is_first = false;
-							}
-							$is_first = true;
-							?>
-						</ul>
+								$is_first = true;
+								foreach ( $give_addons as $banner ) {
+									?>
+									<li class="give-tab-list <?php echo ( true === $is_first ) ? ' active' : ''; ?>"
+									    id="give-addon-<?php echo esc_html( basename( $banner['file'], '.php' ) ); ?>">
+										<a href="#"><?php echo esc_html( $banner['name'] ); ?></a>
+									</li>
+									<?php
+									$is_first = false;
+								}
+								$is_first = true;
+								?>
+							</ul>
+						</div>
 						<div class="give-right-side-block">
 							<?php
 							foreach ( $give_addons as $banner ) {
@@ -420,6 +422,10 @@ class Give_Addon_Activation_Banner {
 				margin: 0;
 			}
 
+			ul.give-alert-addon-list li a.inactivate {
+				cursor: default;
+			}
+
 			ul.give-alert-addon-list li a {
 				display: block;
 				font-weight: bold;
@@ -484,6 +490,24 @@ class Give_Addon_Activation_Banner {
 				padding: 0 !important;
 			}
 
+			ul.give-alert-addon-list {
+				max-height: 195px;
+				overflow: hidden;
+			}
+
+			ul.give-alert-addon-list::-webkit-scrollbar {
+				height: 10px;
+				width: 10px;
+				border-radius: 4px;
+				transition: all 0.3s ease;
+				background: rgba(158, 158, 158, 0.15);
+			}
+
+			ul.give-alert-addon-list::-webkit-scrollbar-thumb {
+				background: #939395;
+				border-radius: 4px;
+			}
+
 			/** Responsiveness */
 			@media screen and (max-width: 767px) {
 				.give-alert-tab-wrapper .give-tab-details {
@@ -503,10 +527,13 @@ class Give_Addon_Activation_Banner {
 		<!-- Start of the Give Add-on tab JS -->
 		<script type="text/javascript">
 					jQuery( document ).ready( function( $ ) {
-						$( '.give-alert-tab-wrapper' ).on( 'click', '.give-tab-list', function( e ) {
-							e.preventDefault();
+						$( '.give-alert-tab-wrapper' ).on( 'click', '.give-tab-list', function() {
+							if ( $( this ).find( 'a' ).hasClass( 'inactivate' ) ) {
+								return false;
+							}
 
-							var clicked_tab = $( this ).attr( 'id' ),
+							var
+								clicked_tab = $( this ).attr( 'id' ),
 								addon_tab_wrapper = $( this ).closest( '.give-alert-tab-wrapper' );
 
 							// Remove 'active' class from all tab list.
@@ -519,6 +546,28 @@ class Give_Addon_Activation_Banner {
 
 							return false;
 						} );
+
+						var add_on_tabs = $( '.give-alert-addon-list' );
+
+						add_on_tabs
+							.mouseout( function() {
+								$( this ).css( 'overflow', 'hidden' );
+							} )
+							.mouseover( function() {
+								$( this ).css( 'overflow', 'auto' );
+							} );
+
+						// Prevent default click event of the add-on.
+						add_on_tabs.find( 'li a' ).on( 'click', function( e ) {
+							e.preventDefault();
+						} );
+
+						// If total length of the add-on is 2.
+						if ( 2 === add_on_tabs.find( 'li' ).length ) {
+							var li = $( 'li.give-tab-list' );
+							li.last().clone().prependTo( 'ul.give-alert-addon-list' );
+							li.last().removeAttr( 'id' ).find( 'a' ).addClass( 'inactivate' ).html( '&nbsp;' );
+						}
 					} );
 		</script>
 		<!-- End of the Give Add-on tab JS -->

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -4,7 +4,6 @@
  *
  * @author  WordImpress
  * @version 1.0
- * https://github.com/WordImpress/plugin-activation-banner-demo
  */
 
 // Exit if accessed directly.
@@ -12,8 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+global $give_addons;
+
 /**
  * Class Give_Addon_Activation_Banner
+ *
+ * @since  2.0.7 Added pleasing interface when multiple add-ons are activated.
  */
 class Give_Addon_Activation_Banner {
 
@@ -33,19 +36,32 @@ class Give_Addon_Activation_Banner {
 	 *                               }
 	 */
 	function __construct( $_banner_details ) {
-		$current_user = wp_get_current_user();
+		global $give_addons;
 
-		$this->plugin_activate_by   = 0;
-		$this->banner_details       = $_banner_details;
-		$this->test_mode            = ( $this->banner_details['testing'] == 'true' ) ? true : false;
-		$this->nag_meta_key         = 'give_addon_activation_ignore_' . sanitize_title( $this->banner_details['name'] );
-		$this->activate_by_meta_key = 'give_addon_' . sanitize_title( $this->banner_details['name'] ) . '_active_by_user';
+		// Append add-on information to the global variable.
+		$give_addons[] = $_banner_details;
+
+		// Get the currenct user.
+		$current_user = wp_get_current_user();
 
 		//Get current user
 		$this->user_id = $current_user->ID;
 
-		// Set up hooks.
-		$this->init();
+		// Only if single add-on activated.
+		if ( 1 === count( $give_addons ) ) {
+
+			$this->plugin_activate_by   = 0;
+			$this->banner_details       = $_banner_details;
+			$this->test_mode            = ( $this->banner_details['testing'] == 'true' ) ? true : false;
+			$this->nag_meta_key         = 'give_addon_activation_ignore_' . sanitize_title( $this->banner_details['name'] );
+			$this->activate_by_meta_key = 'give_addon_' . sanitize_title( $this->banner_details['name'] ) . '_active_by_user';
+
+			// Set up hooks.
+			$this->init();
+
+			// Store user id who activate plugin.
+			$this->add_addon_activate_meta();
+		}
 
 		// Store user id who activate plugin.
 		$this->add_addon_activate_meta();

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -583,8 +583,21 @@ class Give_Addon_Activation_Banner {
 	 * @param string $meta_key   Pass meta key.
 	 */
 	private function render_single_addon_banner( $banner_arr, $meta_key = '' ) {
+		// Get all give add-on.
+		$give_addons = give_get_plugins();
+
+		// Plugin main file.
+		$plugin_file = $banner_arr['file'];
+
+		// Get the plugin main file.
+		foreach ( $give_addons as $main_file => $addon ) {
+			if ( isset( $banner_arr['name'] ) && strpos( $addon['Name'], $banner_arr['name'] ) !== false ) {
+				$plugin_file = WP_PLUGIN_DIR . '/' . $main_file;
+			}
+		}
+
 		// Get the add-on details.
-		$plugin_data = get_plugin_data( $banner_arr['file'] );
+		$plugin_data = get_plugin_data( $plugin_file);
 		?>
 		<img src="<?php echo GIVE_PLUGIN_URL; ?>assets/images/svg/give-icon-full-circle.svg" class="give-logo" />
 		<div class="give-alert-message">

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -393,6 +393,8 @@ class Give_Addon_Activation_Banner {
 				max-width: 250px;
 				padding: 0;
 				margin: 0;
+				max-height: 146px;
+				overflow: hidden;
 			}
 
 			div.give-addon-alert .give-addon-description {
@@ -487,11 +489,6 @@ class Give_Addon_Activation_Banner {
 
 			.give-alert-tab-wrapper {
 				padding: 0 !important;
-			}
-
-			ul.give-alert-addon-list {
-				max-height: 195px;
-				overflow: hidden;
 			}
 
 			ul.give-alert-addon-list::-webkit-scrollbar {

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -515,6 +515,25 @@ class Give_Addon_Activation_Banner {
 				}
 			}
 		</style>
+
+		<!-- Start of the Give Add-on tab JS -->
+		<script type="text/javascript">
+					jQuery( document ).ready( function( $ ) {
+						$( '.give-alert-tab-wrapper' ).on( 'click', '.give-tab-list', function() {
+							var clicked_tab = $( this ).attr( 'id' ),
+								addon_tab_wrapper = $( this ).closest( '.give-alert-tab-wrapper' );
+
+							// Remove 'active' class from all tab list.
+							$( '.give-alert-addon-list li' ).removeClass( 'active' );
+							// Add active class to the selected tab.
+							$( this ).addClass( 'active' );
+							// Remove 'active' class from the details.
+							addon_tab_wrapper.find( '.give-tab-details' ).removeClass( 'active' );
+							addon_tab_wrapper.find( '.give-right-side-block .give-tab-details#' + clicked_tab ).addClass( 'active' );
+						} );
+					} );
+		</script>
+		<!-- End of the Give Add-on tab JS -->
 		<?php
 	}
 

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -223,7 +223,7 @@ class Give_Addon_Activation_Banner {
 								$is_first = true;
 								foreach ( $give_addons as $banner ) {
 									?>
-									<li class="give-tab-list <?php echo ( true === $is_first ) ? ' active' : ''; ?>"
+									<li class="give-tab-list<?php echo ( true === $is_first ) ? ' active' : ''; ?>"
 									    id="give-addon-<?php echo esc_html( basename( $banner['file'], '.php' ) ); ?>">
 										<a href="#"><?php echo esc_html( $banner['name'] ); ?></a>
 									</li>
@@ -567,6 +567,7 @@ class Give_Addon_Activation_Banner {
 							var li = $( 'li.give-tab-list' );
 							li.last().clone().prependTo( 'ul.give-alert-addon-list' );
 							li.last().removeAttr( 'id' ).find( 'a' ).addClass( 'inactivate' ).html( '&nbsp;' );
+							$('.give-tab-list:first').trigger('click');
 						}
 					} );
 		</script>
@@ -611,9 +612,7 @@ class Give_Addon_Activation_Banner {
 					<?php
 				}
 				if ( isset( $banner_arr['settings_url'] ) ) { ?>
-					<a href="<?php echo $banner_arr['settings_url']; ?>"><span class="dashicons dashicons-admin-settings"></span>
-						<?php esc_html_e( 'Go to Settings', 'give' ); ?>
-					</a>
+					<a href="<?php echo $banner_arr['settings_url']; ?>"><span class="dashicons dashicons-admin-settings"></span><?php esc_html_e( 'Go to Settings', 'give' ); ?></a>
 					<?php
 				}
 				// Show them how to configure the Addon.

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -376,7 +376,7 @@ class Give_Addon_Activation_Banner {
 				color: #AAA;
 			}
 
-			.give-alert-tab-wrapper .dismiss {
+			div.give-alert-tab-wrapper .dismiss {
 				right: 0px !important;
 				height: 99% !important;
 				top: 23% !important;
@@ -395,14 +395,14 @@ class Give_Addon_Activation_Banner {
 				margin: 0;
 			}
 
-			.give-addon-alert .give-addon-description {
+			div.give-addon-alert .give-addon-description {
 				padding: 1px;
 				display: inline-block;
 				color: #777;
 				margin-bottom: 12px;
 			}
 
-			.give-alert-tab-wrapper .give-right-side-block {
+			div.give-alert-tab-wrapper .give-right-side-block {
 				width: calc(100% - 250px);
 				display: inline-block;
 				float: left;
@@ -411,7 +411,7 @@ class Give_Addon_Activation_Banner {
 				position: relative;
 			}
 
-			.give-vertical-tab {
+			div.give-vertical-tab {
 				width: 100%;
 			}
 
@@ -445,12 +445,12 @@ class Give_Addon_Activation_Banner {
 				box-shadow: none;
 			}
 
-			.updated.give-addon-alert.give-notice.give-alert-tab-wrapper {
+			div.updated.give-addon-alert.give-notice.give-alert-tab-wrapper {
 				display: inline-block;
 				width: 100%;
 			}
 
-			.give-tab-details {
+			.give-alert-tab-wrapper .give-tab-details {
 				display: none;
 				min-height: 100px;
 				position: absolute;
@@ -459,7 +459,7 @@ class Give_Addon_Activation_Banner {
 				padding: 20px 20px 20px 40px;
 			}
 
-			.give-tab-details.active {
+			.give-alert-tab-wrapper .give-tab-details.active {
 				display: block;
 				z-index: 1;
 				position: relative;

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -216,7 +216,7 @@ class Give_Addon_Activation_Banner {
 		}
 
 		// If only one add-on activated.
-		$is_single = 1 === count( $give_addons ) ? true : false;
+		$is_single = 1 === count( $give_addons );
 
 		// If the user hasn't already dismissed the alert, output activation banner.
 		if ( ! get_user_meta( $this->user_id, $this->get_notice_dismiss_meta_key() ) ) {

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -115,3 +115,22 @@ function give_get_admin_page_menu_title() {
 
 	return $title;
 }
+
+/**
+ * Remove the dismissed flag for add-on's activation banners.
+ *
+ * @since 2.0.7
+ *
+ * @param string $plugin_file Plugin file name.
+ */
+function give_remove_activation_dismissed_flag( $plugin_file ) {
+	if ( strpos( $plugin_file, 'Give-' ) !== false ) {
+		// Get the current user.
+		$current_user = wp_get_current_user();
+
+		// Remove meta from the user meta.
+		delete_user_meta( $current_user->ID, 'give_addon_activation_ignore_all' );
+	}
+}
+
+add_action( 'activated_plugin', 'give_remove_activation_dismissed_flag', 10, 1 );


### PR DESCRIPTION
## Description
This PR #2903 

## How Has This Been Tested?
- Manually.

## Screenshots (jpeg or gifs if applicable):

#### When two or more add-on are activated:
![multi](https://user-images.githubusercontent.com/14994452/37521574-3a54e766-2947-11e8-9d0b-885a4076ae45.png)

#### When single add-on is activated:
![screenshot-gwp local-2018 03 16-18-20-15](https://user-images.githubusercontent.com/14994452/37521647-79716690-2947-11e8-9afa-179ebac2bc42.png)

#### Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.