### PR TITLE
build: resolve issue when running "npm run build" #2962

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -128,12 +128,12 @@ class Give_Addon_Activation_Banner {
 					}
 				}
 			} elseif ( WP_DEBUG ) {
-				throw new Exception( __( "File path must be added within the {$this->banner_details['name']} add-on in the banner details.", 'give' ) );
+				throw new Exception( sprintf( __( 'File path must be added within the %s add-on in the banner details.' ), $this->banner_details['name'] ) );
 			}
 
 			// Check plugin path calculated by addon file path.
 			if ( empty( $file_name ) && WP_DEBUG ) {
-				throw new Exception( __( "Empty add-on plugin path for {$this->banner_details['name']} add-on.", 'give' ) );
+				throw new Exception( sprintf( __( 'Empty add-on plugin path for %s add-on' ), $this->banner_details['name'] ) );
 			}
 
 		} catch ( Exception $e ) {


### PR DESCRIPTION
Closes #2962 

## Description
 Figured out the issue with the build process

**Cause**:
`replace()` is a string function, the reason why the console says `replace()` is not a function is because it is being performed on an object.

Check this line no: [131](https://github.com/WordImpress/Give/blob/release/2.1/includes/admin/class-addon-activation-banner.php#L131) and line [136](https://github.com/WordImpress/Give/blob/release/2.1/includes/admin/class-addon-activation-banner.php#L136)

I don't think we should be translating it using `__()` because gettext won't be able to interpret what is inside the variable that is being passed.


## How Has This Been Tested?
Tested this manually

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.