### PR TITLE
feat(admin-email): add Email Recipients section to donor emails 2657

### DIFF
--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -27,6 +27,8 @@ class Give_Email_Setting_Field {
 		// Recipient field.
 		if ( Give_Email_Notification_Util::has_recipient_field( $email ) ) {
 			$setting_fields[] = self::get_recipient_setting_field( $email, $form_id );
+		} else {
+			$setting_fields[] = self::get_disable_recipient_setting_field( $email, $form_id );
 		}
 
 
@@ -323,6 +325,35 @@ class Give_Email_Setting_Field {
 				),
 			);
 		}
+
+		return $recipient;
+	}
+
+	/**
+	 * Get recipient setting field that is disable.
+	 *
+	 * @since  2.0.7
+	 *
+	 * @access static
+	 * @todo check this field in form metabox setting after form api merge.
+	 *
+	 * @param Give_Email_Notification $email
+	 * @param int $form_id
+	 *
+	 * @return array
+	 */
+	public static function get_disable_recipient_setting_field( Give_Email_Notification $email, $form_id = null ) {
+		$recipient = array(
+			'id'         => self::get_prefix( $email, $form_id ) . 'disable_recipient',
+			'name'       => esc_html__( 'Email Recipients', 'give' ),
+			'desc'       => esc_html__( 'This email is sent to the Donor and the recipients cannot be customized.', 'give' ),
+			'default'    => '{donor_email}',
+			'value'      => '{donor_email}',
+			'type'       => 'text',
+			'attributes' => array(
+				'disabled' => true,
+			),
+		);
 
 		return $recipient;
 	}

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -333,7 +333,7 @@ class Give_Email_Setting_Field {
 			$recipient['attributes']['disabled'] = 'disabled';
 			$recipient['value']                  = $recipient['default'] = '{donor_email}';
 			$recipient['repeat']                 = false;
-			$recipient['desc']    = __( 'This email is sent to the Donor and the recipients cannot be customized.', 'give' );
+			$recipient['desc']                   = __( 'This email is sent to the Donor and the recipients cannot be customized.', 'give' );
 		}
 
 		return $recipient;

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -25,12 +25,7 @@ class Give_Email_Setting_Field {
 		$setting_fields = self::get_default_setting_fields( $email, $form_id );
 
 		// Recipient field.
-		if ( Give_Email_Notification_Util::has_recipient_field( $email ) ) {
-			$setting_fields[] = self::get_recipient_setting_field( $email, $form_id );
-		} else {
-			$setting_fields[] = self::get_disable_recipient_setting_field( $email, $form_id );
-		}
-
+		$setting_fields[] = self::get_recipient_setting_field( $email, $form_id, Give_Email_Notification_Util::has_recipient_field( $email ) );
 
 		// Add extra setting field.
 		if ( $extra_setting_field = $email->get_extra_setting_fields( $form_id ) ) {
@@ -135,10 +130,10 @@ class Give_Email_Setting_Field {
 		$settings[] = self::get_notification_status_field( $email, $form_id );
 
 		if ( ! Give_Email_Notification_Util::is_notification_status_editable( $email ) ) {
-			if( $form_id || give_is_add_new_form_page() ){
+			if ( $form_id || give_is_add_new_form_page() ) {
 				// Do not allow admin to disable notification on perform basis.
 				unset( $settings[1]['options']['disabled'] );
-			} else{
+			} else {
 				// Do not allow admin to edit notification status globally.
 				unset( $settings[1] );
 			}
@@ -147,7 +142,7 @@ class Give_Email_Setting_Field {
 		$settings[] = self::get_email_subject_field( $email, $form_id );
 		$settings[] = self::get_email_message_field( $email, $form_id );
 
-		if( Give_Email_Notification_Util::is_content_type_editable( $email ) ) {
+		if ( Give_Email_Notification_Util::is_content_type_editable( $email ) ) {
 			$settings[] = self::get_email_content_type_field( $email, $form_id );
 		}
 
@@ -184,7 +179,7 @@ class Give_Email_Setting_Field {
 			$default_value = 'global';
 		}
 
-		$description = isset($_GET['page']) && 'give-settings' === $_GET['page'] ? __('Choose whether you want this email enabled or not.', 'give') : sprintf( __( 'Global Options are set <a href="%s">in Give settings</a>. You may override them for this form here.', 'give' ), admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=emails' ) );
+		$description = isset( $_GET['page'] ) && 'give-settings' === $_GET['page'] ? __( 'Choose whether you want this email enabled or not.', 'give' ) : sprintf( __( 'Global Options are set <a href="%s">in Give settings</a>. You may override them for this form here.', 'give' ), admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=emails' ) );
 
 		return array(
 			'name'          => esc_html__( 'Notification', 'give' ),
@@ -240,7 +235,7 @@ class Give_Email_Setting_Field {
 				$email_tag_list,
 				sprintf(
 					'<br><a href="%1$s" target="_blank">%2$s</a> %3$s',
-					esc_url('http://docs.givewp.com/meta-email-tags'),
+					esc_url( 'http://docs.givewp.com/meta-email-tags' ),
 					__( 'See our documentation', 'give' ),
 					__( 'for examples of how to use custom meta email tags to output additional donor or donation information in your Give emails.', 'give' )
 				)
@@ -288,15 +283,16 @@ class Give_Email_Setting_Field {
 	 *
 	 * @since  2.0
 	 * @access static
-	 * @todo check this field in form metabox setting after form api merge.
+	 * @todo   check this field in form metabox setting after form api merge.
 	 *
 	 * @param Give_Email_Notification $email
 	 * @param int                     $form_id
+	 * @param bool                    $edit_recipient
 	 *
 	 * @return array
 	 */
-	public static function get_recipient_setting_field( Give_Email_Notification $email, $form_id = null ) {
-		$recipient =  array(
+	public static function get_recipient_setting_field( Give_Email_Notification $email, $form_id = null, $edit_recipient = true ) {
+		$recipient = array(
 			'id'               => self::get_prefix( $email, $form_id ) . 'recipient',
 			'name'             => esc_html__( 'Email Recipients', 'give' ),
 			'desc'             => __( 'Enter the email address(es) that should receive a notification.', 'give' ),
@@ -326,34 +322,18 @@ class Give_Email_Setting_Field {
 			);
 		}
 
-		return $recipient;
-	}
+		// Disable field if email donor has recipient field.
+		// @see https://github.com/WordImpress/Give/issues/2657
+		if ( ! $edit_recipient ) {
+			if ( 'group' == $recipient['type'] ) {
+				$recipient         = current( $recipient['fields'] );
+				$recipient['type'] = 'text';
+			}
 
-	/**
-	 * Get recipient setting field that is disable.
-	 *
-	 * @since  2.0.7
-	 *
-	 * @access static
-	 * @todo check this field in form metabox setting after form api merge.
-	 *
-	 * @param Give_Email_Notification $email
-	 * @param int $form_id
-	 *
-	 * @return array
-	 */
-	public static function get_disable_recipient_setting_field( Give_Email_Notification $email, $form_id = null ) {
-		$recipient = array(
-			'id'         => self::get_prefix( $email, $form_id ) . 'disable_recipient',
-			'name'       => esc_html__( 'Email Recipients', 'give' ),
-			'desc'       => esc_html__( 'This email is sent to the Donor and the recipients cannot be customized.', 'give' ),
-			'default'    => '{donor_email}',
-			'value'      => '{donor_email}',
-			'type'       => 'text',
-			'attributes' => array(
-				'disabled' => true,
-			),
-		);
+			$recipient['attributes']['disabled'] = 'disabled';
+			$recipient['value']                  = $recipient['default'] = '{donor_email}';
+			$recipient['repeat']                 = false;
+		}
 
 		return $recipient;
 	}
@@ -391,10 +371,10 @@ class Give_Email_Setting_Field {
 	 *
 	 * @return string
 	 */
-	public static function get_prefix( Give_Email_Notification $email, $form_id = null  ) {
+	public static function get_prefix( Give_Email_Notification $email, $form_id = null ) {
 		$meta_key = "{$email->config['id']}_";
 
-		if( $form_id || give_is_add_new_form_page() ) {
+		if ( $form_id || give_is_add_new_form_page() ) {
 			$meta_key = "_give_{$email->config['id']}_";
 		}
 

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -282,7 +282,7 @@ class Give_Email_Setting_Field {
 	 * Get recipient setting field.
 	 *
 	 * @since  2.0
-	 * @access static
+	 * @access public
 	 * @todo   check this field in form metabox setting after form api merge.
 	 *
 	 * @param Give_Email_Notification $email

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -333,6 +333,7 @@ class Give_Email_Setting_Field {
 			$recipient['attributes']['disabled'] = 'disabled';
 			$recipient['value']                  = $recipient['default'] = '{donor_email}';
 			$recipient['repeat']                 = false;
+			$recipient['desc']    = __( 'This email is sent to the Donor and the recipients cannot be customized.', 'give' );
 		}
 
 		return $recipient;


### PR DESCRIPTION
## Description
PR to fix #2657 

## How Has This Been Tested?
Manually tested by Making Donation

- [x] Tested By making an offline donation
- [x] Tested by making a test donation and check for a donation receipt 
- [x] Tested by creating a new donor and check for donor registration email
- [x] Tested by enabling the Email access option and then try to access it 


## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/37773974-053516b0-2e05-11e8-864a-f460b5b8c1a6.png)

![image](https://user-images.githubusercontent.com/22215595/37774022-1ef61766-2e05-11e8-967c-d2ebd6654a88.png)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.