### PR TITLE
fix(form-grid): resolve error where Payment Method shows with only one gateway enabled. #3293

### DIFF
--- a/assets/src/css/frontend/modal.scss
+++ b/assets/src/css/frontend/modal.scss
@@ -127,7 +127,6 @@
 	height: 85vh;
 	overflow-y: auto;
 
-	#give-payment-mode-select,
 	#give_purchase_form_wrap {
 		display: block !important;
 	}

--- a/assets/src/css/frontend/modal.scss
+++ b/assets/src/css/frontend/modal.scss
@@ -135,6 +135,10 @@
 	.give-btn-modal {
 		display: none !important;
 	}
+
+	.give-form-title {
+		display: none;
+	}
 }
 
 .modal-fade-slide .give-modal--slide {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -2123,6 +2123,12 @@ function add_give_goal_progress_bar_class( $class_bar ) {
 function add_class_for_form_grid( $class, $id, $args ) {
 	$class[] = 'give-form-grid-wrap';
 
+	foreach ( $class as $index => $item ) {
+		if( false !== strpos( $item, 'give-display-' ) ) {
+			unset( $class[$index] );
+		}
+	}
+
 	return $class;
 }
 
@@ -2175,30 +2181,3 @@ function give_redirect_and_popup_form( $redirect, $args ) {
 }
 
 add_filter( 'give_send_back_to_checkout', 'give_redirect_and_popup_form', 10, 2 );
-
-
-/**
- * Removes classes for modal and reveal templates from Form Grid.
- *
- * @param array   $custom_class Array of custom classes.
- * @param integer $id           Form ID.
- * @param array   $args         Form attributes.
- *
- * @since 2.1.4
- *
- * @return array
- */
-function give_remove_form_wrap_classes_for_form_grid( $custom_class, $id, $args ) {
-
-	$index = array_search( 'give-display-reveal', $custom_class );
-	if ( false !== $index ) {
-		unset( $custom_class[ $index ] );
-	}
-
-	$index = array_search( 'give-display-modal', $custom_class );
-	if ( false !== $index ) {
-		unset( $custom_class[ $index ] );
-	}
-
-	return $custom_class;
-}

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -2175,3 +2175,30 @@ function give_redirect_and_popup_form( $redirect, $args ) {
 }
 
 add_filter( 'give_send_back_to_checkout', 'give_redirect_and_popup_form', 10, 2 );
+
+
+/**
+ * Removes classes for modal and reveal templates from Form Grid.
+ *
+ * @param array   $custom_class Array of custom classes.
+ * @param integer $id           Form ID.
+ * @param array   $args         Form attributes.
+ *
+ * @since 2.1.4
+ *
+ * @return array
+ */
+function give_remove_form_wrap_classes_for_form_grid( $custom_class, $id, $args ) {
+
+	$index = array_search( 'give-display-reveal', $custom_class );
+	if ( false !== $index ) {
+		unset( $custom_class[ $index ] );
+	}
+
+	$index = array_search( 'give-display-modal', $custom_class );
+	if ( false !== $index ) {
+		unset( $custom_class[ $index ] );
+	}
+
+	return $custom_class;
+}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -840,6 +840,7 @@ function give_form_grid_shortcode( $atts ) {
 		add_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class', 10, 1 );
 		add_filter( 'give_form_wrap_classes', 'add_class_for_form_grid', 10, 3 );
 		add_action( 'give_donation_form_top', 'give_is_form_grid_page_hidden_field', 10, 3 );
+		add_filter( 'give_form_wrap_classes', 'give_remove_form_wrap_classes_for_form_grid', 10, 3 );
 
 		echo '<div class="give-wrap">';
 		echo '<div class="give-grid give-grid--' . esc_attr( $atts['columns'] ) . '">';
@@ -858,6 +859,7 @@ function give_form_grid_shortcode( $atts ) {
 
 		remove_filter( 'add_give_goal_progress_class', 'add_give_goal_progress_class' );
 		remove_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class' );
+		remove_filter( 'give_form_wrap_classes', 'give_remove_form_wrap_classes_for_form_grid' );
 
 		if ( false !== $atts['paged'] ) {
 			$paginate_args = array(

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -840,7 +840,6 @@ function give_form_grid_shortcode( $atts ) {
 		add_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class', 10, 1 );
 		add_filter( 'give_form_wrap_classes', 'add_class_for_form_grid', 10, 3 );
 		add_action( 'give_donation_form_top', 'give_is_form_grid_page_hidden_field', 10, 3 );
-		add_filter( 'give_form_wrap_classes', 'give_remove_form_wrap_classes_for_form_grid', 10, 3 );
 
 		echo '<div class="give-wrap">';
 		echo '<div class="give-grid give-grid--' . esc_attr( $atts['columns'] ) . '">';
@@ -861,7 +860,6 @@ function give_form_grid_shortcode( $atts ) {
 		remove_filter( 'add_give_goal_progress_bar_class', 'add_give_goal_progress_bar_class' );
 		remove_filter( 'give_form_wrap_classes', 'add_class_for_form_grid', 10 );
 		remove_action( 'give_donation_form_top', 'give_is_form_grid_page_hidden_field', 10 );
-		remove_filter( 'give_form_wrap_classes', 'give_remove_form_wrap_classes_for_form_grid' );
 
 		if ( false !== $atts['paged'] ) {
 			$paginate_args = array(


### PR DESCRIPTION
Closes #3293 

## Description
This PR will only display the payment select fields only if there are more than 1 gateways enabled.

## How Has This Been Tested?
I have tested this on the Form Grid page and individual Form page and tried all Display options.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.