### PR TITLE
PHPCS: Escaping output and fixing assignment on own line.

### DIFF
--- a/includes/admin/tools/logs/logs.php
+++ b/includes/admin/tools/logs/logs.php
@@ -25,7 +25,7 @@ function give_get_logs_tab() {
 	require( GIVE_PLUGIN_DIR . 'includes/admin/tools/logs/logs.php' );
 
 	// Get current section.
-	$current_section = $_GET['section'] = give_get_current_setting_section();
+	$current_section = give_get_current_setting_section();
 
 	/**
 	 * Fires the in report page logs view.
@@ -61,7 +61,8 @@ function give_logs_view_sales() {
 		 */
 		do_action( 'give_logs_donations_top' );
 
-		$logs_table->display(); ?>
+		$logs_table->display();
+		?>
 		<input type="hidden" name="post_type" value="give_forms"/>
 		<input type="hidden" name="page" value="give-tools"/>
 		<input type="hidden" name="tab" value="logs"/>
@@ -105,7 +106,8 @@ function give_logs_view_updates() {
 		 */
 		do_action( 'give_logs_update_top' );
 
-		$logs_table->display(); ?>
+		$logs_table->display();
+		?>
 		<input type="hidden" name="post_type" value="give_forms"/>
 		<input type="hidden" name="page" value="give-tools"/>
 		<input type="hidden" name="tab" value="logs"/>
@@ -150,7 +152,8 @@ function give_logs_view_gateway_errors() {
 		 */
 		do_action( 'give_logs_payment_error_top' );
 
-		$logs_table->display(); ?>
+		$logs_table->display();
+		?>
 		<input type="hidden" name="post_type" value="give_forms"/>
 		<input type="hidden" name="page" value="give-tools"/>
 		<input type="hidden" name="tab" value="logs"/>
@@ -224,7 +227,7 @@ function give_log_views() {
 		return;
 	}
 	?>
-	<form id="give-logs-filter" method="get" action="<?php echo 'edit.php?post_type=give_forms&page=give-tools&tab=logs&section=' . $current_section; ?>">
+	<form id="give-logs-filter" method="get" action="<?php echo esc_url( 'edit.php?post_type=give_forms&page=give-tools&tab=logs&section=' . $current_section ); ?>">
 		<?php
 		/**
 		 * Fires after displaying the reports page views drop down.


### PR DESCRIPTION
## Description
Escaping output and fixing assignment on own line.

## How Has This Been Tested?

### PHPCS output before PR
```
FILE: ./content/plugins/give/includes/admin/tools/logs/logs.php
------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 5 LINES
------------------------------------------------------------------------------------------------------
  28 | ERROR | [ ] Assignments must be the first block of code on a line
  64 | ERROR | [x] Closing PHP tag must be on a line by itself
 108 | ERROR | [x] Closing PHP tag must be on a line by itself
 153 | ERROR | [x] Closing PHP tag must be on a line by itself
 227 | ERROR | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$current_section'.
------------------------------------------------------------------------------------------------------
```
### PHPCS output after PR
```
All errors and warnings are resolved! 🎉
```

## Types of changes
Escaping output and fixing assignment on own line.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.