### PR TITLE
PHPCS: fixes for admin filters

### DIFF
--- a/includes/admin/abstract-admin-settings-page.php
+++ b/includes/admin/abstract-admin-settings-page.php
@@ -240,7 +240,6 @@ if ( ! class_exists( 'Give_Settings_Page' ) ) :
 			$settings        = $this->get_settings();
 			$current_section = give_get_current_setting_section();
 
-
 			/**
 			 * Use this filter if you want to implement your custom save logic.
 			 *

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -36,13 +36,13 @@ function __give_sanitize_number_decimals_setting_field( $value ) {
 		$value_changed = true;
 	}
 
-	if ( $value_changed && ( $old_value != $value ) ) {
+	if ( $value_changed && ( $old_value !== $value ) ) {
 		Give_Admin_Settings::add_error( 'give-number-decimal', __( 'The \'Number of Decimals\' option has been automatically set to zero because the \'Decimal Separator\' is not set.', 'give' ) );
 	}
 
 	$value = absint( $value );
 
-	if( 6 <= $value ) {
+	if ( 6 <= $value ) {
 		$value = 5;
 		Give_Admin_Settings::add_error( 'give-number-decimal', __( 'The \'Number of Decimals\' option has been automatically set to 5 because you entered a number higher than the maximum allowed.', 'give' ) );
 	}
@@ -67,8 +67,8 @@ add_filter( 'give_admin_settings_sanitize_option_number_decimals', '__give_sanit
  * @return  mixed
  */
 function __give_validate_decimal_separator_setting_field( $value ) {
-	$thousand_separator = give_clean( $_POST['thousands_separator'] );
-	$decimal_separator  = give_clean( $_POST['decimal_separator'] );
+	$thousand_separator = isset( $_POST['thousands_separator'] ) ? give_clean( $_POST['thousands_separator'] ) : '';
+	$decimal_separator  = isset( $_POST['decimal_separator'] ) ? give_clean( $_POST['decimal_separator'] ) : '';
 
 	if ( $decimal_separator === $thousand_separator ) {
 		$value                    = '';
@@ -92,11 +92,11 @@ add_filter( 'give_admin_settings_sanitize_option_decimal_separator', '__give_val
  */
 function __give_import_delimiter_set_callback( $delimiter ) {
 	$delimite_type = array(
-		'csv'                  => ",",
+		'csv'                  => ',',
 		'tab-separated-values' => "\t",
 	);
 
-	return ( array_key_exists( $delimiter, $delimite_type ) ? $delimite_type[ $delimiter ] : "," );
+	return ( array_key_exists( $delimiter, $delimite_type ) ? $delimite_type[ $delimiter ] : ',' );
 }
 
 add_filter( 'give_import_delimiter_set', '__give_import_delimiter_set_callback', 10 );
@@ -143,7 +143,7 @@ function give_import_core_settings_merge_image_size( $json_to_array, $type ) {
 		) {
 			$images_sizes = get_intermediate_image_sizes();
 
-			if ( ! in_array( $json_to_array['featured_image_size'], $images_sizes ) ) {
+			if ( ! in_array( $json_to_array['featured_image_size'], $images_sizes, true ) ) {
 				unset( $json_to_array['featured_image_size'] );
 			}
 		}
@@ -247,7 +247,7 @@ add_filter( 'give_import_core_settings_data', 'give_import_core_settings_merge_d
  *
  * @return mixed
  */
-function give_bc_1817_cleanup_user_roles( $caps ){
+function give_bc_1817_cleanup_user_roles( $caps ) {
 
 	if (
 		! give_has_upgrade_completed( 'v1817_cleanup_user_roles' ) &&


### PR DESCRIPTION
## Description
Fixing strict comparison (`!==`).
Adding spacing for PHPCS.
Adding newline at end of file.
Spot checking all access to $_POST superglobal.
Verifying existence of key in $_POST superglobal before proceeding.

### PHPCS output before PR

```
FILE: ./content/plugins/give/includes/admin/admin-filters.php
------------------------------------------------------------------------------------------------------
FOUND 22 ERRORS AND 6 WARNINGS AFFECTING 15 LINES
------------------------------------------------------------------------------------------------------
  30 | ERROR   | [ ] Function name "__give_sanitize_number_decimals_setting_field" is invalid; only PHP magic methods should be prefixed with a double underscore
  34 | WARNING | [ ] Detected access of super global var $_POST, probably needs manual inspection.
  34 | ERROR   | [ ] Processing form data without nonce verification.
  35 | WARNING | [ ] Detected access of super global var $_POST, probably needs manual inspection.
  35 | ERROR   | [ ] Processing form data without nonce verification.
  39 | WARNING | [ ] Found: !=. Use strict comparisons (=== or !==).
  45 | ERROR   | [x] Expected 1 space(s) after IF keyword; 0 found
  45 | ERROR   | [x] Space after opening control structure is required
  45 | ERROR   | [x] No space before opening parenthesis is prohibited
  69 | ERROR   | [ ] Function name "__give_validate_decimal_separator_setting_field" is invalid; only PHP magic methods should be prefixed with a double underscore
  70 | WARNING | [ ] Detected access of super global var $_POST, probably needs manual inspection.
  70 | ERROR   | [ ] Detected usage of a non-validated input variable: $_POST
  70 | ERROR   | [ ] Missing wp_unslash() before sanitization.
  70 | ERROR   | [ ] Detected usage of a non-sanitized input variable: $_POST
  70 | ERROR   | [ ] Processing form data without nonce verification.
  71 | WARNING | [ ] Detected access of super global var $_POST, probably needs manual inspection.
  71 | ERROR   | [ ] Detected usage of a non-validated input variable: $_POST
  71 | ERROR   | [ ] Missing wp_unslash() before sanitization.
  71 | ERROR   | [ ] Detected usage of a non-sanitized input variable: $_POST
  71 | ERROR   | [ ] Processing form data without nonce verification.
  93 | ERROR   | [ ] Function name "__give_import_delimiter_set_callback" is invalid; only PHP magic methods should be prefixed with a double underscore
  95 | ERROR   | [x] String "," does not require double quotes; use single quotes instead
  99 | ERROR   | [x] String "," does not require double quotes; use single quotes instead
 144 | ERROR   | [ ] Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is
     |         |     intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.
 146 | WARNING | [ ] Not using strict comparison for in_array; supply true for third argument.
 250 | ERROR   | [x] Expected 1 space before opening brace; found 0
 250 | ERROR   | [x] Space between opening control structure and closing parenthesis is required
 262 | ERROR   | [x] File must end with a newline character
------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 8 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------------------

```

## How Has This Been Tested?

### PHPCS output after PR
```
FILE: ./content/plugins/give/includes/admin/admin-filters.php
------------------------------------------------------------------------------------------------------
FOUND 14 ERRORS AND 6 WARNINGS AFFECTING 8 LINES
------------------------------------------------------------------------------------------------------
  30 | ERROR   | Function name "__give_sanitize_number_decimals_setting_field" is invalid; only PHP magic methods should be prefixed with a double underscore
  34 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  34 | ERROR   | Processing form data without nonce verification.
  35 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  35 | ERROR   | Processing form data without nonce verification.
  69 | ERROR   | Function name "__give_validate_decimal_separator_setting_field" is invalid; only PHP magic methods should be prefixed with a double underscore
  70 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  70 | ERROR   | Processing form data without nonce verification.
  70 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  70 | ERROR   | Missing wp_unslash() before sanitization.
  70 | ERROR   | Detected usage of a non-sanitized input variable: $_POST
  70 | ERROR   | Processing form data without nonce verification.
  71 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  71 | ERROR   | Processing form data without nonce verification.
  71 | WARNING | Detected access of super global var $_POST, probably needs manual inspection.
  71 | ERROR   | Missing wp_unslash() before sanitization.
  71 | ERROR   | Detected usage of a non-sanitized input variable: $_POST
  71 | ERROR   | Processing form data without nonce verification.
  93 | ERROR   | Function name "__give_import_delimiter_set_callback" is invalid; only PHP magic methods should be prefixed with a double underscore
 144 | ERROR   | Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is
     |         | intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.
------------------------------------------------------------------------------------------------------
```

## Types of changes
Fixing strict comparison (!==).
Adding spacing for PHPCS.
Adding newline at end of file.
Verifying existence of key in $_POST superglobal before proceeding.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.