### PR TITLE
PHPCS: Fixing escaping for html-admin-page-data

### DIFF
--- a/includes/admin/tools/views/html-admin-page-data.php
+++ b/includes/admin/tools/views/html-admin-page-data.php
@@ -60,17 +60,17 @@ do_action( 'give_tools_recount_stats_before' );
 							'chosen'      => true,
 							'placeholder' => __( 'Select Form', 'give' ),
 						);
-						echo Give()->html->forms_dropdown( $args );
+						echo wp_kses_post( Give()->html->forms_dropdown( $args ) );
 						?>
 					</span>
 
 					<span class="tools-form-dropdown tools-form-dropdown-delete-import-donors" style="display: none">
 						<label for="delete-import-donors">
 							<?php
-							echo Give()->html->checkbox( array(
-								'name'    => 'delete-import-donors'
-							) );
-							_e( 'Delete imported WordPress users', 'give' );
+							echo wp_kses_post( Give()->html->checkbox( array(
+								'name' => 'delete-import-donors',
+							) ) );
+							esc_html_e( 'Delete imported WordPress users', 'give' );
 							?>
 						</label>
 					</span>
@@ -94,8 +94,8 @@ do_action( 'give_tools_recount_stats_before' );
 						 */
 						do_action( 'give_recount_tool_descriptions' );
 						?>
-						<span id="delete-test-transactions"><?php _e( '<strong>Deletes</strong> all TEST donations, donors, and related log entries.', 'give' ); ?></span>
-						<span id="reset-stats"><?php _e( '<strong>Deletes</strong> ALL donations, donors, and related log entries regardless of test or live mode.', 'give' ); ?></span>
+						<span id="delete-test-transactions"><strong><?php echo esc_html_e( 'Deletes', 'give' ); ?></strong> <?php esc_html_e( 'all TEST donations, donors, and related log entries.', 'give' ); ?></span>
+						<span id="reset-stats"><strong><?php echo esc_html_e( 'Deletes', 'give' ); ?></strong> <?php esc_html_e( 'ALL donations, donors, and related log entries regardless of test or live mode.', 'give' ); ?></span>
 					</span>
 
 					<span class="spinner"></span>


### PR DESCRIPTION
## Description
Fixing output escaping and alignment issues for PHPCS.

## How Has This Been Tested?

### PHPCS Output before PR
```

FILE: ./content/plugins/give/includes/admin/tools/views/html-admin-page-data.php
------------------------------------------------------------------------------------------------------
FOUND 6 ERRORS AND 1 WARNING AFFECTING 6 LINES
------------------------------------------------------------------------------------------------------
 63 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'Give'.
 70 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'Give'.
 71 | WARNING | [x] Array double arrow not aligned correctly; expected 1 space(s) between "'name'" and double arrow, but found 4.
 71 | ERROR   | [x] Each array item in a multi-line array declaration must end in a comma
 73 | ERROR   | [ ] All output should be run through an escaping function (like esc_html_e() or esc_attr_e()), found '_e'.
 97 | ERROR   | [ ] All output should be run through an escaping function (like esc_html_e() or esc_attr_e()), found '_e'.
 98 | ERROR   | [ ] All output should be run through an escaping function (like esc_html_e() or esc_attr_e()), found '_e'.
------------------------------------------------------------------------------------------------------
```

### PHPCS Output after PR

```
No Errors or Warnings!
```

## Types of changes
Fixing output escaping and alignment issues for PHPCS.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.