### PR TITLE
fix(form): validate the min/max amount only if custom amount enabled.

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -792,6 +792,12 @@ Give.form = {
 		 * @return {boolean}
 		 */
 		isValidDonationAmount: function( $form ) {
+
+			// Return true, if custom amount is not enabled.
+			if ( $form.find( 'input[name="give-form-minimum"]' ).length <= 0 ) {
+				return true;
+			}
+
 			var min_amount = this.getMinimumAmount( $form ),
 				max_amount = this.getMaximumAmount( $form ),
 				amount = this.getAmount( $form ),

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1955,9 +1955,9 @@ function __give_form_add_donation_hidden_field( $form_id, $args, $form ) {
 	if ( give_is_setting_enabled( $custom_amount ) ) {
 		?>
 		<input type="hidden" name="give-form-minimum"
-		       value="<?php echo give_maybe_sanitize_amount( give_get_form_minimum_price( $form_id ) ); ?>" />
+		       value="<?php echo give_maybe_sanitize_amount( give_get_form_minimum_price( $form_id ) ); ?>"/>
 		<input type="hidden" name="give-form-maximum"
-		       value="<?php echo give_maybe_sanitize_amount( give_get_form_maximum_price( $form_id ) ); ?>" />
+		       value="<?php echo give_maybe_sanitize_amount( give_get_form_maximum_price( $form_id ) ); ?>"/>
 		<?php
 	}
 


### PR DESCRIPTION
## Description
This PR fix #3122

## How Has This Been Tested?
- Tested it by making the donation,
- Tested it with currency-switcher.


## Types of changes
 Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.