### PR TITLE
fix(admin-donor): Add popup while trying to edit donor fields

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -1433,6 +1433,7 @@ var give_setting_edit = false;
 	var GiveDonor = {
 
 		init: function () {
+			this.unlockDonorFields();
 			this.editDonor();
 			this.add_email();
 			this.removeUser();
@@ -1442,6 +1443,19 @@ var give_setting_edit = false;
 			this.addressesAction();
 			this.bulkDeleteDonor();
 			$('body').on('click', '#give-donors-filter .bulkactions input[type="submit"]', this.handleBulkActions);
+		},
+
+		unlockDonorFields: function (e) {
+			$('body').on('click', '.give-lock-block', function (e) {
+				new GiveErrorAlert({
+					modalContent:{
+						title: give_vars.unlock_donor_fields_title,
+						desc: give_vars.unlock_donor_fields_message,
+						cancelBtnTitle: give_vars.ok,
+					}
+				}).render();
+				e.preventDefault();
+			});
 		},
 
 		editDonor: function () {

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -208,7 +208,8 @@ class Give_Scripts {
 			'search_placeholder_donor'          => __( 'Type to search all donors', 'give' ),
 			'search_placeholder_country'        => __( 'Type to search all countries', 'give' ),
 			'search_placeholder_state'          => __( 'Type to search all states/provinces', 'give' ),
-			'unlock_donor_fields'               => __( 'To edit first name and last name, please go to user profile of the donor.', 'give' ),
+			'unlock_donor_fields_title'         => __( 'Action forbidden', 'give' ),
+			'unlock_donor_fields_message'               => __( 'To edit first name and last name, please go to user profile of the donor.', 'give' ),
 			'remove_from_bulk_delete'           => __( 'Remove from Bulk Delete', 'give' ),
 			'donors_bulk_action'                => array(
 				'no_donor_selected'  => array(


### PR DESCRIPTION
Closes #3063 

## Description
Added GiveModal popup error while trying to edit donor name fields.

## How Has This Been Tested?
By trying to edit the donor fields.

## Screenshots (jpeg or gifs if applicable):
![donorfields](https://snag.gy/RU7Pbg.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.