### PR TITLE
fix(form): Add shortcode support to Offline Donations Instructions output #2937

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1553,8 +1553,6 @@ function give_terms_agreement( $form_id ) {
 		return false;
 	}
 
-	// Format term and decode shortcodes.
-	$terms = wpautop( do_shortcode( $terms ) );
 
 	// Bailout: Check if term and conditions text is empty or not.
 	if ( empty( $terms ) ) {
@@ -1564,6 +1562,13 @@ function give_terms_agreement( $form_id ) {
 
 		return false;
 	}
+
+	/**
+	 * Filter the form term content
+	 *
+	 * @since  2.1.5
+	 */
+	$terms = apply_filters( 'give_the_term_content',  wpautop( do_shortcode( $terms ) ), $terms, $form_id );
 
 	?>
 	<fieldset id="give_terms_agreement">
@@ -1577,7 +1582,7 @@ function give_terms_agreement( $form_id ) {
 			 */
 			do_action( 'give_before_terms' );
 
-			echo wpautop( stripslashes( $terms ) );
+			echo $terms;
 			/**
 			 * Fires while rendering terms of agreement, after the fields.
 			 *

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1855,17 +1855,32 @@ add_action( 'give_pre_form_output', 'give_form_content', 10, 2 );
  * @return void
  */
 function give_form_display_content( $form_id, $args ) {
-
-	$content      = wpautop( give_get_meta( $form_id, '_give_form_content', true ) );
+	$content      = give_get_meta( $form_id, '_give_form_content', true );
 	$show_content = give_get_form_content_placement( $form_id, $args );
 
 	if ( give_is_setting_enabled( give_get_option( 'the_content_filter' ) ) ) {
 		$content = apply_filters( 'the_content', $content );
+	} else{
+		$content = wpautop( do_shortcode( $content ) );
 	}
 
-	$output = '<div id="give-form-content-' . $form_id . '" class="give-form-content-wrap ' . $show_content . '-content">' . $content . '</div>';
+	$output = sprintf(
+		'<div id="give-form-content-%s" class="give-form-content-wrap %s-content">%s</div>',
+		$form_id,
+		$show_content,
+		$content
+	);
 
-	echo apply_filters( 'give_form_content_output', $output );
+	/**
+	 * Filter form content html
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $output
+	 * @param int    $form_id
+	 * @param array  $args
+	 */
+	echo apply_filters( 'give_form_content_output', $output, $form_id, $args );
 
 	// remove action to prevent content output on addition forms on page.
 	// @see: https://github.com/WordImpress/Give/issues/634.

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1553,6 +1553,9 @@ function give_terms_agreement( $form_id ) {
 		return false;
 	}
 
+	// Format term and decode shortcodes.
+	$terms = wpautop( do_shortcode( $terms ) );
+
 	// Bailout: Check if term and conditions text is empty or not.
 	if ( empty( $terms ) ) {
 		if ( is_user_logged_in() && current_user_can( 'edit_give_forms' ) ) {

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -460,11 +460,25 @@ function give_get_offline_payment_instruction( $form_id, $wpautop = false ) {
 			$settings_url
 		);
 
-	$offline_instructions = $wpautop
+	$formmated_offline_instructions = $wpautop
 		? wpautop( do_shortcode( $offline_instructions ) )
 		: $offline_instructions;
 
-	return $offline_instructions;
+	/**
+	 * Filter the offline instruction content
+	 *
+	 * @since 2.2.0
+	 *
+	 */
+	$formmated_offline_instructions = apply_filters(
+		'give_the_offline_instructions_content',
+		$formmated_offline_instructions,
+		$offline_instructions,
+		$form_id,
+		$wpautop
+	);
+
+	return $formmated_offline_instructions;
 }
 
 

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -30,7 +30,6 @@ function give_offline_register_gateway( $gateways ) {
 
 add_filter( 'give_payment_gateways', 'give_offline_register_gateway', 1 );
 
-
 /**
  * Add our payment instructions to the checkout
  *
@@ -454,9 +453,18 @@ function give_get_offline_payment_instruction( $form_id, $wpautop = false ) {
 	$settings_url = admin_url( 'post.php?post=' . $form_id . '&action=edit&message=1' );
 
 	/* translators: %s: form settings url */
-	$offline_instructions = ! empty( $offline_instructions ) ? $offline_instructions : sprintf( __( 'Please enter offline donation instructions in <a href="%s">this form\'s settings</a>.', 'give' ), $settings_url );
+	$offline_instructions = ! empty( $offline_instructions )
+		? $offline_instructions
+		: sprintf(
+			__( 'Please enter offline donation instructions in <a href="%s">this form\'s settings</a>.', 'give' ),
+			$settings_url
+		);
 
-	return ( $wpautop ? wpautop( $offline_instructions ) : $offline_instructions );
+	$offline_instructions = $wpautop
+		? wpautop( do_shortcode( $offline_instructions ) )
+		: $offline_instructions;
+
+	return $offline_instructions;
 }
 
 


### PR DESCRIPTION
## Description
PR to fix #2937 

## How Has This Been Tested?
Tested using the shortcode in the offline donation instruction 

## Tasks
- [x] Implement the code change cited above.
- [x] Ensure the results are the same for both the Global Offline content and the perform Offline content.
- [x] Review all other WYSIWYG outputs throughout Give core for anywhere that we don't use the `the_content` filter and update as well. We should ensure that the frontend output matches expectations with the backend, and this issue has come up previously (see "Related" above).
- [x] Consider adding additional filters to the output for further customization.
- [x] Add two new filters:
        a. `give_the_term_content`: filter form terms content
        b. `give_the_offline_instructions_content`: filter form offline donation instruction

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cF1I1xFh9i

![image](https://user-images.githubusercontent.com/22215595/41333837-db26b3d2-6f00-11e8-8859-08442f5f55e1.png)

![image](https://user-images.githubusercontent.com/22215595/41333847-e2483a6e-6f00-11e8-9955-a9b1ee56db2f.png)

![image](https://user-images.githubusercontent.com/22215595/41334300-be7f5534-6f02-11e8-96d9-1439a2f3e496.png)

![image](https://user-images.githubusercontent.com/22215595/41334325-db729eee-6f02-11e8-8baa-7c5735d5fe4b.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.