### PR TITLE
fix(shortcode): select donation form alert must be open using modal api #3244 #3282 #3286

### DIFF
--- a/assets/src/css/plugins/_settings.scss
+++ b/assets/src/css/plugins/_settings.scss
@@ -11,7 +11,7 @@ $mfp-shadow:                          0 0 8px rgba(0, 0, 0, 0.6) !default; // Sh
 $mfp-popup-padding-left:              8px !default;                        // Padding from left and from right side
 $mfp-popup-padding-left-mobile:       6px !default;                        // Same as above, but is applied when width of window is less than 800px
 
-$mfp-z-index-base:                    1040 !default;                       // Base z-index of popup
+$mfp-z-index-base:                    999999 !default;                       // Base z-index of popup
 
 // controls
 $mfp-include-arrows:                  true !default;                       // Include styles for nav arrows

--- a/includes/admin/shortcodes/admin-shortcodes.js
+++ b/includes/admin/shortcodes/admin-shortcodes.js
@@ -12,6 +12,8 @@
 
 /* global ajaxurl, jQuery, scShortcodes, tinymce */
 
+import {GiveWarningAlert, GiveErrorAlert, GiveConfirmModal} from '../../../assets/src/js/plugins/modal';
+
 var jq = jQuery.noConflict();
 
 var scShortcode, scButton;
@@ -19,7 +21,7 @@ var scShortcode, scButton;
 /**
  * Show continue button title setting field only if display style is not All Fields.
  */
-var render_continue_button_title_field = function() {
+window.render_continue_button_title_field = function() {
 	var selected_display_style = jq('.mce-txt', '.mce-give-display-style').text(),
 		expected_display_styles = [ '- Select -', 'All Fields' ];
 
@@ -30,7 +32,7 @@ var render_continue_button_title_field = function() {
 	}
 };
 
-var scForm = {
+window.scForm = {
 
 	open: function( editor_id ) {
 		var editor = tinymce.get( editor_id );
@@ -101,7 +103,13 @@ var scForm = {
 
 									valid = false;
 
-									alert( required[ id ] );
+									new GiveWarningAlert({
+										modalContent:{
+											title: give_vars.no_form_selected,
+											desc: required[ id ],
+											cancelBtnTitle: give_vars.ok,
+										}
+									}).render();
 
 									break;
 								}

--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -86,7 +86,7 @@ final class Give_Shortcode_Button {
 
 		wp_enqueue_script(
 			'give_shortcode',
-			GIVE_PLUGIN_URL . 'includes/admin/shortcodes/admin-shortcodes.js',
+			GIVE_PLUGIN_URL . 'assets/dist/js/admin-shortcodes.js',
 			array( 'jquery' ),
 			GIVE_VERSION,
 			true

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -198,6 +198,7 @@ class Give_Scripts {
 			'import_failed'                     => __( 'Import failed', 'give' ),
 			'flush_success'                     => __( 'Flush success', 'give' ),
 			'flush_error'                       => __( 'Flush error', 'give' ),
+			'no_form_selected'                  => __( 'No form selected', 'give' ),
 			'batch_export_no_class'             => __( 'You must choose a method.', 'give' ),
 			'batch_export_no_reqs'              => __( 'Required fields not completed.', 'give' ),
 			'reset_stats_warn'                  => __( 'Are you sure you want to reset Give? This process is <strong><em>not reversible</em></strong> and will delete all data regardless of test or live mode. Please be sure you have a recent backup before proceeding.', 'give' ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const config = {
 		'admin-shortcode-button': [ './assets/src/css/admin/shortcodes.scss' ],
 		give: [ './assets/src/js/frontend/give.js', './assets/src/css/frontend/give-frontend.scss' ],
 		gutenberg: [ './blocks/load.js' ],
+		'admin-shortcodes': './includes/admin/shortcodes/admin-shortcodes.js',
 	},
 
 	// Tell webpack where to output.


### PR DESCRIPTION
Closes #3282 

## Description
This PR replaces the native alert dialog with GiveModalWarning.

## How Has This Been Tested?
By adding a form in a shortcode without choosing a form.

## Screenshots (jpeg or gifs if applicable):
![warning](https://snag.gy/bkP5Cg.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.