### PR TITLE
fix(gutenberg): ensure Give Form Grid block can be inserted #2960

### DIFF
--- a/blocks/donation-form-grid/class-give-donation-form-grid-block.php
+++ b/blocks/donation-form-grid/class-give-donation-form-grid-block.php
@@ -127,7 +127,7 @@ class Give_Donation_form_Grid_Block {
 			'display_type'        => $attributes['displayType'],
 		);
 
-		return give_donation_grid_shortcode( $parameters );
+		return give_form_grid_shortcode( $parameters );
 	}
 }
 

--- a/includes/api/class-give-api-v2.php
+++ b/includes/api/class-give-api-v2.php
@@ -153,7 +153,7 @@ class Give_API_V2 {
 	public function get_donation_grid( $request ) {
 		$parameters = $request->get_params();
 
-		return give_donation_grid_shortcode( $parameters );
+		return give_form_grid_shortcode( $parameters );
 	}
 
 	/**


### PR DESCRIPTION
Closes #2960 

## Description
Corrected the name of the function from `give_donation_grid_shortcode` to `give_form_grid_shortcode`.

## How Has This Been Tested?
Manually tested by adding **Give Donation Form Grid** block.

## Screenshots (jpeg or gifs if applicable):
![donationgridblock](https://snag.gy/BznmUO.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.