### PR TITLE
feat(form): allow forms to be queried based on close status #2250

### DIFF
--- a/assets/src/css/admin/goals.scss
+++ b/assets/src/css/admin/goals.scss
@@ -4,7 +4,7 @@
   background: #EEE;
   border-radius: 25px;
   overflow: hidden;
-  margin: 5px 0 0;
+  margin: 5px 0 2px;
 
   > span {
 	display: block;

--- a/assets/src/css/admin/goals.scss
+++ b/assets/src/css/admin/goals.scss
@@ -1,32 +1,31 @@
-td.column-goal {
-  .give-progress-bar {
-	height: 8px;
+.give-admin-progress-bar {
+  height: 8px;
+  position: relative;
+  background: #EEE;
+  border-radius: 25px;
+  overflow: hidden;
+  margin: 5px 0 0;
+
+  > span {
+	display: block;
+	height: 100%;
+	border-top-right-radius: 8px;
+	border-bottom-right-radius: 8px;
+	border-top-left-radius: 20px;
+	border-bottom-left-radius: 20px;
+	background-color: rgb(43, 194, 83);
 	position: relative;
-	background: #EEE;
-	border-radius: 25px;
 	overflow: hidden;
-	margin: 5px 0 0;
-
-	> span {
-	  display: block;
-	  height: 100%;
-	  border-top-right-radius: 8px;
-	  border-bottom-right-radius: 8px;
-	  border-top-left-radius: 20px;
-	  border-bottom-left-radius: 20px;
-	  background-color: rgb(43, 194, 83);
-	  position: relative;
-	  overflow: hidden;
-	}
-  }
-
-  .goal-achieved {
-	> .dashicons {
-	  color: $orange;
-	  font-size: 13px;
-	  height: 16px;
-	  width: 13px;
-	  line-height: 18px;
-	}
   }
 }
+
+.give-admin-goal-achieved {
+  > .dashicons {
+	color: $orange;
+	font-size: 13px;
+	height: 16px;
+	width: 13px;
+	line-height: 18px;
+  }
+}
+

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -582,14 +582,17 @@ class Give_MetaBox_Form_Data {
 			'high'
 		);
 
-		add_meta_box(
-			'give-form-goal-stats',
-			__( 'Goal Statistics', 'give' ),
-			array( $this, 'output_goal' ),
-			array( 'give_forms' ),
-			'side',
-			'high'
-		);
+		// Show Goal Metabox only if goal is enabled.
+		if ( give_is_setting_enabled( give_get_meta( give_get_admin_post_id(), '_give_goal_option', true ) ) ) {
+			add_meta_box(
+				'give-form-goal-stats',
+				__( 'Goal Statistics', 'give' ),
+				array( $this, 'output_goal' ),
+				array( 'give_forms' ),
+				'side',
+				'high'
+			);
+		}
 
 	}
 

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -926,7 +926,7 @@ class Give_MetaBox_Form_Data {
 						}
 
 						// Verify and delete form meta based on the form status.
-						give_verify_form_status( $post_id );
+						give_set_form_closed_status( $post_id );
 
 						// Fire after saving form meta key.
 						do_action( "give_save_{$form_meta_key}", $form_meta_key, $form_meta_value, $post_id, $post );

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -581,6 +581,16 @@ class Give_MetaBox_Form_Data {
 			'normal',
 			'high'
 		);
+
+		add_meta_box(
+			'give-form-goal-stats',
+			__( 'Goal Statistics', 'give' ),
+			array( $this, 'output_goal' ),
+			array( 'give_forms' ),
+			'side',
+			'high'
+		);
+
 	}
 
 
@@ -751,6 +761,21 @@ class Give_MetaBox_Form_Data {
 		endif; // End if().
 	}
 
+	/**
+	 * Output Goal meta-box settings.
+	 *
+	 * @param object $post Post Object.
+	 *
+	 * @access public
+	 * @since  2.1.0
+	 *
+	 * @return void
+	 */
+	public function output_goal( $post ) {
+
+		echo give_admin_form_goal_stats( $post->ID );
+
+	}
 
 	/**
 	 * Check if setting field has sub tabs/fields

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -590,7 +590,7 @@ class Give_MetaBox_Form_Data {
 				array( $this, 'output_goal' ),
 				array( 'give_forms' ),
 				'side',
-				'high'
+				'low'
 			);
 		}
 

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -925,6 +925,9 @@ class Give_MetaBox_Form_Data {
 							give_update_meta( $post_id, $form_meta_key, $form_meta_value );
 						}
 
+						// Verify and delete form meta based on the form status.
+						give_verify_form_status( $post_id );
+
 						// Fire after saving form meta key.
 						do_action( "give_save_{$form_meta_key}", $form_meta_key, $form_meta_value, $post_id, $post );
 					}// End if().

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -87,33 +87,10 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'goal':
 				if ( give_is_setting_enabled( give_get_meta( $post_id, '_give_goal_option', true ) ) ) {
 
-					$goal_stats       = give_goal_progress_stats( $post_id );
-					$percent_complete = round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100;
-					$html             = '';
-
-					$html .= sprintf(
-						( 'percentage' !== $goal_stats['format'] ) ?
-							'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s</div>' :
-							'<div class="give-goal-text"><a href="%3$s">%1$s</a></div>',
-						( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
-						( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
-						esc_url( admin_url( "post.php?post={$post_id}&action=edit&give_tab=donation_goal_options" ) ),
-						$goal_stats['goal'],
-						( 'donors' === $goal_stats['format'] ? __( 'Donors', 'give' ) : ( 'donation' === $goal_stats['format'] ? __( 'Donations', 'give' ) : '' ) )
-					);
-
-					if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
-						$html .= sprintf( '<span class="goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>', __( 'Goal achieved', 'give' ) );
-					} else {
-						$html .= sprintf( '<div class="give-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%s">', esc_attr( $goal_stats['progress'] ) );
-						$html .= sprintf( '<span style="width:%s%%;"></span>', esc_attr( $goal_stats['progress'] ) );
-						$html .= '</div>';
-					}
-					// Output HTML from above.
-					echo $html;
+					echo give_admin_form_goal_stats( $post_id );
 
 				} else {
-					esc_html_e( 'No Goal Set', 'give' );
+					_e( 'No Goal Set', 'give' );
 				}
 
 				printf(

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2618,7 +2618,11 @@ function give_v203_upgrades() {
 
 }
 
-
+/**
+ * Upgrade routine for 2.1 to set form closed status for all the donation forms.
+ *
+ * @since 2.1
+ */
 function give_v210_verify_form_status_upgrades_callback() {
 
 	$give_updates = Give_Updates::get_instance();

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2644,7 +2644,10 @@ function give_v210_verify_form_status_upgrades_callback() {
 			$donation_forms->the_post();
 			$form_id = get_the_ID();
 
-			give_verify_form_status( $form_id );
+			$form_closed_status = give_get_meta( $form_id, '_give_form_status', true );
+			if ( empty( $form_closed_status ) ) {
+				give_verify_form_status( $form_id );
+			}
 		}
 
 		/* Restore original Post Data */

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2646,7 +2646,7 @@ function give_v210_verify_form_status_upgrades_callback() {
 
 			$form_closed_status = give_get_meta( $form_id, '_give_form_status', true );
 			if ( empty( $form_closed_status ) ) {
-				give_verify_form_status( $form_id );
+				give_set_form_closed_status( $form_id );
 			}
 		}
 

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -1117,8 +1117,12 @@ class Give_Donate_Form {
 	 */
 	public function is_close_donation_form() {
 
-		// Check for backward compatibility.
-		$this->bc_210_is_close_donation_form();
+		// If manual upgrade not completed, proceed with backward compatible code.
+		if ( ! give_has_upgrade_completed( 'v210_verify_form_status_upgrades' ) ) {
+
+			// Check for backward compatibility.
+			return $this->bc_210_is_close_donation_form();
+		}
 
 		/**
 		 * Filter the close form result.
@@ -1169,45 +1173,41 @@ class Give_Donate_Form {
 	 */
 	private function bc_210_is_close_donation_form() {
 
-		// If manual upgrade not completed, proceed with backward compatible code.
-		if ( ! give_has_upgrade_completed( 'v210_verify_form_status_upgrades' ) ) {
+		$close_form      = false;
+		$is_goal_enabled = give_is_setting_enabled( give_get_meta( $this->ID, '_give_goal_option', true, 'disabled' ) );
 
-			$close_form      = false;
-			$is_goal_enabled = give_is_setting_enabled( give_get_meta( $this->ID, '_give_goal_option', true, 'disabled' ) );
+		// Proceed, if the form goal is enabled.
+		if ( $is_goal_enabled ) {
 
-			// Proceed, if the form goal is enabled.
-			if ( $is_goal_enabled ) {
+			$close_form_when_goal_achieved = give_is_setting_enabled( give_get_meta( $this->ID, '_give_close_form_when_goal_achieved', true, 'disabled' ) );
 
-				$close_form_when_goal_achieved = give_is_setting_enabled( give_get_meta( $this->ID, '_give_close_form_when_goal_achieved', true, 'disabled' ) );
+			// Proceed, if close form when goal achieved option is enabled.
+			if ( $close_form_when_goal_achieved ) {
 
-				// Proceed, if close form when goal achieved option is enabled.
-				if ( $close_form_when_goal_achieved ) {
+				$form        = new Give_Donate_Form( $this->ID );
+				$goal_format = give_get_form_goal_format( $this->ID );
 
-					$form        = new Give_Donate_Form( $this->ID );
-					$goal_format = give_get_form_goal_format( $this->ID );
-
-					// Verify whether the form is closed or not after processing data based on goal format.
-					switch ( $goal_format ) {
-						case 'donation':
-							$closed = $form->get_goal() <= $form->get_sales();
-							break;
-						case 'donors':
-							$closed = $form->get_goal() <= give_get_form_donor_count( $this->ID );
-							break;
-						default :
-							$closed = $form->get_goal() <= $form->get_earnings();
-							break;
-					}
-
-					if ( $closed ) {
-						$close_form = true;
-					}
-
+				// Verify whether the form is closed or not after processing data based on goal format.
+				switch ( $goal_format ) {
+					case 'donation':
+						$closed = $form->get_goal() <= $form->get_sales();
+						break;
+					case 'donors':
+						$closed = $form->get_goal() <= give_get_form_donor_count( $this->ID );
+						break;
+					default :
+						$closed = $form->get_goal() <= $form->get_earnings();
+						break;
 				}
-			}
 
-			return $close_form;
+				if ( $closed ) {
+					$close_form = true;
+				}
+
+			}
 		}
+
+		return $close_form;
 	}
 
 }

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -1116,12 +1116,13 @@ class Give_Donate_Form {
 	 * @return bool
 	 */
 	public function is_close_donation_form() {
+		$is_closed = ( 'closed' === give_get_meta( $this->ID, '_give_form_status', true, 'open' ) );
 
 		// If manual upgrade not completed, proceed with backward compatible code.
 		if ( ! give_has_upgrade_completed( 'v210_verify_form_status_upgrades' ) ) {
 
 			// Check for backward compatibility.
-			return $this->bc_210_is_close_donation_form();
+			$is_closed = $this->bc_210_is_close_donation_form();
 		}
 
 		/**
@@ -1131,7 +1132,8 @@ class Give_Donate_Form {
 		 */
 		return apply_filters(
 			'give_is_close_donation_form',
-			( 'closed' === give_get_meta( $this->ID, '_give_form_status', true, 'open' ) )
+			$is_closed,
+			$this
 		);
 
 	}

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -1117,36 +1117,15 @@ class Give_Donate_Form {
 	 */
 	public function is_close_donation_form() {
 
-		$goal_format = give_get_form_goal_format( $this->ID );
-
-		switch ( $goal_format ) {
-			case  'donation':
-				$closed = $this->get_goal() <= $this->get_sales();
-				break;
-			case 'donors':
-				$closed = $this->get_goal() <= give_get_form_donor_count( $this->ID );
-				break;
-			default :
-				$closed = $this->get_goal() <= $this->get_earnings();
-				break;
-		}
-
 		/**
 		 * Filter the close form result.
 		 *
 		 * @since 1.8
 		 */
-		$is_close_form = apply_filters(
+		return apply_filters(
 			'give_is_close_donation_form',
-			(
-				give_is_setting_enabled( give_get_meta( $this->ID, '_give_goal_option', true ) )
-				&& give_is_setting_enabled( give_get_meta( $this->ID, '_give_close_form_when_goal_achieved', true ) )
-				&& $closed
-			),
-			$this->ID
+			( 'closed' === give_get_meta( $this->ID, '_give_form_status', true ) )
 		);
-
-		return $is_close_form;
 
 	}
 

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -1124,7 +1124,7 @@ class Give_Donate_Form {
 		 */
 		return apply_filters(
 			'give_is_close_donation_form',
-			( 'closed' === give_get_meta( $this->ID, '_give_form_status', true ) )
+			( 'closed' === give_get_meta( $this->ID, '_give_form_status', true, 'open' ) )
 		);
 
 	}

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1240,6 +1240,7 @@ function give_verify_form_status( $form_id ) {
 		return;
 	}
 
+	$open_form       = false;
 	$is_goal_enabled = give_is_setting_enabled( give_get_meta( $form_id, '_give_goal_option', true, 'disabled' ) );
 
 	// Proceed, if the form goal is enabled.
@@ -1270,8 +1271,17 @@ function give_verify_form_status( $form_id ) {
 			if ( $closed ) {
 				give_update_meta( $form_id, '_give_form_status', 'closed' );
 			} else {
-				give_update_meta( $form_id, '_give_form_status', 'open' );
+				$open_form = true;
 			}
+		} else {
+			$open_form = true;
 		}
+	} else {
+		$open_form = true;
+	}
+
+	// If $open_form is true, then update form status to open.
+	if ( $open_form ) {
+		give_update_meta( $form_id, '_give_form_status', 'open' );
 	}
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1285,3 +1285,40 @@ function give_set_form_closed_status( $form_id ) {
 		give_update_meta( $form_id, '_give_form_status', 'open' );
 	}
 }
+
+/**
+ * Show Form Goal Stats in Admin ( Listing and Detail page )
+ *
+ * @param int $form_id Form ID.
+ *
+ * @since 2.1.0
+ *
+ * @return string
+ */
+function give_admin_form_goal_stats( $form_id ) {
+
+	$goal_stats       = give_goal_progress_stats( $form_id );
+	$percent_complete = round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100;
+	$html             = '';
+
+	$html .= sprintf(
+		( 'percentage' !== $goal_stats['format'] ) ?
+			'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s</div>' :
+			'<div class="give-goal-text"><a href="%3$s">%1$s</a></div>',
+		( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
+		( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
+		esc_url( admin_url( "post.php?post={$form_id}&action=edit&give_tab=donation_goal_options" ) ),
+		$goal_stats['goal'],
+		( 'donors' === $goal_stats['format'] ? __( 'Donors', 'give' ) : ( 'donation' === $goal_stats['format'] ? __( 'Donations', 'give' ) : '' ) )
+	);
+
+	if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
+		$html .= sprintf( '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>', __( 'Goal achieved', 'give' ) );
+	} else {
+		$html .= sprintf( '<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%s">', esc_attr( $goal_stats['progress'] ) );
+		$html .= sprintf( '<span style="width:%s%%;"></span>', esc_attr( $goal_stats['progress'] ) );
+		$html .= '</div>';
+	}
+
+	return $html;
+}

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1297,14 +1297,21 @@ function give_set_form_closed_status( $form_id ) {
  */
 function give_admin_form_goal_stats( $form_id ) {
 
+	$html             = '';
 	$goal_stats       = give_goal_progress_stats( $form_id );
 	$percent_complete = round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100;
-	$html             = '';
+
+	$html .= sprintf(
+		'<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">
+<span style="width:%1$s%%;"></span>
+</div>',
+		esc_attr( $goal_stats['progress'] )
+	);
 
 	$html .= sprintf(
 		( 'percentage' !== $goal_stats['format'] ) ?
-			'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s</div>' :
-			'<div class="give-goal-text"><a href="%3$s">%1$s</a></div>',
+			'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s ' :
+			'<div class="give-goal-text"><a href="%3$s">%1$s </a>',
 		( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
 		( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
 		esc_url( admin_url( "post.php?post={$form_id}&action=edit&give_tab=donation_goal_options" ) ),
@@ -1314,11 +1321,10 @@ function give_admin_form_goal_stats( $form_id ) {
 
 	if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
 		$html .= sprintf( '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>', __( 'Goal achieved', 'give' ) );
-	} else {
-		$html .= sprintf( '<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%s">', esc_attr( $goal_stats['progress'] ) );
-		$html .= sprintf( '<span style="width:%s%%;"></span>', esc_attr( $goal_stats['progress'] ) );
-		$html .= '</div>';
 	}
+
+	$html .= '</div>';
+
 
 	return $html;
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1233,7 +1233,7 @@ function give_get_form_donor_count( $form_id, $args = array() ) {
  *
  * @return void
  */
-function give_verify_form_status( $form_id ) {
+function give_set_form_closed_status( $form_id ) {
 
 	// Bailout.
 	if ( empty( $form_id ) ) {

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -993,7 +993,7 @@ final class Give_Payment {
 				}
 
 				// Verify and update form meta based on the form status.
-				give_verify_form_status( $this->form_id );
+				give_set_form_closed_status( $this->form_id );
 
 			}
 

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -991,6 +991,10 @@ final class Give_Payment {
 					$donor->increase_purchase_count();
 
 				}
+
+				// Verify and update form meta based on the form status.
+				give_verify_form_status( $this->form_id );
+
 			}
 
 			$this->update_meta( '_give_payment_total', give_sanitize_amount_for_db( $this->total ) );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -744,6 +744,7 @@ function give_form_grid_shortcode( $atts ) {
 		'image_height'        => 'auto',
 		'excerpt_length'      => 16,
 		'display_style'       => 'redirect',
+		'status'              => '' // open or closed
 	), $atts );
 
 	// Validate integer attributes.
@@ -772,6 +773,16 @@ function give_form_grid_shortcode( $atts ) {
 			'relation' => 'AND',
 		),
 	);
+
+	// Filter results of form grid based on form status.
+	if ( ! empty( $atts['status'] ) ) {
+		$form_args['meta_query'] = array(
+			array(
+				'key'   => '_give_form_status',
+				'value' => $atts['status'],
+			),
+		);
+	}
 
 	// Maybe add pagination.
 	if ( true === $atts['paged'] ) {
@@ -813,42 +824,42 @@ function give_form_grid_shortcode( $atts ) {
 		add_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class', 10, 1 );
 
 		echo '<div class="give-wrap">';
-			echo '<div class="give-grid give-grid--' . esc_attr( $atts['columns'] ) . '">';
+		echo '<div class="give-grid give-grid--' . esc_attr( $atts['columns'] ) . '">';
 
-			while ( $form_query->have_posts() ) {
-				$form_query->the_post();
+		while ( $form_query->have_posts() ) {
+			$form_query->the_post();
 
-				// Give/templates/shortcode-form-grid.php.
-				give_get_template( 'shortcode-form-grid', array( $give_settings, $atts ) );
+			// Give/templates/shortcode-form-grid.php.
+			give_get_template( 'shortcode-form-grid', array( $give_settings, $atts ) );
 
-			}
+		}
 
-			wp_reset_postdata();
+		wp_reset_postdata();
 
-			echo '</div><!-- .give-grid -->';
+		echo '</div><!-- .give-grid -->';
 
-			remove_filter( 'add_give_goal_progress_class', 'add_give_goal_progress_class' );
-			remove_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class' );
+		remove_filter( 'add_give_goal_progress_class', 'add_give_goal_progress_class' );
+		remove_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class' );
 
-			if ( false !== $atts['paged'] ) {
-				$paginate_args = array(
-					'current'   => max( 1, get_query_var( 'paged' ) ),
-					'total'     => $form_query->max_num_pages,
-					'show_all'  => false,
-					'end_size'  => 1,
-					'mid_size'  => 2,
-					'prev_next' => true,
-					'prev_text' => __( '« Previous', 'give' ),
-					'next_text' => __( 'Next »', 'give' ),
-					'type'      => 'plain',
-					'add_args'  => false,
-				);
+		if ( false !== $atts['paged'] ) {
+			$paginate_args = array(
+				'current'   => max( 1, get_query_var( 'paged' ) ),
+				'total'     => $form_query->max_num_pages,
+				'show_all'  => false,
+				'end_size'  => 1,
+				'mid_size'  => 2,
+				'prev_next' => true,
+				'prev_text' => __( '« Previous', 'give' ),
+				'next_text' => __( 'Next »', 'give' ),
+				'type'      => 'plain',
+				'add_args'  => false,
+			);
 
-				printf(
-					'<div class="give-page-numbers">%s</div>',
-					paginate_links( $paginate_args )
-				);
-			}
+			printf(
+				'<div class="give-page-numbers">%s</div>',
+				paginate_links( $paginate_args )
+			);
+		}
 		echo '</div><!-- .give-wrap -->';
 
 		return ob_get_clean();

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -775,11 +775,12 @@ function give_form_grid_shortcode( $atts ) {
 	);
 
 	// Filter results of form grid based on form status.
-	if ( ! empty( $atts['status'] ) ) {
+	$form_closed_status = trim( $atts['status'] );
+	if ( ! empty( $form_closed_status ) ) {
 		$form_args['meta_query'] = array(
 			array(
 				'key'   => '_give_form_status',
-				'value' => $atts['status'],
+				'value' => $form_closed_status,
 			),
 		);
 	}

--- a/tests/unit-tests/tests-donate-form-class.php
+++ b/tests/unit-tests/tests-donate-form-class.php
@@ -146,6 +146,7 @@ class Tests_Donate_Form_Class extends Give_Unit_Test_Case {
 		// Default earning for form is 40.00, so set donation goal to less then earnings.
 		give_update_meta( $this->_simple_form->ID, '_give_set_goal', '30.00' );
 		give_update_meta( $this->_simple_form->ID, '_give_close_form_when_goal_achieved', 'enabled' );
+		give_update_meta( $this->_simple_form->ID, '_give_form_status', 'closed' );
 
 		$this->assertSame( 'give-form-wrap give-form-closed', $simple_form->get_form_wrap_classes( array() ) );
 	}


### PR DESCRIPTION
## Description
This PR resolves #2250 and resolves #3027

## How Has This Been Tested?
I've tested this PR with following scenarios:
- updated form meta to `closed` when form goal is achieved.
- updated form meta to `open` when form goal is updated with which goal is not achieved.
- tested form grid shortcode with `open` and `closed` status and without status

## Types of changes
New feature (a non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.