### PR TITLE
fix(admin-form): Give's bottom text overlapping on the Give's banner when storefront theme is activated. #3274

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -153,6 +153,10 @@ div.give-field-description,
 	display: none;
 }
 
+.tablenav {
+	height: auto;
+}
+
 // CMB2 Checkbox Revised Styles
 .cmb-type-checkbox .cmb-td {
 	width: 80%;


### PR DESCRIPTION
Closes #3274 

## Description
Fixes overlapping of Give footer on WooCommerce Storefront notice.

## How Has This Been Tested?
By reloading the page after running `npm run dev`

## Screenshots (jpeg or gifs if applicable):
![tablenav](https://snag.gy/STC9xp.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.