### PR TITLE
fix(compat): shortcode dropdown appearing in Elementor TinyMCE editor window #3171

### DIFF
--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -47,7 +47,16 @@ final class Give_Shortcode_Button {
 
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_assets' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_localize_scripts' ), 13 );
-			add_action( 'media_buttons', array( $this, 'shortcode_button' ) );
+			
+
+			/**
+			 * Filter to enable the give shortcode button. Default is true.
+			 *
+			 * @since 2.1.3
+			 */
+			if ( apply_filters( 'give_enable_give_shortcodes_button', true ) ) {
+				add_action( 'media_buttons', array( $this, 'shortcode_button' ) );
+			}
 		}
 
 		add_action( "wp_ajax_give_shortcode", array( $this, 'shortcode_ajax' ) );


### PR DESCRIPTION
Closes #3171 

## Description
This PR provides a filter to show/hide the Give Shortcode Button.

The following filter will hide the Give Shortcode Button on the Elementor's Editor page:

```php
add_filter( 'give_enable_give_shortcodes_button', function() {

	/**
	 * Is the plugin: Elementor activated?
	 */
	$is_elementor_active = in_array( 'elementor/elementor.php', get_option( 'active_plugins' ), true ) ? true : false;
	
	/**
	 * Is this Elementor's editor page?
	 */
	$is_elementor_page   = ( 'elementor' === give_clean( $_GET['action'] ) ) ? true : false;

	/**
	 * If Elementor plugin is activated and the user is
	 * on the Elementor's editor page, then hide
	 * Give Shortcodes Button.
	 */
	if ( $is_elementor_active && $is_elementor_page ) {

		return false;
	}

	return true;
});
```

## How Has This Been Tested?
I tested this with using the filter on the Elementor's editor page. It hid the Give Shortcodes button.
I also tested for console errors and PHP errors and there were none.

## Screenshots (jpeg or gifs if applicable):
![elementor](https://snag.gy/6uyqUX.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.