### PR TITLE
Fixing escaping and adding wp_unslash to the give_clean function

### DIFF
--- a/includes/admin/tools/export/class-core-settings-export.php
+++ b/includes/admin/tools/export/class-core-settings-export.php
@@ -76,7 +76,11 @@ class Give_Core_Settings_Export extends Give_Export {
 	 */
 	public function export() {
 		if ( ! $this->can_export() ) {
-			wp_die( __( 'You do not have permission to export data.', 'give' ), __( 'Error', 'give' ), array( 'response' => 403 ) );
+			wp_die(
+				esc_html__( 'You do not have permission to export data.', 'give' ),
+				esc_html__( 'Error', 'give' ),
+				array( 'response' => 403 )
+			);
 		}
 
 		// Set headers.

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -620,7 +620,7 @@ function give_clean( $var ) {
 	if ( is_array( $var ) ) {
 		return array_map( 'give_clean', $var );
 	} else {
-		return is_scalar( $var ) ? sanitize_text_field( $var ) : $var;
+		return is_scalar( $var ) ? sanitize_text_field( wp_unslash( $var ) ) : $var;
 	}
 }
 


### PR DESCRIPTION
## Description
Adding escaping to output for `wp_die()`.
Adding `wp_unslash` to `give_clean` function.

### PHPCS Output Before PR:
```
FILE: ./content/plugins/give/includes/admin/tools/export/class-core-settings-export.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 7 ERRORS AND 2 WARNINGS AFFECTING 3 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | ERROR   | Class file names should be based on the class name with "class-" prepended. Expected class-give-core-settings-export.php, but found class-core-settings-export.php.
 57 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
 57 | ERROR   | Processing form data without nonce verification.
 57 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
 57 | ERROR   | Missing wp_unslash() before sanitization.
 57 | ERROR   | Detected usage of a non-sanitized input variable: $_POST
 57 | ERROR   | Processing form data without nonce verification.
 79 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'.
 79 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '__'.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### PHPCS Output After PR:
```
FILE: ./content/plugins/give/includes/admin/tools/export/class-core-settings-export.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | ERROR   | Class file names should be based on the class name with "class-" prepended. Expected class-give-core-settings-export.php, but found class-core-settings-export.php.
 57 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
 57 | ERROR   | Processing form data without nonce verification.
 57 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
 57 | ERROR   | Missing wp_unslash() before sanitization.
 57 | ERROR   | Detected usage of a non-sanitized input variable: $_POST
 57 | ERROR   | Processing form data without nonce verification.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## Types of changes
Escaping and sanitization.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.