### PR TITLE
fix(admin-setting): License tab is not showing when addon is network enabled #3349

### DIFF
--- a/includes/admin/settings/class-settings-license.php
+++ b/includes/admin/settings/class-settings-license.php
@@ -99,6 +99,14 @@ if ( ! class_exists( 'Give_Settings_License' ) ) :
 			$licensed_addons   = Give_License::get_licensed_addons();
 			$activated_plugins = get_option( 'active_plugins', array() );
 
+			// Get list of network enabled plugin.
+			if ( is_multisite() ) {
+				$sitewide_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+				$activated_plugins = ! empty( $activated_plugins )
+					? array_merge( $sitewide_activated_plugins, $activated_plugins )
+					: $sitewide_activated_plugins;
+			}
+
 			return (bool) count( array_intersect( $activated_plugins, $licensed_addons ) );
 		}
 	}


### PR DESCRIPTION
## Description
This pr will resolve #3349 

## How Has This Been Tested?
- [x] MultiSite
   - [x] Addon network activated  Give, Fee recovery
   - [x] Addon network activated Give, Fee recovery activated on the subsite
- [x] Addon activated on single site

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.