### PR TITLE
PHPCS Adding escaping to output and fixing alignment.

### DIFF
--- a/includes/admin/tools/logs/class-update-logs-list-table.php
+++ b/includes/admin/tools/logs/class-update-logs-list-table.php
@@ -48,7 +48,7 @@ class Give_Update_Log_Table extends WP_List_Table {
 		parent::__construct( array(
 			'singular' => give_get_forms_label_singular(),    // Singular name of the listed records
 			'plural'   => give_get_forms_label_plural(),        // Plural name of the listed records
-			'ajax'     => false,// Does this table support ajax?
+			'ajax'     => false, // Does this table support ajax?
 		) );
 	}
 
@@ -120,16 +120,16 @@ class Give_Update_Log_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function column_details( $item ) {
-		echo Give()->tooltips->render_link( array(
+		echo wp_kses_post( Give()->tooltips->render_link( array(
 			'label'       => __( 'View Update Log', 'give' ),
 			'tag_content' => '<span class="dashicons dashicons-visibility"></span>',
 			'link'        => "#TB_inline?width=640&amp;inlineId=log-details-{$item['ID']}",
 			'attributes'  => array(
 				'class' => 'thickbox give-error-log-details-link button button-small',
 			),
-		) );
+		) ) );
 		?>
-		<div id="log-details-<?php echo $item['ID']; ?>" style="display:none;">
+		<div id="log-details-<?php echo esc_attr( $item['ID'] ); ?>" style="display:none;">
 			<?php
 
 			// Print Log Content, if not empty.
@@ -259,10 +259,9 @@ class Give_Update_Log_Table extends WP_List_Table {
 		$total_items           = Give()->logs->get_log_count( 0, 'update' );
 
 		$this->set_pagination_args( array(
-				'total_items' => $total_items,
-				'per_page'    => $this->per_page,
-				'total_pages' => ceil( $total_items / $this->per_page ),
-			)
-		);
+			'total_items' => $total_items,
+			'per_page'    => $this->per_page,
+			'total_pages' => ceil( $total_items / $this->per_page ),
+		) );
 	}
 }


### PR DESCRIPTION
## Description
Fixing output escaping and alignment issues for PHPCS.

## How Has This Been Tested?

### PHPCS Output before PR
```
FILE: ./content/plugins/give/includes/admin/tools/logs/class-update-logs-list-table.php
------------------------------------------------------------------------------------------------------
FOUND 9 ERRORS AND 3 WARNINGS AFFECTING 10 LINES
------------------------------------------------------------------------------------------------------
   1 | ERROR   | [ ] Class file names should be based on the class name with "class-" prepended. Expected class-give-update-log-table.php, but found
     |         |     class-update-logs-list-table.php.
  51 | ERROR   | [x] Expected 1 space between comma and "// Does this table support ajax?
     |         |     "; 0 found
 123 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'Give'.
 126 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found
     |         |     '"#TB_inline?width=640&amp;inlineId=log-details-{$item['ID']}"'.
 132 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$item'.
 189 | WARNING | [ ] Detected access of super global var $_GET, probably needs manual inspection.
 189 | WARNING | [ ] Processing form data without nonce verification.
 189 | WARNING | [ ] Detected access of super global var $_GET, probably needs manual inspection.
 262 | ERROR   | [x] Array item not aligned correctly; expected 12 spaces but found 16
 263 | ERROR   | [x] Array item not aligned correctly; expected 12 spaces but found 16
 264 | ERROR   | [x] Array item not aligned correctly; expected 12 spaces but found 16
 265 | ERROR   | [x] Array closer not aligned correctly; expected 8 space(s) but found 12
------------------------------------------------------------------------------------------------------
```

### PHPCS Output after PR

```
FILE: ./content/plugins/give/includes/admin/tools/logs/class-update-logs-list-table.php
------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 3 WARNINGS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------
   1 | ERROR   | Class file names should be based on the class name with "class-" prepended. Expected class-give-update-log-table.php, but found class-update-logs-list-table.php.
 189 | WARNING | Detected access of super global var $_GET, probably needs manual inspection.
 189 | WARNING | Processing form data without nonce verification.
 189 | WARNING | Detected access of super global var $_GET, probably needs manual inspection.
------------------------------------------------------------------------------------------------------
```

## Types of changes
Fixing output escaping and alignment issues for PHPCS.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.