### PR TITLE
PHPCS: Fixing PHPCS warnings and errors, tabs vs spaces. 

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -132,14 +132,17 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 		case 'tags':
 			$has_view = in_array( $passed_view, array( 'list-table', 'edit', 'new' ), true );
 
-			if ( ! in_array( $query_args['taxonomy'], array( 'give_forms_category', 'give_forms_tag' ), true ) && 'edit-tags.php' !== $pagenow
-			     && ( $has_view ||
-			          (
-				          ( in_array( $passed_view, array( 'list-table', 'new' ), true ) && 'edit' === $query_args['action'] ) ||
-				          ( 'edit' !== $passed_view && 'edit' !== $query_args['action'] )
-				          && ! $has_view
-			          )
-			     )
+			if (
+				! in_array( $query_args['taxonomy'], array( 'give_forms_category', 'give_forms_tag' ), true ) &&
+				'edit-tags.php' !== $pagenow &&
+				(
+					$has_view ||
+					(
+						( in_array( $passed_view, array( 'list-table', 'new' ), true ) && 'edit' === $query_args['action'] ) ||
+						( 'edit' !== $passed_view && 'edit' !== $query_args['action'] ) &&
+						! $has_view
+					)
+				)
 			) {
 				$found = false;
 			}
@@ -148,11 +151,17 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 		case 'give_forms':
 			$has_view = in_array( $passed_view, array( 'new', 'list-table', 'edit' ), true );
 
-			if ( 'give_forms' !== $typenow
-			     && ( ( 'list-table' !== $passed_view && 'edit.php' !== $pagenow  ) &&
-			          ( 'edit' !== $passed_view && 'post.php' !== $pagenow ) &&
-			          ( 'new' !== $passed_view && 'post-new.php' !== $pagenow ) )
-			     || ( ! $has_view && ( 'post-new.php' !== $pagenow && 'give_forms' !== $query_args['post_type'] ) )
+			if (
+				'give_forms' !== $typenow &&
+				(
+					( 'list-table' !== $passed_view && 'edit.php' !== $pagenow ) &&
+					( 'edit' !== $passed_view && 'post.php' !== $pagenow ) &&
+					( 'new' !== $passed_view && 'post-new.php' !== $pagenow )
+				) ||
+				(
+					! $has_view &&
+					( 'post-new.php' !== $pagenow && 'give_forms' !== $query_args['post_type'] )
+				)
 			) {
 				$found = false;
 			}
@@ -162,23 +171,26 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 			$has_view = array_intersect( array( $passed_view, $query_args['view'] ), array( 'list-table', 'overview', 'notes' ) );
 
 			if (
-				( 'give-donors' !== $query_args['page'] || 'edit.php' !== $pagenow )
-			     && ( ( $passed_view !== $query_args['view'] || ! empty( $has_view ) ) ||
-			          ( false !== $query_args['view'] && 'list-table' !== $passed_view )
-			     )
+				( 'give-donors' !== $query_args['page'] || 'edit.php' !== $pagenow ) &&
+				(
+					( $passed_view !== $query_args['view'] || ! empty( $has_view ) ) ||
+					( false !== $query_args['view'] && 'list-table' !== $passed_view )
+				)
 			) {
 				$found = false;
 			}
 			break;
 		// Give Donations page.
-		case 'payments' :
-			if ( ( 'give-payment-history' !== $query_args['page'] || 'edit.php' !== $pagenow )
-			     && ( ! in_array( $passed_view, array( 'list-table', 'edit' ), true ) ||
-			          (
-				          ( 'list-table' !== $passed_view && false !== $query_args['view'] ) ||
-				          ( 'edit' !== $passed_view && 'view-payment-details' !== $query_args['view'] )
-			          )
-			     )
+		case 'payments':
+			if (
+				( 'give-payment-history' !== $query_args['page'] || 'edit.php' !== $pagenow ) &&
+				(
+					! in_array( $passed_view, array( 'list-table', 'edit' ), true ) ||
+					(
+						( 'list-table' !== $passed_view && false !== $query_args['view'] ) ||
+						( 'edit' !== $passed_view && 'view-payment-details' !== $query_args['view'] )
+					)
+				)
 			) {
 				$found = false;
 			}
@@ -191,8 +203,9 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 			$give_setting_page = in_array( $query_args['page'], array( 'give-reports', 'give-settings', 'give-addons' ), true );
 
 			// Check if it's Give Setting page or not.
-			if ( ( 'edit.php' !== $pagenow || ! $give_setting_page )
-			     && ! Give_Admin_Settings::is_setting_page( $current_tab )
+			if (
+				( 'edit.php' !== $pagenow || ! $give_setting_page ) &&
+				! Give_Admin_Settings::is_setting_page( $current_tab )
 			) {
 				$found = false;
 			}
@@ -247,7 +260,7 @@ function give_settings_page_pages( $settings ) {
 		include( GIVE_PLUGIN_DIR . 'includes/admin/settings/class-settings-license.php' ),
 
 		// Advanced settings.
-		include( GIVE_PLUGIN_DIR . 'includes/admin/settings/class-settings-advanced.php' )
+		include( GIVE_PLUGIN_DIR . 'includes/admin/settings/class-settings-advanced.php' ),
 	);
 
 	// Output.
@@ -292,7 +305,6 @@ add_filter( 'give-reports_get_settings_pages', 'give_reports_page_pages', 0, 1 )
  */
 function give_tools_page_pages( $settings ) {
 	include( 'abstract-admin-settings-page.php' );
-
 
 	$settings = array(
 
@@ -358,7 +370,7 @@ add_filter( 'give_default_setting_tab_give-reports', 'give_set_default_tab_form_
  */
 function give_add_display_page_states( $post_states, $post ) {
 
-	switch( $post->ID ) {
+	switch ( $post->ID ) {
 		case give_get_option( 'success_page' ):
 			$post_states['give_successfully_page'] = __( 'Donation Success Page', 'give' );
 			break;


### PR DESCRIPTION
## Description
Fixing PHPCS warnings and errors for tabs vs spaces
Verifying all usages of the $_GET superglobal.


### PHPCS Output before PR

```
FILE: ./content/plugins/give/includes/admin/admin-pages.php
---------------------------------------------------------------------------------------------------
FOUND 28 ERRORS AND 26 WARNINGS AFFECTING 26 LINES
---------------------------------------------------------------------------------------------------
 125 | WARNING | [ ] Detected access of super global var $_GET, probably needs manual inspection.
 125 | WARNING | [ ] Processing form data without nonce verification.
 125 | WARNING | [ ] Silencing errors is discouraged
 125 | WARNING | [ ] Detected access of super global var $_GET, probably needs manual inspection.
 125 | WARNING | [ ] Processing form data without nonce verification.
 136 | WARNING | [ ] Found precision alignment of 1 spaces.
 136 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 137 | WARNING | [ ] Found precision alignment of 2 spaces.
 137 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 138 | WARNING | [ ] Found precision alignment of 2 spaces.
 138 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 139 | WARNING | [ ] Found precision alignment of 2 spaces.
 139 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 140 | WARNING | [ ] Found precision alignment of 2 spaces.
 140 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 141 | WARNING | [ ] Found precision alignment of 2 spaces.
 141 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 142 | WARNING | [ ] Found precision alignment of 1 spaces.
 142 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 152 | WARNING | [ ] Found precision alignment of 1 spaces.
 152 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 152 | ERROR   | [x] Expected 1 space before close parenthesis; 2 found
 153 | WARNING | [ ] Found precision alignment of 2 spaces.
 153 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 154 | WARNING | [ ] Found precision alignment of 2 spaces.
 154 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 155 | WARNING | [ ] Found precision alignment of 1 spaces.
 155 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 166 | WARNING | [ ] Found precision alignment of 1 spaces.
 166 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 167 | WARNING | [ ] Found precision alignment of 2 spaces.
 167 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 168 | WARNING | [ ] Found precision alignment of 1 spaces.
 168 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 174 | ERROR   | [x] There must be no space before the colon in a CASE statement
 176 | WARNING | [ ] Found precision alignment of 1 spaces.
 176 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 177 | WARNING | [ ] Found precision alignment of 2 spaces.
 177 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 178 | WARNING | [ ] Found precision alignment of 2 spaces.
 178 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 179 | WARNING | [ ] Found precision alignment of 2 spaces.
 179 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 180 | WARNING | [ ] Found precision alignment of 2 spaces.
 180 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 181 | WARNING | [ ] Found precision alignment of 1 spaces.
 181 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 195 | WARNING | [ ] Found precision alignment of 1 spaces.
 195 | ERROR   | [x] Tabs must be used to indent lines; spaces are not allowed
 250 | ERROR   | [x] Each array item in a multi-line array declaration must end in a comma
 295 | ERROR   | [x] Functions must not contain multiple empty lines in a row; found 2 empty lines
 361 | ERROR   | [x] Expected 1 space(s) after SWITCH keyword; 0 found
 361 | ERROR   | [x] Space after opening control structure is required
 361 | ERROR   | [x] No space before opening parenthesis is prohibited
---------------------------------------------------------------------------------------------------
```

### PHPCS Output after PR
```
FILE: ./content/plugins/give/includes/admin/admin-pages.php
--------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------
 125 | WARNING | Detected access of super global var $_GET, probably needs manual inspection.
 125 | WARNING | Processing form data without nonce verification.
 125 | WARNING | Silencing errors is discouraged
 125 | WARNING | Detected access of super global var $_GET, probably needs manual inspection.
 125 | WARNING | Processing form data without nonce verification.
--------------------------------------------------------------------------------------------------
```

## Types of changes
PHPCS Cleanup

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.