### PR TITLE
fix(admin-plugins): display activation banner immediately upon activation refresh #3153

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -492,10 +492,11 @@ class Give_Addon_Activation_Banner {
 	 * Get list of add-on last activated.
 	 *
 	 * @since 2.1.0
+	 *
 	 * @return mixed|array
 	 */
 	public function get_recently_activated_addons() {
-		return get_option( 'give_recently_activated_addons', array() );
+		return give_get_recently_activated_addons();
 	}
 
 	/**

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -142,9 +142,11 @@ function give_recently_activated_addons() {
 				break;
 		}
 
-		$give_addons = give_get_recently_activated_addons();
 
 		if ( ! empty( $plugins ) ) {
+
+			$give_addons = give_get_recently_activated_addons();
+
 			foreach ( $plugins as $plugin ) {
 				// Get plugins which has 'Give-' as prefix.
 				if ( stripos( $plugin, 'Give-' ) !== false ) {

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -142,8 +142,9 @@ function give_recently_activated_addons() {
 				break;
 		}
 
+		$give_addons = give_get_recently_activated_addons();
+
 		if ( ! empty( $plugins ) ) {
-			$give_addons = array();
 			foreach ( $plugins as $plugin ) {
 				// Get plugins which has 'Give-' as prefix.
 				if ( stripos( $plugin, 'Give-' ) !== false ) {
@@ -399,3 +400,14 @@ function give_plugin_notice_css() {
 }
 
 add_action( 'admin_head', 'give_plugin_notice_css' );
+
+/**
+ * Get list of add-on last activated.
+ *
+ * @since 2.1.3
+ *
+ * @return mixed|array list of recently activated add-on
+ */
+function give_get_recently_activated_addons() {
+	return get_option( 'give_recently_activated_addons', array() );
+}


### PR DESCRIPTION
## Description
PR to fix #3153 

## How Has This Been Tested?
Manually tested by activating the Give Add-on one by one and multi add-on at once 

## Screenshot 
Video Link: https://screencast-o-matic.com/watch/cFhj6abtAP

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.