### PR TITLE
refactor(admin-tool): reorder Admin tool tabs #3015

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -293,9 +293,14 @@ add_filter( 'give-reports_get_settings_pages', 'give_reports_page_pages', 0, 1 )
 function give_tools_page_pages( $settings ) {
 	include( 'abstract-admin-settings-page.php' );
 
+
 	$settings = array(
-		// System Info.
-		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-system-info.php' ),
+
+		// Export.
+		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-export.php' ),
+
+		// Import
+		include_once( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-import.php' ),
 
 		// Logs.
 		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-logs.php' ),
@@ -306,11 +311,8 @@ function give_tools_page_pages( $settings ) {
 		// Data.
 		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-data.php' ),
 
-		// Export.
-		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-export.php' ),
-
-		// Import
-		include_once( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-import.php' ),
+		// System Info.
+		include( GIVE_PLUGIN_DIR . 'includes/admin/tools/class-settings-system-info.php' ),
 	);
 
 	// Output.

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -326,7 +326,7 @@ add_filter( 'give-tools_get_settings_pages', 'give_tools_page_pages', 0, 1 );
  * @return string
  */
 function give_set_default_tab_form_tools_page( $default_tab ) {
-	return 'system-info';
+	return 'export';
 }
 add_filter( 'give_default_setting_tab_give-tools', 'give_set_default_tab_form_tools_page', 10, 1 );
 


### PR DESCRIPTION
## Description
PR to fix #3015 

## How Has This Been Tested?
Manual tested 

## Tasks 
- [x] Change the order of tab menu
- [x] Make export Page as a default page when admin click on the tools page menu

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/38785705-27ce5670-4140-11e8-8b73-c0d14777ae63.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.