### PR TITLE
fix(admin-plugins): Add check for author name #2953

### DIFF
--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -135,7 +135,6 @@ function give_remove_activation_dismissed_flag( $plugin_file ) {
 
 add_action( 'activated_plugin', 'give_remove_activation_dismissed_flag', 10, 1 );
 
-
 /**
  * Create new menu in plugin section that include all the add-on
  *
@@ -150,7 +149,7 @@ function give_filter_addons_do_filter_addons( $plugin_menu ) {
 
 	foreach ( $plugins['all'] as $plugin_slug => $plugin_data ) {
 
-		if ( false !== strpos( $plugin_data['Name'], 'Give' ) ) {
+		if ( false !== strpos( $plugin_data['Name'], 'Give' ) && false !== strpos( $plugin_data['AuthorName'], 'WordImpress' ) ) {
 			$plugins['give'][ $plugin_slug ]           = $plugins['all'][ $plugin_slug ];
 			$plugins['give'][ $plugin_slug ]['plugin'] = $plugin_slug;
 			// replicate the next step


### PR DESCRIPTION
## Description
PR to fix #2953 

## How Has This Been Tested?
Manually tested by adding multiple Give and another third party Add 

## Task
- [x] Added condition to check for Author name as well
- [x] Tested by creating a third Part Add-on and check it should not get the display on the Give Plugin List

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/37998213-602696d6-323b-11e8-9d9c-f397838ba5b3.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.