### PR TITLE
fix(admin-setting): Disable license tab if not addon is active

### DIFF
--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -413,3 +413,23 @@ add_action( 'admin_head', 'give_plugin_notice_css' );
 function give_get_recently_activated_addons() {
 	return get_option( 'give_recently_activated_addons', array() );
 }
+
+/**
+ * Returns if at least one Give addon is activated.
+ *
+ * @since 2.1.4
+ *
+ * @return boolean
+ */
+function give_any_give_addon_activated() {
+
+	$activated_plugins = get_option( 'active_plugins' );
+
+	foreach ( $activated_plugins as $activated_plugin ) {
+		if ( false !== stripos( $activated_plugin, 'Give-' ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/includes/admin/settings/class-settings-license.php
+++ b/includes/admin/settings/class-settings-license.php
@@ -10,7 +10,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'Give_Settings_License' ) ) :

--- a/includes/admin/settings/class-settings-license.php
+++ b/includes/admin/settings/class-settings-license.php
@@ -30,6 +30,10 @@ if ( ! class_exists( 'Give_Settings_License' ) ) :
 			$this->label = esc_html__( 'Licenses', 'give' );
 
 			parent::__construct();
+
+			// Filter to remove the license tab.
+			add_filter( 'give-settings_tabs_array', array( $this, 'remove_license_tab' ), 9999999, 1 );
+
 		}
 
 		/**
@@ -58,6 +62,29 @@ if ( ! class_exists( 'Give_Settings_License' ) ) :
 
 			// Output.
 			return $settings;
+		}
+
+		/**
+		 * Remove the license tab if no Give addon
+		 * is activated.
+		 *
+		 * @param array $tabs Give Settings Tabs.
+		 *
+		 * @since 2.1.4
+		 *
+		 * @return array
+		 */
+		public function remove_license_tab( $tabs ) {
+
+			/**
+			 * Remove the license tab if no Give addon
+			 * is activated.
+			 */
+			if ( ! give_any_give_addon_activated() ) {
+				unset( $tabs['licenses'] );
+			}
+
+			return $tabs;
 		}
 	}
 


### PR DESCRIPTION
Closes #3254 

## Description
In this PR, it checks if at least 1 Give addon is active. If no Give addon is active, then the License page is removed.

## How Has This Been Tested?
By enabling/disabling Give addons.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.