### PR TITLE
fix(admin-tool): PHP notices on system info page

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -181,11 +181,17 @@ $give_updates = Give_Updates::get_instance();
 			<td class="help"><?php echo Give()->tooltips->render_help( __( 'Most payment gateway APIs only support connections using the TLS 1.2 security protocol.', 'give' ) ); ?></td>
 			<td>
 				<?php
-				$tls_check = wp_remote_post( 'https://www.howsmyssl.com/a/check' );
-				if ( ! is_wp_error( $tls_check ) ) {
-					$tls_check = json_decode( wp_remote_retrieve_body( $tls_check ) );
+				$tls_check = false;
+
+				// Get the SSL status.
+				if ( ini_get( 'allow_url_fopen' ) ) {
+					$tls_check = file_get_contents( 'https://www.howsmyssl.com/a/check' );
+				}
+
+				if ( false !== $tls_check ) {
+					$tls_check = json_decode( $tls_check );
 					/* translators: %s: SSL connection response */
-					printf( __('Connection uses %s', 'give'), esc_html( $tls_check->tls_version )) ;
+					printf( __( 'Connection uses %s', 'give' ), esc_html( $tls_check->tls_version ) );
 				}
 				?>
 			</td>
@@ -195,7 +201,7 @@ $give_updates = Give_Updates::get_instance();
 			<td class="help"><?php echo Give()->tooltips->render_help( __( 'The server\'s connection as rated by https://www.howsmyssl.com/', 'give' ) ); ?></td>
 			<td>
 				<?php
-				if ( ! is_wp_error( $tls_check ) ) {
+				if ( false !== $tls_check ) {
 					esc_html_e( property_exists( $tls_check, 'rating' ) ? $tls_check->rating : $tls_check->tls_version );
 				}
 				?>


### PR DESCRIPTION
## Description
This PR fix #2998 

Fixed old SSL check API instead of integrating new API, please review the changes and let me know.

Note: `wp_remote_get` and `wp_remote_post` both fn returns error in their response. 

## How Has This Been Tested?
- Manually.

## Screenshots (jpeg or gifs if applicable):
![screenshot-givecs local-2018 04 17-18-18-38](https://user-images.githubusercontent.com/14994452/38870556-c6c20584-426b-11e8-902b-e6dcf0b3fb06.png)

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.