### PR TITLE
fix(donation): auto select the default level when donation form load for the first time #3184

### DIFF
--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -765,6 +765,17 @@ Basic Button Style
 }
 
 /*---------------------------------
+Add Button Style when display type is buttons
+-----------------------------------*/
+.give-form-type-multi {
+	.give-list-inline {
+		.give-default-level {
+			background: #767676;
+		}
+	}
+}
+
+/*---------------------------------
 Profile Editor Form
 -----------------------------------*/
 #give_profile_editor_form {


### PR DESCRIPTION
## Description
PR to fix #3184 

## How Has This Been Tested?
Tested by loading the donation form with Display type as  button, radio, and dropdown 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/39656359-ddffd0b4-501c-11e8-91e7-3e7f37e02e2d.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.