### PR TITLE
fix(admin-form): Ensure custom logo appears in email Preview when properly configured #3330

### DIFF
--- a/includes/emails/class-give-emails.php
+++ b/includes/emails/class-give-emails.php
@@ -313,6 +313,20 @@ class Give_Emails {
 		$header_img = give_get_meta( $this->form_id, '_give_email_logo', true );
 		$header_img = $this->form_id ? $header_img : give_get_option( 'email_logo', '' );
 
+		// Fetch correct header image for preview and sening email.
+		if ( ! $this->form_id && isset( $_GET['form_id'] ) ) {
+			$form_id       = give_clean( $_GET['form_id'] );
+			$email_options = give_get_meta( $form_id, '_give_email_options', true );
+
+			if ( 'enabled' === $email_options ) {
+				$header_img = give_get_meta( $form_id, '_give_email_logo', true );
+			}
+
+			if ( 'global' === $email_options ) {
+				$header_img = give_get_option( 'email_logo', '' );
+			}
+		}
+
 		if ( ! empty( $header_img ) ) {
 			$header_img = sprintf(
 				'<div id="template_header_image"><p style="margin-top:0;"><img style="max-width:450px;" src="%1$s" alt="%2$s" /></p></div>',


### PR DESCRIPTION
Closes #3330 

## Description
This PR fixes the header logo on preview from the admin forms page.

## How Has This Been Tested?
- I have tried to preview the email from within the Forms page and the Email Settings Page, with global and custom settings.
- I have also sent test emails using the same method above.
- I have made donations with global as well as custom settings.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.