### PR TITLE
fix(install): verify addon Give dependency before update #3217

### DIFF
--- a/give.php
+++ b/give.php
@@ -466,6 +466,7 @@ if ( ! class_exists( 'Give' ) ) :
 			require_once GIVE_PLUGIN_DIR . 'includes/class-give-tooltips.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/class-notices.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/class-give-translation.php';
+			require_once GIVE_PLUGIN_DIR . 'includes/class-give-readme-parser.php';
 
 			require_once GIVE_PLUGIN_DIR . 'includes/class-give-scripts.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/class-give-roles.php';

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -379,7 +379,7 @@ function __give_verify_addon_dependency_before_update( $error, $hook_extra ) {
 		return new WP_Error(
 			'Give_Addon_Update_Error',
 			sprintf(
-				__( 'You need Give version %s to update this plugin.', 'give' ),
+				__( 'Give version %s is required to update this add-on.', 'give' ),
 				$give_min_version
 			)
 		);

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -332,3 +332,60 @@ function give_update_log_form_id( $args ) {
 }
 
 add_action( 'give_update_log_form_id', 'give_update_log_form_id' );
+
+/**
+ * Verify addon dependency before addon update
+ *
+ * @since 2.1.4
+ *
+ * @param $error
+ * @param $hook_extra
+ *
+ * @return WP_Error
+ */
+function __give_verify_addon_dependency_before_update( $error, $hook_extra ) {
+	// Bailout.
+	if ( is_wp_error( $error ) ) {
+		return $error;
+	}
+
+	$plugin_base    = strtolower( $hook_extra['plugin'] );
+	$licensed_addon = array_map( 'strtolower', Give_License::get_licensed_addons() );
+
+	// Skip if not a Give addon.
+	if ( ! in_array( $plugin_base, $licensed_addon ) ) {
+		return $error;
+	}
+
+	$plugin_base = strtolower( $plugin_base );
+	$plugin_slug = str_replace( '.php', '', basename( $plugin_base ) );
+
+	/**
+	 * Filter the addon readme.txt url
+	 *
+	 * @since 2.1.4
+	 */
+	$url = apply_filters(
+		'give_addon_readme_file_url',
+		"https://givewp.com/downloads/plugins/{$plugin_slug}/readme.txt",
+		$plugin_slug
+	);
+
+	$parser           = new Give_Readme_Parser( $url );
+	$give_min_version = $parser->requires_at_least();
+
+
+	if ( version_compare( GIVE_VERSION, $give_min_version, '<' ) ) {
+		return new WP_Error(
+			'Give_Addon_Update_Error',
+			sprintf(
+				__( 'You need Give version %s to update this plugin.', 'give' ),
+				$give_min_version
+			)
+		);
+	}
+
+	return $error;
+}
+
+add_filter( 'upgrader_pre_install', '__give_verify_addon_dependency_before_update', 10, 2 );

--- a/includes/class-give-readme-parser.php
+++ b/includes/class-give-readme-parser.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Give Readme Parser
+ *
+ * @package     Give
+ * @subpackage  Admin/Readme_Parser
+ * @copyright   Copyright (c) 2018, WordImpress
+ * @license     https://opensource.org/licenses/gpl-license GNU Public License
+ * @since       2.1.4
+ */
+class Give_Readme_Parser{
+	/**
+	 * Readme file url
+	 *
+	 * @since  2.1.4
+	 * @access private
+	 * @var
+	 */
+	private $file_url;
+
+	/**
+	 * Readme file content
+	 *
+	 * @since  2.1.4
+	 * @access private
+	 * @var
+	 */
+	private $file_content;
+
+	/**
+	 * Give_Readme_Parser constructor.
+	 *
+	 * @param string $file_url
+	 */
+	function __construct( $file_url ) {
+		$this->file_url = $file_url;
+		$this->file_content = ! empty( $this->file_url ) ? file_get_contents( $this->file_url ) : '';
+	}
+
+	/**
+	 * Get required Give core minimum version for addon
+	 *
+	 * @since 2.1.4
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function requires_at_least() {
+		// Regex to extract Give core minimum version from the readme.txt file.
+		preg_match('|Give requires at least:(.*)|i', $this->file_content, $_requires_at_least );
+
+		if( is_array( $_requires_at_least ) && 1 < count( $_requires_at_least ) ) {
+			$_requires_at_least = trim( $_requires_at_least[1] );
+		}else{
+			$_requires_at_least = null;
+		}
+
+		return $_requires_at_least;
+	}
+}

--- a/includes/class-give-readme-parser.php
+++ b/includes/class-give-readme-parser.php
@@ -47,7 +47,7 @@ class Give_Readme_Parser{
 	 */
 	public function requires_at_least() {
 		// Regex to extract Give core minimum version from the readme.txt file.
-		preg_match('|Give requires at least:(.*)|i', $this->file_content, $_requires_at_least );
+		preg_match('|Requires Give:(.*)|i', $this->file_content, $_requires_at_least );
 
 		if( is_array( $_requires_at_least ) && 1 < count( $_requires_at_least ) ) {
 			$_requires_at_least = trim( $_requires_at_least[1] );

--- a/includes/class-give-readme-parser.php
+++ b/includes/class-give-readme-parser.php
@@ -33,8 +33,8 @@ class Give_Readme_Parser{
 	 * @param string $file_url
 	 */
 	function __construct( $file_url ) {
-		$this->file_url = $file_url;
-		$this->file_content = ! empty( $this->file_url ) ? file_get_contents( $this->file_url ) : '';
+		$this->file_url     = $file_url;
+		$this->file_content = wp_remote_retrieve_body( wp_remote_get( $this->file_url ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
This pr will resolve #3217

## How Has This Been Tested?
I tested this pr by updating multiple licensed Give addon.
Testing video: https://drive.google.com/file/d/1Jrdy9wQdiQirzid0CncdGmO9RyiSoECL/view?
usp=sharing
Snippet link: https://givewp.slack.com/files/U1DDJMUTV/FAWLZ3GSD/give_pull_3268.php
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.