### PR TITLE
PHPCS: Class blank slate fixes.

### DIFF
--- a/includes/admin/class-blank-slate.php
+++ b/includes/admin/class-blank-slate.php
@@ -150,7 +150,7 @@ class Give_Blank_Slate {
 	 *
 	 * @param string $which The location of the list table hook: 'top' or 'bottom'.
 	 */
-	public function render( $which = 'bottom') {
+	public function render( $which = 'bottom' ) {
 		// Bail out to prevent content from rendering twice.
 		if ( 'top' === $which ) {
 			return null;
@@ -260,7 +260,8 @@ class Give_Blank_Slate {
 			'cta_text'  => __( 'Create Donation Form', 'give' ),
 			'cta_link'  => admin_url( 'post-new.php?post_type=give_forms' ),
 			'help'      => sprintf(
-				__( 'Need help? Get started with %sGive 101%s.', 'give' ),
+				/* translators: 1: Opening anchor tag. 2: Closing anchor tag. */
+				__( 'Need help? Get started with %1$sGive 101%2$s.', 'give' ),
 				'<a href="http://docs.givewp.com/give101/" target="_blank">',
 				'</a>'
 			),
@@ -278,7 +279,8 @@ class Give_Blank_Slate {
 				'cta_text' => __( 'View All Forms', 'give' ),
 				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
 				'help'     => sprintf(
-					__( 'Need help? Learn more about %sDonations%s.', 'give' ),
+					/* translators: 1: Opening anchor tag. 2: Closing anchor tag. */
+					__( 'Need help? Learn more about %1$sDonations%2$s.', 'give' ),
 					'<a href="http://docs.givewp.com/core-donations/">',
 					'</a>'
 				),
@@ -293,7 +295,8 @@ class Give_Blank_Slate {
 				'cta_text' => __( 'View All Forms', 'give' ),
 				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
 				'help'     => sprintf(
-					__( 'Need help? Learn more about %sDonors%s.', 'give' ),
+					/* translators: 1: Opening anchor tag. 2: Closing anchor tag. */
+					__( 'Need help? Learn more about %1$sDonors%2$s.', 'give' ),
 					'<a href="http://docs.givewp.com/core-donors/">',
 					'</a>'
 				),


### PR DESCRIPTION
## Description
Fixing placeholder PHPCS errors and warnings for translators comments.

## How Has This Been Tested?

### PHPCS Output before
```
FILE: ./content/plugins/give/includes/admin/class-blank-slate.php
------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AND 3 WARNINGS AFFECTING 5 LINES
------------------------------------------------------------------------------------------------------
   1 | ERROR   | [ ] Class file names should be based on the class name with "class-" prepended. Expected class-give-blank-slate.php, but found class-blank-slate.php.
 153 | ERROR   | [x] No space before closing parenthesis is prohibited
 263 | WARNING | [ ] A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the
     |         |     placeholders.
 263 | ERROR   | [x] Multiple placeholders should be ordered. Expected '%1$s, %2$s', but got %s, %s.
 281 | WARNING | [ ] A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the
     |         |     placeholders.
 281 | ERROR   | [x] Multiple placeholders should be ordered. Expected '%1$s, %2$s', but got %s, %s.
 296 | WARNING | [ ] A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the
     |         |     placeholders.
 296 | ERROR   | [x] Multiple placeholders should be ordered. Expected '%1$s, %2$s', but got %s, %s.
------------------------------------------------------------------------------------------------------
```

### PHPCS Output after PR:
```
FILE: ./content/plugins/give/includes/admin/class-blank-slate.php
------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------
 1 | ERROR | Class file names should be based on the class name with "class-" prepended. Expected class-give-blank-slate.php, but found class-blank-slate.php.
------------------------------------------------------------------------------------------------------
```

## Types of changes
Changing placeholders to be numbered placeholders (`%1$s`, `%2$s`, ...)
Comments

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.