### PR TITLE
 fix(admin-donation): reset email receipt donation button popup should open using modal api #3244

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -526,7 +526,23 @@ var give_setting_edit = false;
 
 		resend_receipt: function () {
 			$('body').on('click', '#give-resend-receipt', function (e) {
-				return confirm(give_vars.resend_receipt);
+				let that = this;
+
+				e.preventDefault();
+
+				new GiveConfirmModal(
+					{
+						modalContent: {
+							title: give_vars.confirm_action,
+							desc: give_vars.resend_receipt,
+						},
+						successConfirm: function () {
+							window.location.assign( $( that ).attr( 'href' ) );
+
+							return;
+						}
+					}
+				).render();
 			});
 		},
 


### PR DESCRIPTION
Closes #3244 

## Description
Replace native confirm dialog with Give Modal JS

## How Has This Been Tested?
By re-sending receipt from within the payment details page.

## Screenshots
![resendmodal](https://snag.gy/PLCpyh.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.