### PR TITLE
fix(admin-tool): getting PHP notices when exporting donor in lower PHP version #3222

### DIFF
--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -94,7 +94,7 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 			return $filename;
 		}
 
-		$forms = empty( $_GET['forms'] ) ? false : absint( $_GET['forms'] );
+		$forms = empty( $_GET['forms'] ) ? 0 : absint( $_GET['forms'] );
 
 		if ( $forms ) {
 			$slug     = get_post_field( 'post_name', get_post( $forms ) );

--- a/includes/admin/tools/export/class-batch-export-donors.php
+++ b/includes/admin/tools/export/class-batch-export-donors.php
@@ -83,20 +83,21 @@ class Give_Batch_Donors_Export extends Give_Batch_Export {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param $filename
-	 * @param $export_type
+	 * @param string $filename File name.
+	 * @param string $export_type export type.
 	 *
-	 * @return string
+	 * @return string $filename file name.
 	 */
-	function give_export_filename( $filename, $export_type ) {
-
+	public function give_export_filename( $filename, $export_type ) {
 
 		if ( $this->export_type !== $export_type ) {
 			return $filename;
 		}
 
-		if ( ! empty( (int) $_GET['forms'] ) ) {
-			$slug     = get_post_field( 'post_name', get_post( absint( $_GET['forms'] ) ) );
+		$forms = empty( $_GET['forms'] ) ? false : absint( $_GET['forms'] );
+
+		if ( $forms ) {
+			$slug     = get_post_field( 'post_name', get_post( $forms ) );
 			$filename = 'give-export-donors-' . $slug . '-' . date( 'm-d-Y' );
 		} else {
 			$filename = 'give-export-donors-all-forms-' . date( 'm-d-Y' );


### PR DESCRIPTION
## Description
PR to fix #3222 

## How Has This Been Tested?
Tested by manually exportin donor and donation in PHP version 5.3, 5.4 and 7.0


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.