### PR TITLE
fix(admin-form): prevent js notice when edit price type setting field #3161

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2964,7 +2964,7 @@ var give_setting_edit = false;
 		$poststuff.on('focusout', 'input.give-money-field, input.give-price-field', function () {
 			price_string = give_unformat_currency($(this).val(), false);
 
-			$(this).giveHintCss( 'hide', {});
+			$(this).giveHintCss( 'hide', {label: give_vars.price_format_guide.trim()});
 
 			// Back out.
 			if (give_unformat_currency('0', false) === give_unformat_currency($(this).val(), false)) {

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -402,7 +402,7 @@ function give_donation_limit( $field ) {
 					id="<?php echo $field_options['id']; ?>_give_donation_limit_<?php echo $amount_range; ?>"
 					data-range_type="<?php echo esc_attr( $amount_range ); ?>"
 					value="<?php echo esc_attr( $amount ); ?>"
-					placeholder="<?php echo $field_options['options'][ $amount_range ]; ?>"
+					placeholder="<?php echo $field_options['attributes']['placeholder']; ?>"
 				<?php echo give_get_custom_attributes( $field_options ); ?>
 			/>
 			<?php


### PR DESCRIPTION
## Description
This pr will resolve #3161 

## How Has This Been Tested?
Manually by edit admin form settings.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.