### PR TITLE
fix(admin-tool): getting PHP notices when importing Give core Settings #2999

### DIFF
--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -139,7 +139,7 @@ function give_import_core_settings_merge_image_size( $json_to_array, $type ) {
 		if (
 			! empty( $json_to_array['form_featured_img'] )
 			&& ! empty( $json_to_array['featured_image_size'] )
-			&& 'enabled' === $json_to_array['form_featured_img']
+			&& give_is_setting_enabled( $json_to_array['form_featured_img'] )
 		) {
 			$images_sizes = get_intermediate_image_sizes();
 

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -136,13 +136,7 @@ add_filter( 'give_import_core_settings_data', 'give_import_core_settings_merge_p
 function give_import_core_settings_merge_image_size( $json_to_array, $type ) {
 	if ( 'merge' === $type ) {
 		// Featured image sizes import under Display Options > Post Types > Featured Image Size.
-		if (
-			! empty( $json_to_array['form_featured_img'] )
-			&&
-			! empty( $json_to_array['featured_image_size'] )
-			&&
-			'enabled' === $json_to_array['form_featured_img']
-		) {
+		if ( ! empty( $json_to_array['form_featured_img'] ) && ! empty( $json_to_array['featured_image_size'] ) && 'enabled' === $json_to_array['form_featured_img'] ) {
 			$images_sizes = get_intermediate_image_sizes();
 
 			if ( ! in_array( $json_to_array['featured_image_size'], $images_sizes ) ) {

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -136,7 +136,13 @@ add_filter( 'give_import_core_settings_data', 'give_import_core_settings_merge_p
 function give_import_core_settings_merge_image_size( $json_to_array, $type ) {
 	if ( 'merge' === $type ) {
 		// Featured image sizes import under Display Options > Post Types > Featured Image Size.
-		if ( 'enabled' === $json_to_array['form_featured_img'] ) {
+		if (
+			! empty( $json_to_array['form_featured_img'] )
+			&&
+			! empty( $json_to_array['featured_image_size'] )
+			&&
+			'enabled' === $json_to_array['form_featured_img']
+		) {
 			$images_sizes = get_intermediate_image_sizes();
 
 			if ( ! in_array( $json_to_array['featured_image_size'], $images_sizes ) ) {

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -136,7 +136,11 @@ add_filter( 'give_import_core_settings_data', 'give_import_core_settings_merge_p
 function give_import_core_settings_merge_image_size( $json_to_array, $type ) {
 	if ( 'merge' === $type ) {
 		// Featured image sizes import under Display Options > Post Types > Featured Image Size.
-		if ( ! empty( $json_to_array['form_featured_img'] ) && ! empty( $json_to_array['featured_image_size'] ) && 'enabled' === $json_to_array['form_featured_img'] ) {
+		if (
+			! empty( $json_to_array['form_featured_img'] )
+			&& ! empty( $json_to_array['featured_image_size'] )
+			&& 'enabled' === $json_to_array['form_featured_img']
+		) {
 			$images_sizes = get_intermediate_image_sizes();
 
 			if ( ! in_array( $json_to_array['featured_image_size'], $images_sizes ) ) {


### PR DESCRIPTION
## Description
PR to fix #2999 

## How Has This Been Tested?
Manually tested by importing Core Setting on fresh instances 


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.