### PR TITLE
fix(form): getting js error when get back to page with form grid shortcode #3019

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -109,7 +109,11 @@ jQuery( function( $ ) {
 		var historyTraversal = event.persisted || ( typeof 'undefined' !== window.performance && 2 === window.performance.navigation.type );
 
 		if ( historyTraversal ) {
-			$( 'body' ).find( 'form.give-form' )[0].reset();
+			let form = $( 'body' ).find( 'form.give-form' )[0];
+
+			if ( undefined !== form ) {
+				form.reset();
+			}
 		}
 	});
 });


### PR DESCRIPTION
Closes #3019 

## Description
Checks if the variable is undefined before resetting the form

## How Has This Been Tested?
This has been tested manually.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.