### PR TITLE
fix(form): do not unformat the min/max amount using JS functions.

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -519,10 +519,7 @@ Give.form = {
 		 * @return {string}
 		 */
 		getMinimumAmount: function( $form ) {
-			return Give.fn.unFormatCurrency(
-				$form.find( 'input[name="give-form-minimum"]' ).val(),
-				Give.form.fn.getInfo( 'decimal_separator', $form )
-			);
+			return $form.find( 'input[name="give-form-minimum"]' ).val();
 		},
 
 		/**
@@ -534,10 +531,7 @@ Give.form = {
 		 * @return {string}
 		 */
 		getMaximumAmount: function( $form ) {
-			return Give.fn.unFormatCurrency(
-				$form.find( 'input[name="give-form-maximum"]' ).val(),
-				Give.form.fn.getInfo( 'decimal_separator', $form )
-			);
+			return $form.find( 'input[name="give-form-maximum"]' ).val();
 		},
 
 		/**


### PR DESCRIPTION
## Description
This PR fix #3122 

## How Has This Been Tested?
- Tested it with changing a thousand separators and decimal separator.
- Tested it with the custom amount and creating donations.

## Types of changes
 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.