### PR TITLE
 fix(admin-form): Make Range-slider more practical when setting the minimum amount #3135

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -586,6 +586,21 @@ ASIDE
 			}
 		}
 	}
+
+	.minmax-wrap {
+		display: block;
+		margin-bottom: .5rem;
+
+		label {
+			display: inline-block;
+			width: 120px;
+		}
+
+		input {
+			margin-left: 1px;
+		}
+	}
+
 }
 
 // Hide first row remove button for multi-level.

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -152,7 +152,7 @@ class Give_MetaBox_Form_Data {
 					),
 					array(
 						'name'          => __( 'Min/Max. Amount', 'give' ),
-						'description'   => __( 'Set minimum and maximum amount limit.', 'give' ),
+						'description'   => __( 'Set the minimum and maximum amount for all gateways.', 'give' ),
 						'id'            => $prefix . 'custom_amount_range',
 						'type'          => 'range_slider',
 						'wrapper_class' => 'give-hidden',

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -354,14 +354,6 @@ function give_range_slider( $field ) {
 	<span class="give_range_slider_display">
 		<?php
 
-		if ( ! empty( $field_options['options']['display_label'] ) ) {
-			?>
-			<span class="give_range_slider_label">
-				<?php echo esc_html( $field_options['options']['display_label'] ); ?>
-			</span>
-			<?php
-		}
-
 		foreach ( $field_options['value'] as $amount_range => $amount_value ) {
 
 			switch ( $field_options['data_type'] ) {
@@ -397,6 +389,11 @@ function give_range_slider( $field ) {
 					break;
 			}
 
+			$amount = give_format_amount( give_maybe_sanitize_amount( $field_options['value'][ $amount_range ] ), array( 'sanitize' => false ) );
+
+			echo '<span class=minmax-wrap>';
+			printf( '<label for="%1$s_give_range_slider_%2$s">%3$s</label>', esc_attr( $field_options['id'] ), esc_attr( $amount_range ), esc_html( $tooltip_label ) );
+
 			echo isset( $before_html ) ? $before_html : '';
 			?>
 			<input
@@ -404,20 +401,16 @@ function give_range_slider( $field ) {
 					type="text"
 					id="<?php echo $field_options['id']; ?> _give_range_slider_<?php echo $amount_range; ?>"
 					data-range_type="<?php echo esc_attr( $amount_range ); ?>"
-					value="<?php echo esc_attr( $field_options['value'][ $amount_range ] ); ?>"
+					value="<?php echo esc_attr( $amount ); ?>"
 					placeholder="<?php echo $field_options['options'][ $amount_range ]; ?>"
 				<?php echo give_get_custom_attributes( $field_options ); ?>
 			/>
 			<?php
 			echo isset( $after_html ) ? $after_html : '';
+			echo '</span>';
 		}
 		?>
 	</span>
-		<span
-				id="<?php echo esc_attr( $field_options['id'] ); ?>"
-				style="display: block; <?php echo esc_attr( $field_options['style'] ); ?>"
-				class="<?php echo apply_filters( "give_range_slider_{$field['id']}_classes", "give-range_slider_field" ); ?>"
-		></span>
 		<?php echo give_get_field_description( $field_options ); ?>
 	</p>
 	<?php


### PR DESCRIPTION
Closes #3135 

## Description
Removed the range slider and implemented the new UI as per the requirements

## Screenshots (jpeg or gifs if applicable):
![rangeslider](https://snag.gy/ecjKX6.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.