### PR TITLE
fix(donation): do not parse decimal separator value to integer.

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -41,9 +41,9 @@ export default Give = {
 			// Global currency setting.
 			var format_args = {
 				symbol: '',
-				decimal: parseInt( give_global_vars.decimal_separator ),
+				decimal: give_global_vars.decimal_separator,
 				thousand: give_global_vars.thousands_separator,
-				precision: give_global_vars.number_decimals,
+				precision: parseInt( give_global_vars.number_decimals ),
 				currency: give_global_vars.currency
 			};
 


### PR DESCRIPTION
## Description
This PR fix #3238 

## How Has This Been Tested?
- Manully.

## Types of changes
 Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.