### PR TITLE
fix(compat): beaver builder conflict preventing from seeing page builder element on backend. #3207

### DIFF
--- a/includes/admin/shortcodes/abstract-shortcode-generator.php
+++ b/includes/admin/shortcodes/abstract-shortcode-generator.php
@@ -282,22 +282,21 @@ abstract class Give_Shortcode_Generator {
 	protected function generate_post( $field ) {
 
 		$args = array(
-			'post_type'      => 'post',
-			'orderby'        => 'title',
-			'order'          => 'ASC',
-			'posts_per_page' => 30,
+			'post_type'        => 'post',
+			'orderby'          => 'title',
+			'order'            => 'ASC',
+			'posts_per_page'   => 30,
+			'suppress_filters' => false,
 		);
 
 		$args    = wp_parse_args( (array) $field['query_args'], $args );
-		$posts   = new WP_Query( $args );
+
+		$posts   = get_posts( $args );
 		$options = array();
 
-		if ( $posts->have_posts() ) {
-			while ( $posts->have_posts() ) {
-				$posts->the_post();
-				$post_title = get_the_title();
-				$post_id = get_the_ID();
-				$options[ absint( $post_id ) ] = ( empty( $post_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $post_id ) : $post_title );
+		if ( ! empty( $posts ) ) {
+			foreach ( $posts as $post ) {
+				$options[ absint( $post->ID ) ] = empty( $post->post_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $post->ID ) : apply_filters( 'the_title', $post->post_title );
 			}
 
 			$field['type']    = 'listbox';


### PR DESCRIPTION
Closes #3207 

Related #2729 

## Description
Fixes the plugin conflict between Give Core and Beaver Builder.

I have replaced `WP_Query` with `get_posts()` and set `suppress_filters` parameter to `true`. This way the Donation Form Goal shortcode also works.

## How Has This Been Tested?
By activating Give Core and Beaver Builder side by side.

## Video
https://www.useloom.com/share/8b71fb474e894298b9a6afc67f49bd56

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.