### PR TITLE
Fixing phpcs errors and warnings for abstract admin settings page.

### DIFF
--- a/includes/admin/abstract-admin-settings-page.php
+++ b/includes/admin/abstract-admin-settings-page.php
@@ -181,8 +181,8 @@ if ( ! class_exists( 'Give_Settings_Page' ) ) :
 			}
 
 			// Show section settings only if setting section exist.
-			if ( $current_section && ! in_array( $current_section, array_keys( $sections ) ) ) {
-				echo '<div class="error"><p>' . __( 'Oops, this settings page does not exist.', 'give' ) . '</p></div>';
+			if ( $current_section && ! in_array( $current_section, array_keys( $sections ), true ) ) {
+				echo wp_kses_post( '<div class="error"><p>' . __( 'Oops, this settings page does not exist.', 'give' ) . '</p></div>' );
 				$GLOBALS['give_hide_save_button'] = true;
 
 				return;
@@ -203,13 +203,13 @@ if ( ! class_exists( 'Give_Settings_Page' ) ) :
 					continue;
 				}
 
-				$section_list[] = '<li><a href="' . admin_url( 'edit.php?post_type=give_forms&page=' . $this->current_setting_page . '&tab=' . $this->id . '&section=' . sanitize_title( $id ) ) . '" class="' . ( $current_section == $id ? 'current' : '' ) . '">' . $label . '</a>';
+				$section_list[] = '<li><a href="' . admin_url( 'edit.php?post_type=give_forms&page=' . $this->current_setting_page . '&tab=' . $this->id . '&section=' . sanitize_title( $id ) ) . '" class="' . ( $current_section === $id ? 'current' : '' ) . '">' . $label . '</a>';
 			}
 
-			echo sprintf(
+			echo wp_kses_post( sprintf(
 				'<ul class="subsubsub">%s</ul><br class="clear" /><hr>',
 				implode( ' | </li>', $section_list )
-			);
+			) );
 		}
 
 		/**


### PR DESCRIPTION
## Description
- Fixing usage of `in_array` to use strict comparison with true for third arg.
- Wrapped output in `wp_kses_post` to sanitize HTML being delivered to user.
- Fixed comparison using (==) and changed to strict comparison (===).

### PHPCS WordPress-VIP Code Standard Output:
```
FILE: ./content/plugins/give/includes/admin/abstract-admin-settings-page.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AND 2 WARNINGS AFFECTING 5 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   1 | ERROR   | Class file names should be based on the class name with "class-" prepended. Expected class-give-settings-page.php, but found abstract-admin-settings-page.php.
 184 | WARNING | Not using strict comparison for in_array; supply true for third argument.
 185 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'.
 206 | WARNING | Found: ==. Use strict comparisons (=== or !==).
 211 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$section_list'.
```

## How Has This Been Tested?
Manually ran the same HTML through `wp_kses_post()` to ensure the output still generates as expected.

## Types of changes
PHPCS Fixes to better pass WordPress-VIP Code Standards.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.