### PR TITLE
fix(donation): Fix get_maximum_price() function

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -570,7 +570,7 @@ class Give_Donate_Form {
 			$this->maximum_price = give_get_meta( $this->ID, '_give_custom_amount_range_maximum', true, 999999.99 );
 
 			if ( ! $this->is_custom_price_mode() ) {
-				$this->maximum_price = give_get_highest_price_option();
+				$this->maximum_price = give_get_highest_price_option( $this->ID );
 			}
 		}
 


### PR DESCRIPTION
## Description
This will fix #3159

This is a quick fix and not related to any issue.

Donation was not possible because of the following error:

`Error: This form has a maximum donation amount of $0`

## How Has This Been Tested?
By making a successful donation.

## Screenshots:
![donationerror](https://snag.gy/d7SMX4.jpg)
