### PR TITLE
fix(donation): dismiss button should work when rendering Give notice using the JS.

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -93,7 +93,7 @@ jQuery( function( $ ) {
 	}
 
 	// Button to close notices on front-end.
-	jQuery(document).on( 'click', '.give-notice-close', function() {
+	$(document).on( 'click', '.give-notice-close', function() {
 		$(this).hide();
 		const notice_container = $(this).closest( '.give_notices' );
 		notice_container.slideUp();

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -93,8 +93,7 @@ jQuery( function( $ ) {
 	}
 
 	// Button to close notices on front-end.
-	const give_notice_close = jQuery( '.give-notice-close' );
-	give_notice_close.on( 'click', function() {
+	jQuery(document).on( 'click', '.give-notice-close', function() {
 		$(this).hide();
 		const notice_container = $(this).closest( '.give_notices' );
 		notice_container.slideUp();

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -93,7 +93,7 @@ jQuery( function( $ ) {
 	}
 
 	// Button to close notices on front-end.
-	$(document).on( 'click', '.give-notice-close', function() {
+	$('body').on( 'click', '.give-notice-close', function() {
 		$(this).hide();
 		const notice_container = $(this).closest( '.give_notices' );
 		notice_container.slideUp();


### PR DESCRIPTION
## Description
This PR fix #3278 

## How Has This Been Tested?
- Tested it by creating dimiss notices and removing them.
- Tested it with https://github.com/WordImpress/Give-Currency-Switcher/issues/128 

## Types of changes
 Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.