### PR TITLE
refactor(admin-setting): Add filter to disable save button

### DIFF
--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 		 */
 		public function output() {
 			if ( $this->enable_save ) {
-				$GLOBALS['give_hide_save_button'] = apply_filters( 'hide_save_button_on_email_page', false );
+				$GLOBALS['give_hide_save_button'] = apply_filters( 'give_hide_save_button_on_email_admin_setting_page', false );
 			}
 
 			$settings = $this->get_settings();

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -163,6 +163,24 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 			$email_notifications_table->prepare_items();
 			$email_notifications_table->display();
 		}
+
+		/**
+		 * Output the settings.
+		 *
+		 * Note: if you want to overwrite this function then manage show/hide save button in your class.
+		 *
+		 * @since  1.8
+		 * @return void
+		 */
+		public function output() {
+			if ( $this->enable_save ) {
+				$GLOBALS['give_hide_save_button'] = apply_filters( 'hide_save_button_on_email_page', false );
+			}
+
+			$settings = $this->get_settings();
+
+			Give_Admin_Settings::output_fields( $settings, 'give_settings' );
+		}
 	}
 
 endif;


### PR DESCRIPTION
## Description
**This is not related to any issue.**

This PR adds a new filter to disable the save button on a specific tab & section of the admin settings page.

## How Has This Been Tested?
This is tested in the upcoming Recurring Donation [feature](https://github.com/WordImpress/Give-Recurring-Donations/issues/11).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.