### PR TITLE
WIP: fix(admin-shortcode): get JS error in console of file not found #3292

### DIFF
--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -86,7 +86,7 @@ final class Give_Shortcode_Button {
 
 		wp_enqueue_script(
 			'give_shortcode',
-			GIVE_PLUGIN_URL . 'assets/dist/js/admin-shortcodes.js',
+			GIVE_PLUGIN_URL . 'assets/dist/js/admin-shortcode-button.js',
 			array( 'jquery' ),
 			GIVE_VERSION,
 			true


### PR DESCRIPTION
## Description
PR to fix #3292 

## How Has This Been Tested?
Need @ravinderk help on this the shortcode button on Page is not working 

![image](https://user-images.githubusercontent.com/22215595/40750215-2df54182-6484-11e8-9d4c-0b44c7a82e72.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.