### PR TITLE
fix(donation): prevent WP users from being created if donation fails #3035

### DIFF
--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1423,10 +1423,11 @@ function give_validate_required_form_fields( $form_id ) {
  * @return void
  */
 function give_donation_form_validate_name_fields( $post_data ) {
-	$is_alpha_first_name = ctype_alpha( $post_data['give_first'] ) ? true : false;
-	$is_alpha_last_name  = ctype_alpha( $post_data['give_last'] ) ? true : false;
+
+	$is_alpha_first_name = ( ! is_email( $post_data['give_first'] ) && ! preg_match( '~[0-9]~', $post_data['give_first'] ) );
+	$is_alpha_last_name  = ( ! is_email( $post_data['give_last'] ) && ! preg_match( '~[0-9]~', $post_data['give_last'] ) );
 
 	if ( ! $is_alpha_first_name || ( ! empty( $post_data['give_last'] ) && ! $is_alpha_last_name ) ) {
-		give_set_error( 'invalid_name', esc_html__( '<First Name | Last Name> cannot contain email address, numbers or special characters.', 'give' ) );
+		give_set_error( 'invalid_name', esc_html__( '<First Name | Last Name> cannot contain email address or numbers.', 'give' ) );
 	}
 }


### PR DESCRIPTION
## Description
This PR resolves #3035 

## How Has This Been Tested?
I've fixed the issue with Latin characters so that it won't strict those users from donating their donations.

## Screenshots (jpeg or gifs if applicable):
I've performed a successful donation with Chinese letters.
![image](https://user-images.githubusercontent.com/1852711/40462904-c037dd5c-5f2f-11e8-92df-6d46ece0594d.png)


## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.