### PR TITLE
fix(admin-tool): All Forms dropdown on the Donation Export only uses first ten forms #3303

### DIFF
--- a/includes/admin/tools/export/give-export-donations-functions.php
+++ b/includes/admin/tools/export/give-export-donations-functions.php
@@ -189,6 +189,10 @@ function give_export_donation_form_search_args( $args ) {
 	$fields = isset( $_POST['fields'] ) ? $_POST['fields'] : null;
 	parse_str( $fields );
 
+	if ( ! empty( $give_forms_categories ) || ! empty( $give_forms_tags ) ) {
+		$args['posts_per_page'] = -1;
+	}
+
 	if ( ! empty( $give_forms_categories ) && ! empty( $give_forms_tags ) ) {
 		$args['tax_query']['relation'] = 'AND';
 	}

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -290,8 +290,13 @@ function give_ajax_form_search() {
 	$search  = esc_sql( sanitize_text_field( $_POST['s'] ) );
 
 	$args = array(
-		'post_type' => 'give_forms',
-		's'         => $search,
+		'post_type'              => 'give_forms',
+		's'                      => $search,
+		'update_post_term_cache' => false,
+		'update_post_meta_cache' => false,
+		'cache_results'          => false,
+		'no_found_rows'          => true,
+		'post_status'            => 'publish',
 	);
 
 	/**


### PR DESCRIPTION
## Description
PR to fix #3303 

## How Has This Been Tested?
Tested by exporting donation by selecting the cat and tag and then exporting the donation 


Video Link: https://screencast-o-matic.com/watch/cF1l1eFfAa

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.