### PR TITLE
fix(admin-form): max / min slider appears broken and field title needs updating #2963

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -151,7 +151,7 @@ class Give_MetaBox_Form_Data {
 						),
 					),
 					array(
-						'name'          => __( 'Max/Min. Amount', 'give' ),
+						'name'          => __( 'Min/Max. Amount', 'give' ),
 						'description'   => __( 'Set minimum and maximum amount limit.', 'give' ),
 						'id'            => $prefix . 'custom_amount_range',
 						'type'          => 'range_slider',


### PR DESCRIPTION
## Description
This PR resolves #2963 

## How Has This Been Tested?
I've tested that the field title is updated to `Min/Max. Amount`.

## Screenshots (jpeg or gifs if applicable):

**Before**
![image](https://user-images.githubusercontent.com/1852711/38788873-199c6ad8-4154-11e8-990f-425c3664805c.png)

**After**
![image](https://user-images.githubusercontent.com/1852711/38789300-160cf506-4157-11e8-9806-ea1312fe0f0b.png)

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.