### PR TITLE
 fix(form): ensure state field styles don't break when changing country #3255

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -218,16 +218,16 @@ window.give_open_form_modal = function ( $form_wrap, $form ) {
 	} );
 };
 
-
 /**
  * Floating Labels Custom Events
  */
+var give_float_labels;
 window.give_fl_trigger = function() {
 	if ( give_float_labels instanceof FloatLabels ) {
 		give_float_labels.rebuild();
 	}
 	else {
-		var give_float_labels = new FloatLabels( '.float-labels-enabled', {
+		give_float_labels = new FloatLabels( '.float-labels-enabled', {
 			exclude: '#give-amount, .give-select-level, [multiple]',
 			prioritize: 'placeholder',
 			prefix: 'give-fl-',


### PR DESCRIPTION
## Description
PR to fix #3255 

## How Has This Been Tested?
Tested by changing the donation country fields also by changing the gateway and then changing the country fields again 


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.