### PR TITLE
fix(admin-setting): immediately disable default column radio button if payment gateway unchecked #3296

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -665,6 +665,12 @@ var give_setting_edit = false;
 					checked_cbs
 						.prev( '.gateways-radio' )
 						.attr( 'checked', 'checked' );
+
+					if ( this.checked ) {
+						radio.removeAttr( 'disabled' );
+					} else {
+						radio.attr( 'disabled', 'disabled' );
+					}
 				} else {
 					if ( this.checked ) {
 						radio.removeAttr( 'disabled' );


### PR DESCRIPTION
Closes #3296 

## Description
This PR disables/enables the radio button when you toggle the checkboxes.

## How Has This Been Tested?
Manually tested by enabling/disabling the checkboxes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.