### PR TITLE
feat(donor-wall): add Load More button

### DIFF
--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -829,46 +829,31 @@ Form validation style
 Button with Loader
 -----------------------------------*/
 .give-button-with-loader {
-	position: relative;
-	padding: 1rem 2rem;
-   
-   .give-btl-spinner {
-		position: absolute;
-		top: 13px;
-		left: 20px;
-		display: inline-block;
-		opacity: 0;
-		border-radius: 50%;
-		height: 18px;
-		width: 18px;
-		border: 2px solid;
-		border-top-color: transparent;
-		animation: spinner 1.5s linear infinite;
-		transform: rotate(0deg);
-   }
+	span.give-loading-animation {
+		display: none;
 
-   .give-button-inner-text {
-		display: inline-block;
-		left: 0;
-   }
-}
-
-.give-active {
-   .give-button-inner-text {
+		// Align loading icon with button text.
 		position: relative;
-		left: 20px;
-		transition: all 0.3s ease;
-   }
-   
-   .give-btl-spinner {
-		opacity: 1;
-		transition: all 0.3s ease;
-		transition-delay: 0.2s;
-   }
+		top: 3px;
+		float: left;
+
+		@include iconstyle();
+		height: 16px;
+		width: 16px;
+		line-height: 1;
+		font-size: 16px;
+		margin: 0 5px 0 0;
+		background-size: 20px 20px;
+		background-repeat: no-repeat;
+		background-color: transparent;
+		@extend .give-icon-spinner2;
+		@extend .fa-spin;
+	}
 }
 
-@keyframes spinner {
-  to {
-		transform: rotate(360deg);
+
+.give-active{
+	span.give-loading-animation {
+		display: inline;
 	}
 }

--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -824,3 +824,51 @@ Form validation style
 		border-color: red !important;
 	}
 }
+
+/*---------------------------------
+Button with Loader
+-----------------------------------*/
+.give-button-with-loader {
+	position: relative;
+	padding: 1rem 2rem;
+   
+   .give-btl-spinner {
+		position: absolute;
+		top: 13px;
+		left: 20px;
+		display: inline-block;
+		opacity: 0;
+		border-radius: 50%;
+		height: 18px;
+		width: 18px;
+		border: 2px solid;
+		border-top-color: transparent;
+		animation: spinner 1.5s linear infinite;
+		transform: rotate(0deg);
+   }
+
+   .give-button-inner-text {
+		display: inline-block;
+		left: 0;
+   }
+}
+
+.give-active {
+   .give-button-inner-text {
+		position: relative;
+		left: 20px;
+		transition: all 0.3s ease;
+   }
+   
+   .give-btl-spinner {
+		opacity: 1;
+		transition: all 0.3s ease;
+		transition-delay: 0.2s;
+   }
+}
+
+@keyframes spinner {
+  to {
+		transform: rotate(360deg);
+	}
+}

--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -835,14 +835,14 @@ Button with Loader
 		// Align loading icon with button text.
 		position: relative;
 		top: 3px;
-		float: left;
+		float: right;
 
 		@include iconstyle();
 		height: 16px;
 		width: 16px;
 		line-height: 1;
 		font-size: 16px;
-		margin: 0 5px 0 0;
+		margin: 0 0 0 5px;
 		background-size: 20px 20px;
 		background-repeat: no-repeat;
 		background-color: transparent;


### PR DESCRIPTION
Closes #3340 

## Description
Added a Load More button with an animatable loader inside the button.

## How Has This Been Tested?
Tested using the following snippet

```html
<button class="give-button-with-loader">
	<span class="give-btl-spinner"></span>
	<span class="give-button-inner-text">BUTTON TEXT</span>
</button>
```

```js
$(document).ready( function() {
   
   $( '.give-button-with-loader' ).on( 'click', function() {
      $( this ).addClass( 'give-active' );
   });
   
});
```

## Video
https://www.useloom.com/share/6fc7c8f208f0464c9f1b3fc1cdde4ed7

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.