### PR TITLE
fix(shortcode): select donation form alert must be open using modal api #3282 #3060

### DIFF
--- a/includes/admin/shortcodes/admin-shortcodes.js
+++ b/includes/admin/shortcodes/admin-shortcodes.js
@@ -103,7 +103,7 @@ window.scForm = {
 
 									valid = false;
 
-									new GiveWarningAlert({
+									new GiveErrorAlert({
 										modalContent:{
 											desc: required[ id ],
 											cancelBtnTitle: give_vars.ok,


### PR DESCRIPTION
## Description
PR to fix #3282 https://github.com/WordImpress/Give/issues/3060#issuecomment-394301653

## How Has This Been Tested?
- [x] Testing by inserting shortcode without select the donation form
- [x] Testing by adding the total goal with empty 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/40915379-6e9dcb44-6819-11e8-864e-8253ac9aa7a6.png)

![image](https://user-images.githubusercontent.com/22215595/40915408-8940ef4e-6819-11e8-9d39-fffbdd1adf35.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.