### PR TITLE
feat(form): ensure w3c validations for donation forms #3139

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -245,6 +245,7 @@ function give_load_gateway( form_object, payment_mode ) {
 	var loading_element = jQuery( form_object ).find( '#give-payment-mode-select .give-loading-text' );
 	var give_total = jQuery( form_object ).find( '#give-amount' ).val();
 	var give_form_id = jQuery( form_object ).find( 'input[name="give-form-id"]' ).val();
+	var give_form_id_prefix = jQuery( form_object ).find( 'input[name="give-form-id-prefix"]' ).val();
 
 	// Show the ajax loader
 	loading_element.fadeIn();
@@ -266,6 +267,7 @@ function give_load_gateway( form_object, payment_mode ) {
 			action: 'give_load_gateway',
 			give_total: give_total,
 			give_form_id: give_form_id,
+			give_form_id_prefix: give_form_id_prefix,
 			give_payment_mode: payment_mode
 		},
 		function( response ) {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1342,7 +1342,8 @@ add_action( 'give_donation_form_login_fields', 'give_get_login_fields', 10, 1 );
  */
 function give_payment_mode_select( $form_id ) {
 
-	$gateways = give_get_enabled_payment_gateways( $form_id );
+	$gateways  = give_get_enabled_payment_gateways( $form_id );
+	$id_prefix = ! empty( $args['id_prefix'] ) ? $args['id_prefix'] : '';
 
 	/**
 	 * Fires while selecting payment gateways, before the fields.
@@ -1377,7 +1378,7 @@ function give_payment_mode_select( $form_id ) {
 		<div id="give-payment-mode-wrap">
 			<?php
 			/**
-			 * Fires while selecting payment gateways, befire the gateways list.
+			 * Fires while selecting payment gateways, before the gateways list.
 			 *
 			 * @since 1.7
 			 */
@@ -1400,7 +1401,7 @@ function give_payment_mode_select( $form_id ) {
 					$checked_class = $checked ? ' class="give-gateway-option-selected"' : ''; ?>
 					<li<?php echo $checked_class ?>>
 						<input type="radio" name="payment-mode" class="give-gateway"
-							   id="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
+							   id="give-gateway-<?php echo esc_attr( $gateway_id . '-' . $id_prefix ); ?>"
 							   value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
 
 						<?php
@@ -1409,7 +1410,7 @@ function give_payment_mode_select( $form_id ) {
 							$label = $gateways_label[ $gateway_id ];
 						}
 						?>
-						<label for="give-gateway-<?php echo esc_attr( $gateway_id ) . '-' . $form_id; ?>"
+						<label for="give-gateway-<?php echo esc_attr( $gateway_id . '-' . $id_prefix ); ?>"
 							   class="give-gateway-option"
 							   id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $label ); ?></label>
 					</li>

--- a/includes/gateways/actions.php
+++ b/includes/gateways/actions.php
@@ -38,13 +38,21 @@ add_action( 'give_gateway_select', 'give_process_gateway_select' );
  * @return void
  */
 function give_load_ajax_gateway() {
-	if ( isset( $_POST['give_payment_mode'] ) ) {
+
+	$post_data = give_clean( $_POST ); // WPCS: input var ok.
+
+	if ( isset( $post_data['give_payment_mode'] ) ) {
+
+		$args = array(
+			'id_prefix' => $post_data['give_form_id_prefix'],
+		);
+
 		/**
 		 * Fire to render donation form.
 		 *
 		 * @since 1.7
 		 */
-		do_action( 'give_donation_form', $_POST['give_form_id'] );
+		do_action( 'give_donation_form', $post_data['give_form_id'], $args );
 
 		exit();
 	}


### PR DESCRIPTION
## Description
This PR is created to support Stripe Elements issue https://github.com/WordImpress/Give-Stripe/issues/178

## How Has This Been Tested?
I've tested this PR with donation forms having CC fields created by Stripe Elements and Google/Apple Pay Buttons created by Payment Request API.
I've also tested it with 5 donation forms on a single page with 2 same donation forms to be used twice on the single page.

## Types of changes
Bug fix (a non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.