### PR TITLE
fix(admin-setting): prevent setting menu to appear on top of modal #3164

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -627,7 +627,7 @@ h2.give-nav-tab-wrapper {
 .give-sub-nav-tab-wrapper {
 	position: relative;
 	display: inline-block;
-	z-index: 9999;
+	z-index: 999;
 	float: left;
 
 	nav.give-sub-nav-tab {


### PR DESCRIPTION
Closes #3164 

## Description
Reduced the z-index of the sub navigation.

## Screenshot
![reducezindex](https://snag.gy/XOBgFs.jpg)

## Checklist:
- [x] My code is tested.