### PR TITLE
fix(admin-settings): load default company field settings on fresh install #3079

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -332,6 +332,7 @@ function give_get_default_settings() {
 		'css'                                         => 'enabled',
 		'floatlabels'                                 => 'disabled',
 		'welcome'                                     => 'enabled',
+		'company_field'                               => 'disabled',
 		'forms_singular'                              => 'enabled',
 		'forms_archives'                              => 'enabled',
 		'forms_excerpt'                               => 'enabled',


### PR DESCRIPTION
## Description
This PR resolves #3079 

## How Has This Been Tested?
I've tested this PR with the fresh install and confirmed the default settings by checking the DB.

## Types of changes
Bug fix (a non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.