### PR TITLE
fix(admin-form): set donation amount as minimum amount if it is less then minimum amount.

### DIFF
--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -312,6 +312,7 @@ add_filter( 'months_dropdown_results', 'give_remove_month_filter', 99 );
  * Updates price when saving post
  *
  * @since 1.0
+ * @since 2.1.4 If the donation amount is less than the Minimum amount then set the donation amount as Donation minimum amount.
  *
  * @param int $post_id Download (Post) ID
  *
@@ -330,6 +331,15 @@ function give_price_save_quick_edit( $post_id ) {
 
 	if ( isset( $_REQUEST['_give_regprice'] ) ) {
 		give_update_meta( $post_id, '_give_set_price', give_sanitize_amount_for_db( strip_tags( stripslashes( $_REQUEST['_give_regprice'] ) ) ) );
+	}
+
+	// Override the Donation minimum amount.
+	if (
+		isset( $_REQUEST['_give_custom_amount'], $_REQUEST['_give_set_price'], $_REQUEST['_give_custom_amount_range'] )
+		&& give_is_setting_enabled( $_REQUEST['_give_custom_amount'] )
+		&& $_REQUEST['_give_set_price'] < $_REQUEST['_give_custom_amount_range']['minimum']
+	) {
+		give_update_meta( $post_id, '_give_custom_amount_range_minimum', give_sanitize_amount_for_db( $_REQUEST['_give_set_price'] ) );
 	}
 }
 

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -337,7 +337,7 @@ function give_price_save_quick_edit( $post_id ) {
 	if (
 		isset( $_REQUEST['_give_custom_amount'], $_REQUEST['_give_set_price'], $_REQUEST['_give_custom_amount_range'] )
 		&& give_is_setting_enabled( $_REQUEST['_give_custom_amount'] )
-		&& $_REQUEST['_give_set_price'] < $_REQUEST['_give_custom_amount_range']['minimum']
+		&& give_maybe_sanitize_amount( $_REQUEST['_give_set_price'] ) < give_maybe_sanitize_amount( $_REQUEST['_give_custom_amount_range']['minimum'] )
 	) {
 		give_update_meta( $post_id, '_give_custom_amount_range_minimum', give_sanitize_amount_for_db( $_REQUEST['_give_set_price'] ) );
 	}


### PR DESCRIPTION
## Description
Fix #3249 

## How Has This Been Tested?
- By saving the donation without custom amount enabled.
- By tweaking the give currency setting.
- By creating donation on the front-end.

## Screenshots (jpeg or gifs if applicable):
![demo](https://user-images.githubusercontent.com/14994452/40713740-4d3141ce-641e-11e8-9342-28cc936512e3.gif)


## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.