### PR TITLE
refactor(form): hide min/max field if custom amount is disabled. 

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1947,11 +1947,19 @@ function __give_form_add_donation_hidden_field( $form_id, $args, $form ) {
 	<input type="hidden" name="give-current-url"
 		   value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
 	<input type="hidden" name="give-form-url" value="<?php echo htmlspecialchars( give_get_current_page_url() ); ?>"/>
-	<input type="hidden" name="give-form-minimum"
-	       value="<?php echo give_format_decimal( give_get_form_minimum_price( $form_id ) ); ?>"/>
-	<input type="hidden" name="give-form-maximum"
-	       value="<?php echo give_format_decimal( give_get_form_maximum_price( $form_id ) ); ?>"/>
 	<?php
+	// Get the custom option amount.
+	$custom_amount = give_get_meta( $form_id, '_give_custom_amount', true );
+
+	// If custom amount enabled.
+	if ( give_is_setting_enabled( $custom_amount ) ) {
+		?>
+		<input type="hidden" name="give-form-minimum"
+		       value="<?php echo give_format_decimal( give_get_form_minimum_price( $form_id ) ); ?>"/>
+		<input type="hidden" name="give-form-maximum"
+		       value="<?php echo give_format_decimal( give_get_form_maximum_price( $form_id ) ); ?>"/>
+		<?php
+	}
 
 	// WP nonce field.
 	wp_nonce_field( "donation_form_nonce_{$form_id}", '_wpnonce', false );

--- a/tests/unit-tests/tests-templates.php
+++ b/tests/unit-tests/tests-templates.php
@@ -56,7 +56,7 @@ class Tests_Templates extends Give_Unit_Test_Case {
 		$this->assertContains( '<input type="hidden" name="give-form-title" value="' . get_the_title( $this->_post->ID ) . '"/>', $form );
 		$this->assertContains( '<input type="hidden" name="give-form-url" value="' . htmlspecialchars( give_get_current_page_url() ) . '"/>', $form );
 		$this->assertContains( '<input type="hidden" name="give-current-url" value="' . htmlspecialchars( give_get_current_page_url() ) . '"/>', $form );
-		$this->assertContains( '<input type="hidden" name="give-form-minimum" value="' . give_format_amount( give_get_form_minimum_price( $this->_post->ID ) ) . '"/>', $form );
+		$this->assertNotContains( '<input type="hidden" name="give-form-minimum" value="' . give_format_amount( give_get_form_minimum_price( $this->_post->ID ) ) . '"/>', $form );
 		$this->assertContains( '<input id="give-form-honeypot-' . $this->_post->ID . '" type="text" name="give-honeypot" class="give-honeypot give-hidden"/>', $form );
 
 		// The donation form we created has variable pricing, so ensure the price options render
@@ -67,6 +67,37 @@ class Tests_Templates extends Give_Unit_Test_Case {
 		// Test a single price point as well
 
 
+	}
+
+	/**
+	 * Test test_donation_form_range()
+	 */
+	public function test_donation_form_range() {
+
+		$this->go_to( '/' );
+
+		$args = array(
+			'id' => $this->_post->ID,
+		);
+
+		// Enable Custom amount.
+		give_update_meta( $this->_post->ID, '_give_custom_amount', 'enabled' );
+		give_update_meta( $this->_post->ID, '_give_custom_amount_range_minimum', 1.000000 );
+		give_update_meta( $this->_post->ID, '_give_custom_amount_range_maximum', 10.000000 );
+
+		ob_start();
+
+		give_get_donation_form( $args );
+
+		$form = ob_get_clean();
+		// Remove html form whitespace.
+		$form = preg_replace( '/\s+/S', ' ', $form );
+
+		$this->assertContains( '<input type="hidden" name="give-form-minimum" value="' . give_format_amount( give_get_form_minimum_price( $this->_post->ID ) ) . '"/>', $form );
+		$this->assertContains( '<input type="hidden" name="give-form-maximum" value="' . give_format_amount( give_get_form_maximum_price( $this->_post->ID ) ) . '"/>', $form );
+
+		// Custom amount disabled.
+		give_delete_meta( $this->_post->ID, '_give_custom_amount' );
 	}
 
 	/**

--- a/tests/unit-tests/tests-templates.php
+++ b/tests/unit-tests/tests-templates.php
@@ -70,9 +70,9 @@ class Tests_Templates extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * Test test_donation_form_range()
+	 * Test test_donation_form_amount_range()
 	 */
-	public function test_donation_form_range() {
+	public function test_donation_form_amount_range() {
 
 		$this->go_to( '/' );
 


### PR DESCRIPTION
## Description
This PR fix #3122 

## How Has This Been Tested?
- Tested it by creating donations.
- Tested it by changing the donation form settings.


## Types of changes
 Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.