### PR TITLE
fix(admin-settings): Disables radio button if payment gateway is disa…

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -615,6 +615,7 @@ var give_setting_edit = false;
 	var Give_Settings = {
 
 		init: function () {
+			this.toggle_gateways();
 			this.setting_change_country();
 			this.toggle_options();
 			this.main_setting_update_notice();
@@ -623,6 +624,47 @@ var give_setting_edit = false;
 			this.changeAlert();
 			this.detectSettingsChange();
 			this.sequentialDonationIDPreview();
+		},
+
+
+		/**
+		 * Disables the default gateway radio button if the
+		 * gateway is disabled.
+		 */
+		toggle_gateways: function() {
+			let checkbox = $( '.gateways-checkbox' );
+
+			checkbox.on( 'click', function() {
+
+				// Get the radio button object related to this checkbox.
+				let radio       = $( this ).prev( '.gateways-radio' );
+
+				// Get the checked value of the current checbox.
+				let checked     = this.checked;
+
+				// Get all the checkbox that are checked.
+				let checked_cbs = $( '.gateways-checkbox:checked' );
+
+				// Get the count of all the checked checkbox.
+				let count_cbs   = checked_cbs.length;
+
+				/**
+				 * If there is only one checked checkbox, then
+				 * make that gateway the default gateway.
+				 */
+				if ( 1 === count_cbs ) {
+					checked_cbs
+						.prev( '.gateways-radio' )
+						.attr( 'checked', 'checked' );
+				} else {
+					if ( this.checked ) {
+						radio.removeAttr( 'disabled' );
+						radio.removeAttr( 'checked' );
+					} else {
+						radio.attr( 'disabled', 'disabled' );
+					}
+				}
+			});
 		},
 
 		/**

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -320,10 +320,11 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 				);
 
 				printf(
-					'<input class="gateways-radio" type="radio" name="%1$s" value="%2$s" %3$s>',
+					'<input class="gateways-radio" type="radio" name="%1$s" value="%2$s" %3$s %4$s>',
 					'default_gateway',
 					$key,
-					checked( $key, $default_gateway, false )
+					checked( $key, $default_gateway, false ),
+					disabled( NULL, $enabled, false )
 				);
 
 				printf(


### PR DESCRIPTION
Closes #2939 

## Description
This PR disables the default gateway radio button if the gateway is not enabled.

## How Has This Been Tested?
By enabling/disabling the various payment gateways in different combinations.

## Screenshots (jpeg or gifs if applicable):
![paymentgateways](https://snag.gy/reV5un.jpg)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.