### PR TITLE
fix(admin-tool): export donation history should have donation number #3043

### DIFF
--- a/includes/admin/tools/export/class-give-export-donations.php
+++ b/includes/admin/tools/export/class-give-export-donations.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'Give_Export_Donations' ) ) {
 											<label for="give-export-seq-id">
 												<input type="checkbox" checked
 												       name="give_give_donations_export_option[seq_id]"
-												       id="give-export-donation-id"><?php _e( 'Donation Number', 'give' ); ?>
+												       id="give-export-seq-id"><?php _e( 'Donation Number', 'give' ); ?>
 											</label>
 										</li>
 										<?php

--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -75,8 +75,6 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 		$this->start      = isset( $request['start'] ) ? sanitize_text_field( $request['start'] ) : '';
 		$this->end        = isset( $request['end'] ) ? sanitize_text_field( $request['end'] ) : '';
 		$this->status     = isset( $request['status'] ) ? sanitize_text_field( $request['status'] ) : 'complete';
-		$this->categories = isset( $request['give_forms_categories'] ) ? sanitize_text_field( $request['give_forms_categories'] ) : array();
-		$this->tags       = isset( $request['give_forms_tags'] ) ? sanitize_text_field( $request['give_forms_tags'] ) : array();
 	}
 
 	/**
@@ -117,6 +115,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 			switch ( $key ) {
 				case 'donation_id' :
 					$cols['donation_id'] = __( 'Donation ID', 'give' );
+					break;
 				case 'seq_id' :
 					$cols['seq_id'] = __( 'Donation Number', 'give' );
 					break;


### PR DESCRIPTION
## Description
PR to fix #3043 

## How Has This Been Tested?
Manually tested by enabling and disabling the **Sequential Ordering** and then exporting the donation 

## Task
- [x] `Disable` the **Sequential Ordering** and then export the donation and check for the Payment Number Columns that Columns should not exist
- [x] `Enable` the **Sequential Ordering** and then export the donation and check for the Payment Number Columns that Columns should not exist
- [x] Tested in fresh installation as well 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/38804480-23b9c74a-4190-11e8-91fd-047a4d2b33ec.png)

![image](https://user-images.githubusercontent.com/22215595/38804498-352b3e1e-4190-11e8-9e3a-a6e2af25358b.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.