### PR TITLE
fix(shortcode): add missing options to [give_form_grid] generator #3147

### DIFF
--- a/includes/admin/shortcodes/shortcode-give-donation-grid.php
+++ b/includes/admin/shortcodes/shortcode-give-donation-grid.php
@@ -92,6 +92,13 @@ class Give_Shortcode_Donation_Grid extends Give_Shortcode_Generator {
 				'tooltip' => esc_attr__( 'Sets the number of donations form per row.', 'give' ),
 				'value'   => 12,
 			),
+			array(
+				'type'    => 'textbox',
+				'name'    => 'forms_ids',
+				'label'   => esc_attr__( 'Form IDs:', 'give' ),
+				'tooltip' => esc_attr__( 'Enter the list of Forms IDs that you want to show by comma separated.', 'give' ),
+				'value'   => '',
+			),
 		);
 	}
 }

--- a/includes/admin/shortcodes/shortcode-give-donation-grid.php
+++ b/includes/admin/shortcodes/shortcode-give-donation-grid.php
@@ -47,10 +47,11 @@ class Give_Shortcode_Donation_Grid extends Give_Shortcode_Generator {
 				'label'   => esc_attr__( 'Columns:', 'give' ),
 				'tooltip' => esc_attr__( 'Sets the number of donations per row.', 'give' ),
 				'options' => array(
-					'1' => esc_html__( '1', 'give' ),
-					'2' => esc_html__( '2', 'give' ),
-					'3' => esc_html__( '3', 'give' ),
-					'4' => esc_html__( '4', 'give' ),
+					'best-fit' => esc_html__( 'Best Fit', 'give' ),
+					'1'        => esc_html__( '1', 'give' ),
+					'2'        => esc_html__( '2', 'give' ),
+					'3'        => esc_html__( '3', 'give' ),
+					'4'        => esc_html__( '4', 'give' ),
 				),
 			),
 			array(

--- a/includes/admin/shortcodes/shortcode-give-donation-grid.php
+++ b/includes/admin/shortcodes/shortcode-give-donation-grid.php
@@ -53,6 +53,7 @@ class Give_Shortcode_Donation_Grid extends Give_Shortcode_Generator {
 					'3'        => esc_html__( '3', 'give' ),
 					'4'        => esc_html__( '4', 'give' ),
 				),
+				'value'   => 'best-fit'
 			),
 			array(
 				'type'    => 'listbox',
@@ -85,14 +86,11 @@ class Give_Shortcode_Donation_Grid extends Give_Shortcode_Generator {
 				),
 			),
 			array(
-				'type'    => 'listbox',
-				'name'    => 'display_style',
-				'label'   => esc_attr__( 'Display Style:', 'give' ),
-				'tooltip' => esc_attr__( 'Show form as modal window or redirect to a new page?', 'give' ),
-				'options' => array(
-					'redirect'     => esc_html__( 'Redirect', 'give' ),
-					'modal_reveal' => esc_html__( 'Modal', 'give' ),
-				),
+				'type'    => 'textbox',
+				'name'    => 'forms_per_page',
+				'label'   => esc_attr__( 'Forms Per Page:', 'give' ),
+				'tooltip' => esc_attr__( 'Sets the number of donations form per row.', 'give' ),
+				'value'   => 12,
 			),
 		);
 	}


### PR DESCRIPTION
## Description
PR to fix #3147 

## How Has This Been Tested?
Manually Tested by creating a new page and testing the **give_form_grid** shortcode with various parameter 

See the video to check on how I have tested this issues 

## Screenshots (jpeg or gifs if applicable):
Video Link: Adding Video

![image](https://user-images.githubusercontent.com/22215595/39523806-7f1fa4be-4e34-11e8-8fc2-f9529d8301ef.png)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.