### PR TITLE
Fixing escaping in tools-delete-test-donors functionality.

### DIFF
--- a/includes/admin/tools/data/class-give-tools-delete-test-donors.php
+++ b/includes/admin/tools/data/class-give-tools-delete-test-donors.php
@@ -234,7 +234,11 @@ class Give_Tools_Delete_Donors extends Give_Batch_Export {
 	public function process_step() {
 
 		if ( ! $this->can_export() ) {
-			wp_die( __( 'You do not have permission to delete test transactions.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+			wp_die(
+				esc_html__( 'You do not have permission to delete test transactions.', 'give' ),
+				esc_html__( 'Error', 'give' ),
+				array( 'response' => 403 )
+			);
 		}
 
 		$had_data = $this->get_data();
@@ -296,7 +300,6 @@ class Give_Tools_Delete_Donors extends Give_Batch_Export {
 			$this->total_step     = ( ( count( $donation_ids ) / $this->per_step ) * 2 ) + count( $donor_ids );
 			$this->step_completed = $page;
 
-
 			if ( $count > $this->per_step ) {
 
 				$this->update_option( $this->step_on_key, $page );
@@ -321,7 +324,6 @@ class Give_Tools_Delete_Donors extends Give_Batch_Export {
 			}
 			do_action( 'give_delete_log_cache' );
 		}
-
 
 		// Here we delete all the donor
 		if ( 3 === $step ) {


### PR DESCRIPTION
## Description
Adding escaping to output for `wp_die()`.

### PHPCS WordPress-VIP Code Standard Output Before

```
FILE: ./content/plugins/give/includes/admin/tools/data/class-give-tools-delete-test-donors.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AND 5 WARNINGS AFFECTING 9 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   1 | ERROR   | [ ] Class file names should be based on the class name with "class-" prepended. Expected class-give-tools-delete-donors.php, but found
     |         |     class-give-tools-delete-test-donors.php.
 173 | WARNING | [ ] Detected usage of meta_key, possible slow query.
 174 | WARNING | [ ] Detected usage of meta_value, possible slow query.
 237 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'.
 237 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'.
 298 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines
 324 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines
 338 | WARNING | [ ] Detected usage of meta_key, possible slow query.
 339 | WARNING | [ ] Detected usage of meta_value, possible slow query.
 343 | WARNING | [ ] get_posts() is discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query, unless you explicitly supply
     |         |     suppress_filters => false.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
### PHPCS WordPress-VIP Code Standard Output After Fixes

```
FILE: ./content/plugins/give/includes/admin/tools/data/class-give-tools-delete-test-donors.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 5 WARNINGS AFFECTING 6 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   1 | ERROR   | Class file names should be based on the class name with "class-" prepended. Expected class-give-tools-delete-donors.php, but found
     |         | class-give-tools-delete-test-donors.php.
 173 | WARNING | Detected usage of meta_key, possible slow query.
 174 | WARNING | Detected usage of meta_value, possible slow query.
 340 | WARNING | Detected usage of meta_key, possible slow query.
 341 | WARNING | Detected usage of meta_value, possible slow query.
 345 | WARNING | get_posts() is discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query, unless you explicitly supply suppress_filters =>
     |         | false.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## Types of changes
Simple escaping of content.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.