### PR TITLE
fix(db-update): prevent blank screen when updating 2.0.6 to 2.1.0 #3163

### DIFF
--- a/includes/admin/upgrades/class-give-updates.php
+++ b/includes/admin/upgrades/class-give-updates.php
@@ -245,11 +245,6 @@ class Give_Updates {
 
 		// Bailout.
 		if ( ! $this->get_total_update_count() ) {
-			return;
-		}
-
-		// Bailout.
-		if ( ! $this->get_total_update_count() ) {
 			// Show complete update message if still on update setting page.
 			if ( isset( $_GET['page'] ) && 'give-updates' === $_GET['page'] ) {
 				// Upgrades
@@ -304,7 +299,7 @@ class Give_Updates {
 		) {
 			delete_option( 'give_show_db_upgrade_complete_notice' );
 
-			wp_redirect( add_query_arg( array( 'give-db-update-completed' => 'give_db_upgrade_completed' ) ) );
+			wp_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-updates&give-db-update-completed=give_db_upgrade_completed' ) );
 			exit();
 		}
 	}

--- a/includes/admin/upgrades/views/db-upgrades-complete-metabox.php
+++ b/includes/admin/upgrades/views/db-upgrades-complete-metabox.php
@@ -1,0 +1,23 @@
+<div id="give-db-updates" data-resume-update="0">
+	<div class="postbox-container">
+		<div class="postbox">
+			<h2 class="hndle"><?php esc_html_e( 'Database Updates', 'give' ); ?></h2>
+			<div class="inside">
+				<div class="progress-container">
+					<p class="update-message"><strong><?php esc_html_e( 'Updates Completed.', 'give' ) ?></strong></p>
+					<div class="progress-content">
+						<div class="notice-wrap give-clearfix">
+							<div class="notice notice-success is-dismissible inline">
+								<p><?php esc_html_e( 'Give database updates completed successfully. Thank you for updating to the latest version!', 'give' ) ?>
+								</p>
+								<button type="button" class="notice-dismiss"></button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<!-- .inside -->
+		</div><!-- .postbox -->
+	</div>
+</div>
+<?php delete_option( 'give_show_db_upgrade_complete_notice' ); ?>

--- a/includes/admin/upgrades/views/upgrades.php
+++ b/includes/admin/upgrades/views/upgrades.php
@@ -19,11 +19,7 @@ $give_updates = Give_Updates::get_instance();
 <div class="wrap" id="poststuff">
 	<div id="give-updates">
 		<h1 id="give-updates-h1"><?php esc_html_e( 'Give - Updates', 'give' ); ?></h1>
-		<hr class="wp-header-end">
-
-		<div class="give-update-panel-content">
-			<p><?php printf( __( 'Give regularly receives new features, bug fixes, and enhancements. It is important to always stay up-to-date with latest version of Give core and its add-ons.  Please create a backup of your site before updating. To update add-ons be sure your <a href="%1$s">license keys</a> are activated.', 'give' ), 'https://givewp.com/my-account/' ); ?></p>
-		</div>
+		<hr class="wp-header-end"
 
 		<?php $db_updates = $give_updates->get_pending_db_update_count(); ?>
 		<?php if ( ! empty( $db_updates ) ) : ?>
@@ -33,6 +29,10 @@ $give_updates = Give_Updates::get_instance();
 			$resume_updates   = get_option( 'give_doing_upgrade' );
 			$width            = ! empty( $resume_updates ) ? $resume_updates['percentage'] : 0;
 			?>
+			<div class="give-update-panel-content">
+				<p><?php printf( __( 'Give regularly receives new features, bug fixes, and enhancements. It is important to always stay up-to-date with latest version of Give core and its add-ons.  Please create a backup of your site before updating. To update add-ons be sure your <a href="%1$s">license keys</a> are activated.', 'give' ), 'https://givewp.com/my-account/' ); ?></p>
+			</div>
+
 			<div id="give-db-updates" data-resume-update="<?php echo absint( $give_updates->is_doing_updates() ); ?>">
 				<div class="postbox-container">
 					<div class="postbox">
@@ -108,6 +108,7 @@ $give_updates = Give_Updates::get_instance();
 					</div><!-- .postbox -->
 				</div>
 			</div>
+			<?php else: include GIVE_PLUGIN_DIR . 'includes/admin/upgrades/views/db-upgrades-complete-metabox.php';?>
 		<?php endif; ?>
 
 		<?php $plugin_updates = $give_updates->get_total_plugin_update_count(); ?>

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -567,10 +567,10 @@ class Give_Donate_Form {
 	public function get_maximum_price() {
 
 		if ( ! isset( $this->maximum_price ) ) {
-			$this->maximum_price = give_get_meta( $this->ID, '_give_custom_amount_range_maximum', true );
+			$this->maximum_price = give_get_meta( $this->ID, '_give_custom_amount_range_maximum', true, 999999.99 );
 
 			if ( ! $this->is_custom_price_mode() ) {
-				$this->maximum_price = 999999.99;
+				$this->maximum_price = give_get_highest_price_option();
 			}
 		}
 


### PR DESCRIPTION
## Description
This pr will fix #3163 

## How Has This Been Tested?
Tested by running DB upgrades on the small database.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.