### PR TITLE
PHPCS: Fixing escaping errors and warnings.

### DIFF
--- a/includes/class-give-gravatars.php
+++ b/includes/class-give-gravatars.php
@@ -543,7 +543,7 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'give' ) ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
-g		</p>
+		</p>
 
 		<?php
 	}

--- a/includes/class-give-gravatars.php
+++ b/includes/class-give-gravatars.php
@@ -492,7 +492,6 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 		// Used by themes. Closes the widget
 		$output .= $args['after_widget'];
 
-
 		echo wp_kses_post( $output );
 	}
 
@@ -544,7 +543,7 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'give' ) ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
-		</p>
+g		</p>
 
 		<?php
 	}

--- a/includes/class-give-gravatars.php
+++ b/includes/class-give-gravatars.php
@@ -246,9 +246,9 @@ class Give_Donors_Gravatars {
 		if ( isset ( $title ) ) {
 
 			if ( $title ) {
-				echo apply_filters( 'give_donors_gravatars_title', '<h3 class="give-gravatars-title">' . esc_attr( $title ) . '</h3>' );
+				echo wp_kses_post( apply_filters( 'give_donors_gravatars_title', '<h3 class="give-gravatars-title">' . esc_attr( $title ) . '</h3>' ) );
 			} elseif ( isset( $give_options['give_donors_gravatars_heading'] ) ) {
-				echo apply_filters( 'give_donors_gravatars_title', '<h3 class="give-gravatars-title">' . esc_attr( $give_options['give_donors_gravatars_heading'] ) . '</h2>' );
+				echo wp_kses_post( apply_filters( 'give_donors_gravatars_title', '<h3 class="give-gravatars-title">' . esc_attr( $give_options['give_donors_gravatars_heading'] ) . '</h2>' ) );
 			}
 
 		}
@@ -291,7 +291,7 @@ class Give_Donors_Gravatars {
 			} // end foreach
 		}
 
-		echo $output;
+		echo wp_kses_post( $output );
 		echo '</ul>';
 		echo '</div>';
 
@@ -459,8 +459,14 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 
-		//@TODO: Don't extract it!!!
-		extract( $args );
+		$defaults = array(
+			'before_widget' => '',
+			'after_widget' => '',
+			'before_title' => '',
+			'after_title' => '',
+		);
+
+		$args = wp_parse_args( $args, $defaults );
 
 		if ( ! is_singular( 'give_forms' ) ) {
 			return;
@@ -469,21 +475,25 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 		// Variables from widget settings
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
+		$output = '';
+
 		// Used by themes. Opens the widget
-		echo $before_widget;
+		$output .= $args['before_widget'];
 
 		// Display the widget title
 		if ( $title ) {
-			echo $before_title . $title . $after_title;
+			$output .= $args['before_title'] . $title . $args['after_title'];
 		}
 
 		$gravatars = new Give_Donors_Gravatars();
 
-		echo $gravatars->gravatars( get_the_ID(), null ); // remove title
+		$output .= $gravatars->gravatars( get_the_ID(), null ); // remove title
 
 		// Used by themes. Closes the widget
-		echo $after_widget;
+		$output .= $args['after_widget'];
 
+
+		echo wp_kses_post( $output );
 	}
 
 	/**
@@ -503,7 +513,7 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 
 		$instance = $old_instance;
 
-		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['title'] = wp_strip_all_tags( $new_instance['title'] );
 
 		return $instance;
 
@@ -532,8 +542,8 @@ class Give_Donors_Gravatars_Widget extends WP_Widget {
 
 		<!-- Title -->
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'give' ) ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $instance['title']; ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'give' ) ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 		</p>
 
 		<?php


### PR DESCRIPTION
## Description
Fixing PHPCS escaping errors and warnings.

## How Has This Been Tested?
### PHPCS Output before PR:

```
FILE: ./content/plugins/give/includes/class-give-gravatars.php
------------------------------------------------------------------------------------------------------
FOUND 15 ERRORS AFFECTING 11 LINES
------------------------------------------------------------------------------------------------------
 249 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'apply_filters'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 251 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found 'apply_filters'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 294 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$output'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 463 | ERROR | extract() usage is highly discouraged, due to the complexity and unintended issues it might cause. (WordPress.Functions.DontExtract.extract_extract)
 473 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$before_widget'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 477 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$before_title'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 477 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$title'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 477 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$after_title'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 482 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$gravatars'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 485 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$after_widget'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 506 | ERROR | `strip_tags()` does not strip CSS and JS in between the script and style tags. `wp_strip_all_tags()` should be used instead.
     |       | (WordPressVIPMinimum.VIP.RestrictedFunctions.strip_tags_strip_tags)
 535 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$this'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 536 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$this'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 536 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$this'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
 536 | ERROR | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$instance'.
     |       | (WordPress.XSS.EscapeOutput.OutputNotEscaped)
------------------------------------------------------------------------------------------------------```

### PHPCS output after PR
```
All errors and warnings resolved!
```

## Types of changes
Fixing PHPCS escaping errors and warnings.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.