### PR TITLE
fix(admin-plugins): update notice shouldn't display when actively updating add-ons #3155

### DIFF
--- a/includes/admin/upgrades/class-give-updates.php
+++ b/includes/admin/upgrades/class-give-updates.php
@@ -589,6 +589,8 @@ class Give_Updates {
 	 * @access public
 	 */
 	public function __show_notice() {
+		$current_screen = get_current_screen();
+
 		// Bailout.
 		if ( ! current_user_can( 'manage_give_settings' ) ) {
 			return;
@@ -601,7 +603,7 @@ class Give_Updates {
 
 
 		// Bailout.
-		if ( isset( $_GET['page'] ) && 'give-updates' === $_GET['page'] ) {
+		if ( in_array( $current_screen->base, array( 'give_forms_page_give-updates', 'update-core' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
This will fix #3155 

## How Has This Been Tested?
Manually by visiting WordPress updates listing page

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.