### PR TITLE
fix(cli): update code to support lower PHP version

### DIFF
--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -1194,7 +1194,8 @@ class GIVE_CLI_COMMAND {
 		 * Convert the comma-separated string of Give-addons in the
 		 * excluded list into array.
 		 */
-		if ( ! empty( ( $addon_names = WP_CLI\Utils\get_flag_value( $assoc, 'exclude', array() ) ) ) ) {
+		$addon_names = WP_CLI\Utils\get_flag_value( $assoc, 'exclude', array() );
+		if ( ! empty( $addon_names ) ) {
 			$addon_names = array_map( 'trim', explode( ',', $addon_names ) );
 		}
 


### PR DESCRIPTION
## Description
PR to fix PHP notices in lower PHP version 

## How Has This Been Tested?
Manually tested by running CLI command

## Debug log
<details>
[22-May-2018 05:48:53 UTC] PHP Parse error:  syntax error, unexpected '(' in /app/public/wp-content/plugins/Give/includes/class-give-cli-commands.php on line 1197
[22-May-2018 05:48:53 UTC] PHP Stack trace:
[22-May-2018 05:48:53 UTC] PHP   1. {main}() /usr/local/bin/wp:0
[22-May-2018 05:48:53 UTC] PHP   2. include() /usr/local/bin/wp:4
[22-May-2018 05:48:53 UTC] PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:8
[22-May-2018 05:48:53 UTC] PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/php/wp-cli.php:23
[22-May-2018 05:48:53 UTC] PHP   5. WP_CLI\Bootstrap\LaunchRunner->process() phar:///usr/local/bin/wp/php/bootstrap.php:75
[22-May-2018 05:48:53 UTC] PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/php/WP_CLI/Bootstrap/LaunchRunner.php:23
[22-May-2018 05:48:53 UTC] PHP   7. WP_CLI\Runner->load_wordpress() phar:///usr/local/bin/wp/php/WP_CLI/Runner.php:983
[22-May-2018 05:48:53 UTC] PHP   8. require() phar:///usr/local/bin/wp/php/WP_CLI/Runner.php:1046
[22-May-2018 05:48:53 UTC] PHP   9. include_once() /app/public/wp-settings.php:305
[22-May-2018 05:48:53 UTC] PHP  10. Give() /app/public/wp-content/plugins/Give/give.php:671
[22-May-2018 05:48:53 UTC] PHP  11. Give::instance() /app/public/wp-content/plugins/Give/give.php:668
[22-May-2018 05:48:53 UTC] PHP  12. Give->__construct() /app/public/wp-content/plugins/Give/give.php:265
[22-May-2018 05:48:53 UTC] PHP  13. Give->includes() /app/public/wp-content/plugins/Give/give.php:288

</details>


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.