### PR TITLE
fix(form): hide donation amount label on modal close

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -212,7 +212,7 @@ window.give_open_form_modal = function ( $form_wrap, $form ) {
 				jQuery( 'body' ).removeClass( 'give-modal-open' );
 
 				//Show all fields again
-				$form.children().not( children ).not( '.give-hidden[for="give-amount-hidden"]' ).show();
+				$form.children().not( children ).show();
 			}
 		}
 	} );

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -212,7 +212,7 @@ window.give_open_form_modal = function ( $form_wrap, $form ) {
 				jQuery( 'body' ).removeClass( 'give-modal-open' );
 
 				//Show all fields again
-				$form.children().not( children ).show();
+				$form.children().not( children ).not( '.give-hidden[for="give-amount-hidden"]' ).show();
 			}
 		}
 	} );

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -199,7 +199,7 @@ window.give_open_form_modal = function ( $form_wrap, $form ) {
 
 				// Hide .give-hidden and .give-btn-modal  if admin only want to show only button.
 				if ( $form_wrap.hasClass( 'give-display-button-only' ) ) {
-					children = $form.children().not( '.give-hidden, .give-btn-modal' );
+					children = $form.children().not( '.give-btn-modal' );
 				}
 
 				//Hide all form elements besides the ones required for payment


### PR DESCRIPTION
Closes #3301 #3308 

## Description
This PR hides the Donation Amount label when the modal popup is closed if the form's display option is set to Button.

## How Has This Been Tested?
Manually tested.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.