### PR TITLE
Phpcs add-ons.php

### DIFF
--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -23,9 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function give_add_ons_page() {
-	ob_start(); ?>
+	?>
 	<div class="wrap" id="give-add-ons">
-		<h1><?php echo get_admin_page_title(); ?>
+		<h1><?php echo esc_html( get_admin_page_title() ); ?>
 			&nbsp;&mdash;&nbsp;<a href="https://givewp.com/addons/" class="button-primary give-view-addons-all" target="_blank"><?php esc_html_e( 'View All Add-ons', 'give' ); ?>
 				<span class="dashicons dashicons-external"></span></a>
 		</h1>
@@ -33,26 +33,25 @@ function give_add_ons_page() {
 		<hr class="wp-header-end">
 
 		<p><?php esc_html_e( 'The following Add-ons extend the functionality of Give.', 'give' ); ?></p>
-		<?php echo give_add_ons_get_feed(); ?>
+		<?php give_add_ons_feed(); ?>
 	</div>
 	<?php
-	echo ob_get_clean();
 }
 
 /**
- * Add-ons Get Feed
+ * Add-ons Render Feed
  *
- * Gets the add-ons page feed.
+ * Renders the add-ons page feed.
  *
  * @since 1.0
- * @return string $cache
+ * @return void
  */
-function give_add_ons_get_feed() {
+function give_add_ons_feed() {
 
 	$addons_debug = false; //set to true to debug
 	$cache        = Give_Cache::get( 'give_add_ons_feed', true );
 
-	if ( $cache === false || $addons_debug === true && WP_DEBUG === true ) {
+	if ( false === $cache || ( true === $addons_debug && true === WP_DEBUG ) ) {
 		$feed = wp_remote_get( 'https://givewp.com/downloads/feed/', array( 'sslverify' => false ) );
 
 		if ( ! is_wp_error( $feed ) ) {
@@ -68,6 +67,5 @@ function give_add_ons_get_feed() {
 		}
 	}
 
-	return $cache;
-
+	echo wp_kses_post( $cache );
 }

--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -52,9 +52,13 @@ function give_add_ons_feed() {
 	$cache        = Give_Cache::get( 'give_add_ons_feed', true );
 
 	if ( false === $cache || ( true === $addons_debug && true === WP_DEBUG ) ) {
-		$feed = wp_remote_get( 'https://givewp.com/downloads/feed/', array( 'sslverify' => false ) );
+		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
+			$feed = vip_safe_wp_remote_get( 'https://givewp.com/downloads/feed/', false, 3, 1, 20, array( 'sslverify' => false ) );
+		} else {
+			$feed = wp_remote_get( 'https://givewp.com/downloads/feed/', array( 'sslverify' => false ) );
+		}
 
-		if ( ! is_wp_error( $feed ) ) {
+		if ( ! is_wp_error( $feed ) && ! empty( $feed ) ) {
 			if ( isset( $feed['body'] ) && strlen( $feed['body'] ) > 0 ) {
 				$cache = wp_remote_retrieve_body( $feed );
 				Give_Cache::set( 'give_add_ons_feed', $cache, HOUR_IN_SECONDS, true );


### PR DESCRIPTION
## Description
- Wrapped output in `wp_kses_post()` and `esc_html` where appropriate to sanitize HTML being delivered to user.
- Changing condition checks to be yoda conditionals
- Adding functionality to run `vip_safe_wp_remote_get()` if the function exists.

### PHPCS WordPress-VIP Code Standard Output
```
FILE: ./content/plugins/give/includes/admin/add-ons.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 6 ERRORS AND 1 WARNING AFFECTING 6 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 28 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'get_admin_page_title'.
 36 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'give_add_ons_get_feed'.
 39 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'ob_get_clean'.
 55 | ERROR   | [ ] Use Yoda Condition checks, you must.
 55 | ERROR   | [ ] Use Yoda Condition checks, you must.
 56 | WARNING | [ ] wp_remote_get() is highly discouraged, please use vip_safe_wp_remote_get() instead.
 73 | ERROR   | [x] File must end with a newline character
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## How Has This Been Tested?
Manually ran the same HTML through `wp_kses_post()` to ensure the output still generates as expected. Implemented `vip_safe_wp_remote_get()` in local  filesystem to test expected output.

## Types of changes
PHPCS Fixes to better pass WordPress-VIP Code Standards.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.