### PR TITLE
fix(admin-donation): delete donation note popup should open using modal api #3123

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -469,33 +469,40 @@ var give_setting_edit = false;
 
 				e.preventDefault();
 
-				if (confirm(give_vars.delete_payment_note)) {
+				let that = this;
 
-					var postData = {
-						action: 'give_delete_payment_note',
-						payment_id: $(this).data('payment-id'),
-						note_id: $(this).data('note-id')
-					};
+				new GiveConfirmModal(
+					{
+						modalContent: {
+							title: give_vars.confirm_deletion,
+							desc: give_vars.delete_payment_note
+						},
+						successConfirm: function ( args ) {
+							var postData = {
+								action: 'give_delete_payment_note',
+								payment_id: $(that).data('payment-id'),
+								note_id: $(that).data('note-id')
+							};
 
-					$.ajax({
-						type: 'POST',
-						data: postData,
-						url: ajaxurl,
-						success: function (response) {
-							$('#give-payment-note-' + postData.note_id).remove();
-							if (!$('.give-payment-note').length) {
-								$('.give-no-payment-notes').show();
-							}
-							return false;
+							$.ajax({
+								type: 'POST',
+								data: postData,
+								url: ajaxurl,
+								success: function (response) {
+									$('#give-payment-note-' + postData.note_id).remove();
+									if (!$('.give-payment-note').length) {
+										$('.give-no-payment-notes').show();
+									}
+									return false;
+								}
+							}).fail(function (data) {
+								if (window.console && window.console.log) {
+									console.log(data);
+								}
+							});
 						}
-					}).fail(function (data) {
-						if (window.console && window.console.log) {
-							console.log(data);
-						}
-					});
-					return true;
-				}
-
+					}
+				).render();
 			});
 
 		},


### PR DESCRIPTION
Closes #3123 

Replaced confirm popup with Give Modal popup.

## How Has This Been Tested?
Tested by deleting a donor note.

## Screenshots (jpeg or gifs if applicable):
![deletedonor](https://snag.gy/0mesHk.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.