### PR TITLE
style(admin): admin footer notice overlapping on update page #3328

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -735,3 +735,9 @@ h2.give-nav-tab-wrapper {
 		border: 4px solid white;
 	}
 }
+
+.post-type-give_forms {
+	#wpfooter {
+		position: relative;
+	}
+}

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -735,9 +735,3 @@ h2.give-nav-tab-wrapper {
 		border: 4px solid white;
 	}
 }
-
-.post-type-give_forms {
-	#wpfooter {
-		position: relative;
-	}
-}

--- a/includes/admin/upgrades/views/upgrades.php
+++ b/includes/admin/upgrades/views/upgrades.php
@@ -106,7 +106,7 @@ $give_updates = Give_Updates::get_instance();
 						</div>
 						<!-- .inside -->
 					</div><!-- .postbox -->
-				</div>
+				</div> <!-- .post-container -->
 			</div>
 			<?php else: include GIVE_PLUGIN_DIR . 'includes/admin/upgrades/views/db-upgrades-complete-metabox.php';?>
 		<?php endif; ?>

--- a/includes/admin/upgrades/views/upgrades.php
+++ b/includes/admin/upgrades/views/upgrades.php
@@ -19,7 +19,7 @@ $give_updates = Give_Updates::get_instance();
 <div class="wrap" id="poststuff">
 	<div id="give-updates">
 		<h1 id="give-updates-h1"><?php esc_html_e( 'Give - Updates', 'give' ); ?></h1>
-		<hr class="wp-header-end"
+		<hr class="wp-header-end">
 
 		<?php $db_updates = $give_updates->get_pending_db_update_count(); ?>
 		<?php if ( ! empty( $db_updates ) ) : ?>


### PR DESCRIPTION
Closes #3328 

## Description
This PR fixes the admin footer on the Give Update page.

## How Has This Been Tested?
By refreshing page after running `npm run dev`

## Screenshots (jpeg or gifs if applicable):
![updatecss](https://snag.gy/SZ6kTe.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.