### PR TITLE
fix(admin-form): hide donor option if goal is disabled.

### DIFF
--- a/assets/src/js/admin/admin-forms.js
+++ b/assets/src/js/admin/admin-forms.js
@@ -113,6 +113,7 @@ jQuery.noConflict();
 
 		//Goals
 		var goal_option = $( '._give_goal_option_field' );
+		var goal_format = $( '._give_goal_format_field input:radio' );
 		//Close Form when Goal Achieved
 		var close_form_when_goal_achieved_option = $( '._give_close_form_when_goal_achieved_field input:radio' );
 
@@ -135,6 +136,7 @@ jQuery.noConflict();
 				$( '._give_close_form_when_goal_achieved_field' ).hide();
 				$( '._give_form_goal_achieved_message_field' ).hide();
 				$( '._give_number_of_donation_goal_field' ).hide();
+				$( '._give_number_of_donor_goal_field' ).hide();
 			} else {
 				$( '._give_set_goal_field' ).show();
 				$( '._give_goal_format_field' ).show();
@@ -147,20 +149,25 @@ jQuery.noConflict();
 					$( '._give_form_goal_achieved_message_field' ).show();
 				}
 
+				// Trigger goal format option.
+				goal_format.change();
 			}
 		} ).change();
 
-		var goal_format = $( '._give_goal_format_field input:radio' );
 		goal_format.on( 'change', function() {
 			var goal_format_val = $( '._give_goal_format_field input:radio:checked' ).val();
 			var goal_option_val = $( '._give_goal_option_field input:radio:checked' ).val();
 
 			if ( 'donation' === goal_format_val ) {
-				$( '._give_set_goal_field, ._give_number_of_donor_goal_field' ).hide();
-				$( '._give_number_of_donation_goal_field' ).show();
+				$( '._give_set_goal_field, ._give_number_of_donor_goal_field,._give_number_of_donation_goal_field' ).hide();
+				if( 'disabled' !== goal_option_val ) {
+					$( '._give_number_of_donation_goal_field' ).show()
+				}
 			} else if ( 'donors' === goal_format_val ) {
-				$( '._give_set_goal_field, ._give_number_of_donation_goal_field' ).hide();
-				$( '._give_number_of_donor_goal_field' ).show();
+				$( '._give_set_goal_field, ._give_number_of_donation_goal_field, ._give_number_of_donor_goal_field' ).hide();
+				if ( 'disabled' !== goal_option_val ) {
+					$( '._give_number_of_donor_goal_field' ).show();
+				}
 			} else {
 				('disabled' === goal_option_val) ? $( '._give_set_goal_field' ).hide() : $( '._give_set_goal_field' ).show();
 				$( '._give_number_of_donation_goal_field, ._give_number_of_donor_goal_field' ).hide();


### PR DESCRIPTION
## Description
This PR fix #3068 

## How Has This Been Tested?
- Tested it by saving different-different Goal Format.
- Enabling/Disabling Goal for the donation form.

## Screenshots (jpeg or gifs if applicable):
![ezgif-5-3e2c5ba382](https://user-images.githubusercontent.com/14994452/39033096-09641cc8-448e-11e8-941e-b97075ae8578.gif)

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.