### PR TITLE
fix(user-role): Give manager should be able to view donation details #3261

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -363,6 +363,15 @@ function give_show_upgrade_notices( $give_updates ) {
 		)
 	);
 
+	// v2.1.5 Add additional capability to the give_manager role.
+	$give_updates->register(
+		array(
+			'id'       => 'v215_update_donor_user_roles',
+			'version'  => '2.1.5',
+			'callback' => 'give_v215_update_donor_user_roles_callback',
+		)
+	);
+
 }
 
 add_action( 'give_register_updates', 'give_show_upgrade_notices' );
@@ -2704,4 +2713,17 @@ function give_v213_delete_donation_meta_callback() {
 		give_set_upgrade_complete( 'v213_delete_donation_meta' );
 	}
 
+}
+
+/**
+ * Adds 'view_give_payments' capability to 'give_manager' user role.
+ *
+ * @since 2.1.5
+ */
+function give_v215_update_donor_user_roles_callback() {
+
+	$role = get_role( 'give_manager' );
+	$role->add_cap( 'view_give_payments' );
+
+	give_set_upgrade_complete( 'v215_update_donor_user_roles' );
 }

--- a/includes/class-give-roles.php
+++ b/includes/class-give-roles.php
@@ -128,6 +128,7 @@ class Give_Roles {
 			$wp_roles->add_cap( 'give_manager', 'view_give_sensitive_data' );
 			$wp_roles->add_cap( 'give_manager', 'export_give_reports' );
 			$wp_roles->add_cap( 'give_manager', 'manage_give_settings' );
+			$wp_roles->add_cap( 'give_manager', 'view_give_payments' );
 
 			$wp_roles->add_cap( 'administrator', 'view_give_reports' );
 			$wp_roles->add_cap( 'administrator', 'view_give_sensitive_data' );


### PR DESCRIPTION
Closes #3261 

## Description
This PR runs an upgrade script to add the user capability `view_give_payments` to the user role `give_manager`.

## How Has This Been Tested?
I tested this by running the upgrader.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.