### PR TITLE
fix(give-api): Make Earnings and Donations Types Respect Daterange as intended #3191

### DIFF
--- a/includes/api/class-give-api.php
+++ b/includes/api/class-give-api.php
@@ -1375,7 +1375,15 @@ class Give_API {
 				if ( get_post_type( $args['form'] ) == 'give_forms' ) {
 					$form_info               = get_post( $args['form'] );
 					$earnings['earnings'][0] = array(
-						$form_info->post_name => give_get_form_earnings_stats( $args['form'] ),
+						$form_info->post_name => $this->stats->get_earnings(
+								$args['form'],
+								is_numeric( $args['startdate'] )
+									? strtotime( $args['startdate'] )
+									: $args['startdate'],
+								is_numeric( $args['enddate'] )
+									? strtotime( $args['enddate'] )
+									: $args['enddate']
+						),
 					);
 				} else {
 					$error['error'] = sprintf( /* translators: %s: form */


### PR DESCRIPTION
## Description
This PR will resolve #3191

## How Has This Been Tested?
Manually by run stat API request for single form and earning type.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.