### PR TITLE
fix(shortcode): load modal forms in form grid via AJAX #2951

### DIFF
--- a/assets/src/css/frontend/donation-grid.scss
+++ b/assets/src/css/frontend/donation-grid.scss
@@ -153,10 +153,6 @@
 	.give-btn-modal {
 		display: none !important;
 	}
-
-	.mfp-close:hover {
-		background-color: rgba(0, 0, 0, 0);
-	}
 }
 
 // .progress {
@@ -262,4 +258,126 @@
 
 .my-mfp-slide-bottom.mfp-removing.mfp-bg {
 	opacity: 0;
+}
+
+.white-popup {
+	position: relative;
+	background: #fff;
+	font-size: 16px;
+	width: auto;
+	max-width: 600px;
+	margin: 20px auto;
+	padding: 1rem 2rem;
+	margin-top: 60px;
+	border-top: 5px solid rgba(0, 0, 0, 0);
+	line-height: 1.5;
+	box-shadow: 0px 15px 10px -5px rgba(0, 0, 0, .15);
+	max-height: 80vh;
+	overflow: auto;
+}
+
+
+.my-mfp-zoom-in .zoom-animation {
+	opacity: 0;
+
+	-webkit-transition: all 0.2s ease-in-out;
+	-moz-transition: all 0.2s ease-in-out;
+	-o-transition: all 0.2s ease-in-out;
+	transition: all 0.2s ease-in-out;
+	-webkit-transform: scale(0.8);
+	-moz-transform: scale(0.8);
+	-ms-transform: scale(0.8);
+	-o-transform: scale(0.8);
+	transform: scale(0.8);
+}
+
+.my-mfp-zoom-in.mfp-ready .zoom-animation {
+	opacity: 1;
+
+	-webkit-transform: scale(1);
+	-moz-transform: scale(1);
+	-ms-transform: scale(1);
+	-o-transform: scale(1);
+	transform: scale(1);
+}
+
+.my-mfp-zoom-in.mfp-removing .zoom-animation {
+	-webkit-transform: scale(0.8);
+	-moz-transform: scale(0.8);
+	-ms-transform: scale(0.8);
+	-o-transform: scale(0.8);
+	transform: scale(0.8);
+	opacity: 0;
+}
+
+.my-mfp-zoom-in.mfp-bg {
+	opacity: 0;
+	-webkit-transition: opacity 0.3s ease-out;
+	-moz-transition: opacity 0.3s ease-out;
+	-o-transition: opacity 0.3s ease-out;
+	transition: opacity 0.3s ease-out;
+}
+
+.my-mfp-zoom-in.mfp-ready.mfp-bg {
+	opacity: 0.8;
+}
+
+.my-mfp-zoom-in.mfp-removing.mfp-bg {
+	opacity: 0;
+}
+
+/**
+ * Fade-move animation for second dialog
+ */
+.popup-fade-slide .zoom-animation {
+	opacity: 0;
+	-webkit-transition: all 0.2s ease-out;
+	-moz-transition: all 0.2s ease-out;
+	-o-transition: all 0.2s ease-out;
+	transition: all 0.2s ease-out;
+
+	-webkit-transform: translateY(-20px) perspective( 600px ) rotateX( 10deg );
+	-moz-transform: translateY(-20px) perspective( 600px ) rotateX( 10deg );
+	-ms-transform: translateY(-20px) perspective( 600px ) rotateX( 10deg );
+	-o-transform: translateY(-20px) perspective( 600px ) rotateX( 10deg );
+	transform: translateY(-20px) perspective( 600px ) rotateX( 10deg );
+
+}
+
+.popup-fade-slide.mfp-ready .zoom-animation {
+	opacity: 1;
+	-webkit-transform: translateY(0) perspective( 600px ) rotateX( 0 );
+	-moz-transform: translateY(0) perspective( 600px ) rotateX( 0 );
+	-ms-transform: translateY(0) perspective( 600px ) rotateX( 0 );
+	-o-transform: translateY(0) perspective( 600px ) rotateX( 0 );
+	transform: translateY(0) perspective( 600px ) rotateX( 0 );
+}
+
+.popup-fade-slide.mfp-removing .zoom-animation {
+	opacity: 0;
+	-webkit-transform: translateY(-10px) perspective( 600px ) rotateX( 10deg );
+	-moz-transform: translateY(-10px) perspective( 600px ) rotateX( 10deg );
+	-ms-transform: translateY(-10px) perspective( 600px ) rotateX( 10deg );
+	-o-transform: translateY(-10px) perspective( 600px ) rotateX( 10deg );
+	transform: translateY(-10px) perspective( 600px ) rotateX( 10deg );
+}
+
+.popup-fade-slide.mfp-bg {
+	opacity: 0;
+	-webkit-transition: opacity 0.3s ease-out;
+	-moz-transition: opacity 0.3s ease-out;
+	-o-transition: opacity 0.3s ease-out;
+	transition: opacity 0.3s ease-out;
+}
+
+.popup-fade-slide.mfp-ready.mfp-bg {
+	opacity: 0.8;
+}
+
+.popup-fade-slide.mfp-removing.mfp-bg {
+	opacity: 0;
+}
+
+.mfp-close:hover {
+	background-color: rgba(0, 0, 0, 0);
 }

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -10,15 +10,37 @@ jQuery( function( $ ) {
 	// Set custom validation message.
 	give_change_html5_form_field_validation_message();
 
-	// Donation grid shortcode popup.
-	$( '.js-give-grid-modal-launcher' ).magnificPopup( {
-		type: 'inline',
-		fixedContentPos: true,
-		fixedBgPos: true,
-		closeBtnInside: true,
-		midClick: true,
-		removalDelay: 300,
-		mainClass: 'my-mfp-slide-bottom',
+	// Get donation form HTML and popup using Magnific popup for [give_form_grid] shortcode.
+	doc.on( 'click', '.give-grid__item', function( e ) {
+		let ajax_popup = $( this ).data( 'ajax-popup' );
+
+		if ( ! ajax_popup ) {
+			return;
+		}
+
+		e.preventDefault();
+
+		let form_id = $( this ).data( 'form-id' );
+
+		$.ajax({
+			url: give_global_vars.ajaxurl,
+			type: 'POST',
+			data: {
+				action: 'get_modal_form_html',
+				form_id: form_id,
+			}
+		}).done( function( response ) {
+			var html = JSON.parse( response );
+
+			$.magnificPopup.open({
+				mainClass: 'popup-fade-slide',
+				removalDelay: 300,
+				items: {
+					src: `<div class="white-popup zoom-animation">${ html.modal_html }</div>`,
+					type: 'inline',
+				}
+			});
+		});
 	});
 
 	// Disable button if it have give-disabled class init.

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -623,3 +623,22 @@ function give_ajax_pages_search() {
 }
 
 add_action( 'wp_ajax_give_pages_search', 'give_ajax_pages_search' );
+
+/**
+ * Sends the HTML rendered by give_get_donation_form() as JSON.
+ */
+function give_ajax_get_modal_form_html() {
+
+	$form_id         = give_clean( $_POST['form_id'] );
+	$rendered_output = array();
+
+	ob_start();
+	give_get_donation_form( array( 'id' => intval( $form_id ) ) );
+	$rendered_output[ 'modal_html' ] = ob_get_clean();
+	echo wp_json_encode( $rendered_output );
+
+	give_die();
+}
+
+add_action( 'wp_ajax_no_priv_get_modal_form_html', 'give_ajax_get_modal_form_html' );
+add_action( 'wp_ajax_get_modal_form_html', 'give_ajax_get_modal_form_html' );

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -14,9 +14,10 @@ $atts             = $args[1]; // Shortcode attributes.
 $raw_content      = ''; // Raw form content.
 $stripped_content = ''; // Form content stripped of HTML tags and shortcodes.
 $excerpt          = ''; // Trimmed form excerpt ready for display.
+$form_id_modal   = ( 'modal' === $atts['display_style'] ) ? 'data-ajax-popup="enabled" data-form-id=' . $form_id : '';
 ?>
 
-<div class="give-grid__item">
+<div class="give-grid__item" <?php echo esc_attr( $form_id_modal ); ?>>
 	<?php
 	// Print the opening anchor tag based on display style.
 	if ( 'redirect' === $atts['display_style'] ) {
@@ -108,15 +109,4 @@ $excerpt          = ''; // Trimmed form excerpt ready for display.
 		}
 		?>
 	</a>
-	<?php
-	// If modal, print form in hidden container until it is time to be revealed.
-	if ( 'modal' === $atts['display_style'] ) {
-		printf(
-			'<div id="give-modal-form-%1$s" class="give-donation-grid-item-form zoom-anim-dialog mfp-hide">',
-			$form_id
-		);
-		give_get_donation_form( $form_id );
-		echo '</div>';
-	}
-	?>
 </div>


### PR DESCRIPTION
Closes #2951 

Ajax is used to render the form if `redirect` is set to `modal`

## How Has This Been Tested?
Manually tested

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.