### PR TITLE
fix(form): show "Create an account" in full row if only registration enabled #3358

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1181,8 +1181,12 @@ function give_get_register_fields( $form_id ) {
 			 * @param int $form_id The form ID.
 			 */
 			do_action( 'give_register_account_fields_before', $form_id );
+
+			$registration = give_get_meta( $form_id, '_give_show_register_form', true );
+
+			$class = ( 'registration' === $registration ) ? 'form-row-wide' : 'form-row-first';
 			?>
-			<div id="give-create-account-wrap-<?php echo $form_id; ?>" class="form-row form-row-first form-row-responsive">
+			<div id="give-create-account-wrap-<?php echo $form_id; ?>" class="form-row <?php echo esc_attr( $class ); ?> form-row-responsive">
 				<label for="give-create-account-<?php echo $form_id; ?>">
 					<?php
 					// Add attributes to checkbox, if Guest Checkout is disabled.

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1182,9 +1182,7 @@ function give_get_register_fields( $form_id ) {
 			 */
 			do_action( 'give_register_account_fields_before', $form_id );
 
-			$registration = give_get_meta( $form_id, '_give_show_register_form', true );
-
-			$class = ( 'registration' === $registration ) ? 'form-row-wide' : 'form-row-first';
+			$class = ( 'registration' === $show_register_form) ? 'form-row-wide' : 'form-row-first';
 			?>
 			<div id="give-create-account-wrap-<?php echo $form_id; ?>" class="form-row <?php echo esc_attr( $class ); ?> form-row-responsive">
 				<label for="give-create-account-<?php echo $form_id; ?>">


### PR DESCRIPTION
Closes #3358 

## Description
This PR fixes the `create an account` field. It makes it full row if only registration is enabled.

## How Has This Been Tested?
By selecting `registration` from `registration` options in a donation form.

## Screenshots:
![createac](https://snag.gy/OlYMzT.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.