### PR TITLE
fix(donations): prevent nested loop from producing unexpected results

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -212,6 +212,8 @@ class Give_Payments_Query extends Give_Stats {
 	 * @return array
 	 */
 	public function get_payments() {
+		global $post;
+
 		$cache_key      = Give_Cache::get_key( 'give_payment_query', $this->args, false );
 		$this->payments = Give_Cache::get_db_query( $cache_key );
 
@@ -237,6 +239,8 @@ class Give_Payments_Query extends Give_Stats {
 		}
 
 		if ( $query->have_posts() ) {
+			$previous_post = $post;
+
 			while ( $query->have_posts() ) {
 				$query->the_post();
 
@@ -247,6 +251,12 @@ class Give_Payments_Query extends Give_Stats {
 			}
 
 			wp_reset_postdata();
+
+			// Prevent nest loop from producing unexpected results.
+			if( $previous_post instanceof WP_Post ) {
+				$post = $previous_post;
+				setup_postdata( $post );
+			}
 		}
 
 		Give_Cache::set_db_query( $cache_key, $this->payments );


### PR DESCRIPTION
## Description
Nest loop breaks parent loop by set unexpected post id. This is known issue in WP Core (https://core.trac.wordpress.org/ticket/18408).

The Form Grid shortcode breaks because Currency Switcher was using `Give_Payment_Query` which internally uses `WP_Query`. Since we have a lot of filters and action in the core, we cannot prevent users to use multiple loops but we can prevent breaking their parent loop if they are using `Give_Payment_Query`.

For Ref:
https://github.com/WordImpress/Give-Currency-Switcher/issues/100

## How Has This Been Tested?
Manually by reverting this https://github.com/WordImpress/Give-Currency-Switcher/issues/100 fix.

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.