### PR TITLE
fix(admin-shortcode): Total goal attribute should be required field for [give_totals] #3060

### DIFF
--- a/includes/admin/shortcodes/shortcode-give-totals.php
+++ b/includes/admin/shortcodes/shortcode-give-totals.php
@@ -93,7 +93,7 @@ class Give_Shortcode_Totals extends Give_Shortcode_Generator {
 				'label'    => __( 'Total Goal:', 'give' ),
 				'tooltip'  => __( 'Enter the total goal amount that you would like to display.', 'give' ),
 				'required' => array(
-					'alert' => esc_html__( 'You must first enter the total goal amount.', 'give' ),
+					'alert' => esc_html__( 'Please enter a valid total goal amount.', 'give' ),
 				),
 			),
 			array(

--- a/includes/admin/shortcodes/shortcode-give-totals.php
+++ b/includes/admin/shortcodes/shortcode-give-totals.php
@@ -72,7 +72,7 @@ class Give_Shortcode_Totals extends Give_Shortcode_Generator {
 			array(
 				'type' => 'container',
 				'html' => sprintf( '<p class="give-totals-shortcode-container-message">%s</p>',
-					 __( 'This shortcode shows the total amount raised towards a custom goal for one or several forms regardless of whether they have goals enabled or not.', 'give' )
+					__( 'This shortcode shows the total amount raised towards a custom goal for one or several forms regardless of whether they have goals enabled or not.', 'give' )
 				),
 			),
 			array(
@@ -80,18 +80,21 @@ class Give_Shortcode_Totals extends Give_Shortcode_Generator {
 				'html' => sprintf( '<p class="strong margin-top">%s</p>', __( 'Shortcode Configuration', 'give' ) ),
 			),
 			array(
-				'type'        => 'textbox',
-				'name'        => 'ids',
-				'label'       => __( 'Donation Form IDs:', 'give' ),
-				'tooltip'     => __( 'Enter the IDs separated by commas for the donation forms you would like to combine within the totals.', 'give' ),
+				'type'    => 'textbox',
+				'name'    => 'ids',
+				'label'   => __( 'Donation Form IDs:', 'give' ),
+				'tooltip' => __( 'Enter the IDs separated by commas for the donation forms you would like to combine within the totals.', 'give' ),
 			),
 			$category_lists,
 			$tag_lists,
 			array(
-				'type'    => 'textbox',
-				'name'    => 'total_goal',
-				'label'   => __( 'Total Goal:', 'give' ),
-				'tooltip' => __( 'Enter the total goal amount that you would like to display.', 'give' ),
+				'type'     => 'textbox',
+				'name'     => 'total_goal',
+				'label'    => __( 'Total Goal:', 'give' ),
+				'tooltip'  => __( 'Enter the total goal amount that you would like to display.', 'give' ),
+				'required' => array(
+					'alert' => esc_html__( 'You must first enter the goal amount total.', 'give' ),
+				),
 			),
 			array(
 				'type'      => 'textbox',

--- a/includes/admin/shortcodes/shortcode-give-totals.php
+++ b/includes/admin/shortcodes/shortcode-give-totals.php
@@ -93,7 +93,7 @@ class Give_Shortcode_Totals extends Give_Shortcode_Generator {
 				'label'    => __( 'Total Goal:', 'give' ),
 				'tooltip'  => __( 'Enter the total goal amount that you would like to display.', 'give' ),
 				'required' => array(
-					'alert' => esc_html__( 'You must first enter the goal amount total.', 'give' ),
+					'alert' => esc_html__( 'You must first enter the total goal amount.', 'give' ),
 				),
 			),
 			array(


### PR DESCRIPTION
## Description
PR to fix #3060 

## How Has This Been Tested?
Tested by entering the shortcode by Goal amount 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/40681538-0a346710-63a7-11e8-95e7-a99a71cffa20.png)



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.