### PR TITLE
feat(admin-plugins): display inline notification before updating #2789

### DIFF
--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -277,7 +277,7 @@ function give_in_plugin_update_message( $data, $response ) {
 }
 
 // Display upgrade notice.
-add_action( 'in_plugin_update_message-' . GIVE_PLUGIN_BASENAME . '/give.php', 'give_in_plugin_update_message', 10, 2 );
+add_action( 'in_plugin_update_message-' . GIVE_PLUGIN_BASENAME, 'give_in_plugin_update_message', 10, 2 );
 
 
 /**
@@ -327,7 +327,7 @@ function give_parse_plugin_update_notice( $content, $new_version ) {
 	$check_for_notices = array(
 		$version_parts[0] . '.0',
 		$version_parts[0] . '.0.0',
-		$version_parts[0] . '.' . $version_parts[1],
+		$version_parts[0] . '.' . $version_parts[1] . '.' . '0',
 	);
 
 	// Regex to extract Upgrade notice from the readme.txt file.
@@ -355,7 +355,9 @@ function give_parse_plugin_update_notice( $content, $new_version ) {
 				$upgrade_notice .= '</p>';
 			}
 
-			break;
+			if ( ! empty( $upgrade_notice ) ) {
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #2789 and related to https://github.com/WordImpress/Give/issues/2789#issuecomment-386689458

## Description
This feature was failing because the comparison was made between version `2.1.0` and `2.1`, where `2.1.0` was written in the `readme.txt` file and `2.1` was calculated programmatically.

```php
version_compare( '2.1.0', '2.1', '=' );
```
evaluates to `false` 

This has been fixed.


## How Has This Been Tested?
I tested this in the same way as it was done [here](https://github.com/WordImpress/Give/pull/3033)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.