### PR TITLE
feat(admin-email): improve management of contact info in emails #3070

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -849,20 +849,6 @@ var give_setting_edit = false;
 					$('input', $parent).not( 'input[name="sequential-ordering_status"]' ).parents('tr').hide();
 				}
 			}).change();
-
-			/**
-			 * Toggle custom email address
-			 */
-			var offline_contact = $('input[name="contact_custom_admin_email"]');
-			offline_contact.on('change', function () {
-				var field_value = $('input[name="contact_custom_admin_email"]:checked').val(),
-					$parent = $(this).closest('tr');
-				if ('enabled' === field_value) {
-					$parent.next('tr').show();
-				} else {
-					$parent.next('tr').hide();
-				}
-			}).change();
 		},
 
 		main_setting_update_notice: function () {

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -849,6 +849,20 @@ var give_setting_edit = false;
 					$('input', $parent).not( 'input[name="sequential-ordering_status"]' ).parents('tr').hide();
 				}
 			}).change();
+
+			/**
+			 * Toggle custom email address
+			 */
+			var offline_contact = $('input[name="contact_custom_admin_email"]');
+			offline_contact.on('change', function () {
+				var field_value = $('input[name="contact_custom_admin_email"]:checked').val(),
+					$parent = $(this).closest('tr');
+				if ('enabled' === field_value) {
+					$parent.next('tr').show();
+				} else {
+					$parent.next('tr').hide();
+				}
+			}).change();
 		},
 
 		main_setting_update_notice: function () {

--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -848,40 +848,40 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 			$this->config['preview_email_tags_values'] = wp_parse_args(
 				$this->config['preview_email_tags_values'],
 				array(
-					'name'              => give_email_tag_first_name( array(
+					'name'                     => give_email_tag_first_name( array(
 						'payment_id' => $payment_id,
 						'user_id'    => $user_id,
 					) ),
-					'fullname'          => give_email_tag_fullname( array(
+					'fullname'                 => give_email_tag_fullname( array(
 						'payment_id' => $payment_id,
 						'user_id'    => $user_id,
 					) ),
-					'username'          => give_email_tag_username( array(
+					'username'                 => give_email_tag_username( array(
 						'payment_id' => $payment_id,
 						'user_id'    => $user_id,
 					) ),
-					'user_email'        => give_email_tag_user_email( array(
+					'user_email'               => give_email_tag_user_email( array(
 						'payment_id' => $payment_id,
 						'user_id'    => $user_id,
 					) ),
-					'payment_total'     => $payment_id ? give_email_tag_payment_total( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
-					'amount'            => $payment_id ? give_email_tag_amount( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
-					'price'             => $payment_id ? give_email_tag_price( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
-					'payment_method'    => $payment_id ? give_email_tag_payment_method( array( 'payment_id' => $payment_id ) ) : __( 'PayPal', 'give' ),
-					'receipt_id'        => $receipt_id,
-					'payment_id'        => $payment_id ? $payment_id : rand( 2000, 2050 ),
-					'receipt_link_url'  => $receipt_link_url,
-					'receipt_link'      => $receipt_link,
-					'date'              => $payment_id ? date( give_date_format(), strtotime( $payment->date ) ) : date( give_date_format(), current_time( 'timestamp' ) ),
-					'donation'          => $payment_id ? give_email_tag_donation( array( 'payment_id' => $payment_id ) ) : esc_html__( 'Sample Donation Form Title', 'give' ),
-					'form_title'        => $payment_id ? give_email_tag_form_title( array( 'payment_id' => $payment_id ) ) : esc_html__( 'Sample Donation Form Title - Sample Donation Level', 'give' ),
-					'sitename'          => $payment_id ? give_email_tag_sitename( array( 'payment_id' => $payment_id ) ) : get_bloginfo( 'name' ),
-					'pdf_receipt'       => sprintf(
+					'payment_total'            => $payment_id ? give_email_tag_payment_total( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
+					'amount'                   => $payment_id ? give_email_tag_amount( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
+					'price'                    => $payment_id ? give_email_tag_price( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
+					'payment_method'           => $payment_id ? give_email_tag_payment_method( array( 'payment_id' => $payment_id ) ) : __( 'PayPal', 'give' ),
+					'receipt_id'               => $receipt_id,
+					'payment_id'               => $payment_id ? $payment_id : rand( 2000, 2050 ),
+					'receipt_link_url'         => $receipt_link_url,
+					'receipt_link'             => $receipt_link,
+					'date'                     => $payment_id ? date( give_date_format(), strtotime( $payment->date ) ) : date( give_date_format(), current_time( 'timestamp' ) ),
+					'donation'                 => $payment_id ? give_email_tag_donation( array( 'payment_id' => $payment_id ) ) : esc_html__( 'Sample Donation Form Title', 'give' ),
+					'form_title'               => $payment_id ? give_email_tag_form_title( array( 'payment_id' => $payment_id ) ) : esc_html__( 'Sample Donation Form Title - Sample Donation Level', 'give' ),
+					'sitename'                 => $payment_id ? give_email_tag_sitename( array( 'payment_id' => $payment_id ) ) : get_bloginfo( 'name' ),
+					'pdf_receipt'              => sprintf(
 						'<a href="#">%s</a>',
 						__( 'Download Receipt', 'give' )
 					),
-					'billing_address'   => $payment_id ? give_email_tag_billing_address( array( 'payment_id' => $payment_id ) ) : '',
-					'email_access_link' => sprintf(
+					'billing_address'         => $payment_id ? give_email_tag_billing_address( array( 'payment_id' => $payment_id ) ) : '',
+					'email_access_link'       => sprintf(
 						'<a href="%1$s">%2$s</a>',
 						add_query_arg(
 							array(
@@ -891,7 +891,15 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 						),
 						__( 'View your donation history &raquo;', 'give' )
 					),
-					'reset_password_link' => $user_id ? give_email_tag_reset_password_link( array( 'user_id' => $user_id ), $payment_id ) : '',
+					'reset_password_link'     => $user_id ? give_email_tag_reset_password_link( array( 'user_id' => $user_id ), $payment_id ) : '',
+					'site_url'                => sprintf(
+						'<a href="%1$s">%2$s</a>',
+						get_bloginfo( 'url' ),
+						get_bloginfo( 'url' )
+					),
+					'admin_email'             => give_email_admin_email(),
+					'site_url'                => give_email_site_url(),
+					'offline_mailing_address' => give_email_offline_mailing_address(),
 				)
 			);
 

--- a/includes/admin/emails/class-email-access-email.php
+++ b/includes/admin/emails/class-email-access-email.php
@@ -175,9 +175,7 @@ if ( ! class_exists( 'Give_Email_Access_Email' ) ) :
 		 */
 		public function get_default_email_message() {
 			$message = sprintf(
-				           __( 'Please click the link to access your donation history on <a target="_blank" href="%1$s">%1$s</a>. If you did not request this email, please contact <a href="mailto:%2$s">%2$s</a>.', 'give' ),
-				           get_bloginfo( 'url' ),
-				           get_bloginfo( 'admin_email' )
+				           __( 'Please click the link to access your donation history on {site_url}. If you did not request this email, please contact {admin_email}.', 'give' )
 			           ) . "\n\n";
 			$message .= '{email_access_link}' . "\n\n";
 			$message .= "\n\n";

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -111,6 +111,36 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 						),
 					);
 					break;
+
+				case 'contact':
+					$settings = array(
+
+						// Section 5: Contact
+
+						array(
+							'id'   => 'give_title_general_settings_5',
+							'type' => 'title'
+						),
+						array(
+							'name'    => __( 'Admin Email Address', 'give' ),
+							'id'      => "contact_admin_email",
+							'desc'    => sprintf( '%1$s <code>{admin_email}</code> %2$s', __( 'By default, the', 'give' ), __( 'tag will use your WordPress admin email. If you would like to customize this address you can do so in the field above.', 'give' ) ),
+							'type'    => 'text',
+							'default' => give_email_admin_email(),
+
+						),
+						array(
+							'name'    => __( 'Offline Mailing Address', 'give' ),
+							'id'      => "contact_offline_mailing_address",
+							'desc'    => sprintf( '%1$s <code>{offline_mailing_address}</code> %2$s', __( 'Set the mailing address to where you would like your donors to send their offline donations. This will customize the', 'give' ), __( 'email tag for the Offline Donations payment gateway.', 'give' ) ),
+							'type'    => 'wysiwyg',
+							'default' => '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . get_bloginfo( 'sitename' ) . '</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>',
+						),
+						array(
+							'id'   => 'give_title_general_settings_4',
+							'type' => 'sectionend'
+						)
+					);
 			}// End switch().
 
 			/**
@@ -141,6 +171,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 		public function get_sections() {
 			$sections = array(
 				'email-settings' => esc_html__( 'Email Settings', 'give' ),
+				'contact'        => esc_html__( 'Contact Information', 'give' ),
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/admin/settings/class-settings-general.php
+++ b/includes/admin/settings/class-settings-general.php
@@ -410,6 +410,45 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 							'type' => 'sectionend'
 						)
 					);
+
+				case 'contact':
+					$settings = array(
+
+						// Section 5: Contact
+
+						array(
+							'id'   => 'give_title_general_settings_5',
+							'type' => 'title'
+						),
+						array(
+							'name'    => __( 'Custom Admin Email', 'give' ),
+							'id'      => "contact_custom_admin_email",
+							'desc'    => __( "The 'disabled' mode uses the admin email address set in WordPress Settings > General. Enable this to set custom admin email address.", 'give' ),
+							'type'    => 'radio_inline',
+							'default' => 'disabled',
+							'options' => array(
+								'enabled'  => __( 'Enabled', 'give' ),
+								'disabled' => __( 'Disabled', 'give' ),
+							),
+						),
+						array(
+							'name'    => __( 'Admin Email Address', 'give' ),
+							'id'      => "contact_admin_email",
+							'desc'    => __( 'Use the {admin_email} tag to use this custom admin email address in the email templates.', 'give' ),
+							'type'    => 'text',
+						),
+						array(
+							'name'    => __( 'Offline Mailing Address', 'give' ),
+							'id'      => "contact_offline_mailing_address",
+							'desc'    => __( 'Set the Offline Mailing Address. Use the {offline_mailing_address} tag to use this in the email templates.', 'give' ),
+							'type'    => 'wysiwyg',
+							'default' => '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . get_bloginfo( 'sitename' ) . '</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>',
+						),
+						array(
+							'id'   => 'give_title_general_settings_4',
+							'type' => 'sectionend'
+						)
+					);
 			}
 
 			/**
@@ -443,6 +482,7 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 				'currency-settings'   => __( 'Currency', 'give' ),
 				'access-control'      => __( 'Access Control', 'give' ),
 				'sequential-ordering' => __( 'Sequential Ordering', 'give' ),
+				'contact'             => __( 'Contact', 'give' ),
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/admin/settings/class-settings-general.php
+++ b/includes/admin/settings/class-settings-general.php
@@ -410,45 +410,6 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 							'type' => 'sectionend'
 						)
 					);
-
-				case 'contact':
-					$settings = array(
-
-						// Section 5: Contact
-
-						array(
-							'id'   => 'give_title_general_settings_5',
-							'type' => 'title'
-						),
-						array(
-							'name'    => __( 'Custom Admin Email', 'give' ),
-							'id'      => "contact_custom_admin_email",
-							'desc'    => __( "The 'disabled' mode uses the admin email address set in WordPress Settings > General. Enable this to set custom admin email address.", 'give' ),
-							'type'    => 'radio_inline',
-							'default' => 'disabled',
-							'options' => array(
-								'enabled'  => __( 'Enabled', 'give' ),
-								'disabled' => __( 'Disabled', 'give' ),
-							),
-						),
-						array(
-							'name'    => __( 'Admin Email Address', 'give' ),
-							'id'      => "contact_admin_email",
-							'desc'    => __( 'Use the {admin_email} tag to use this custom admin email address in the email templates.', 'give' ),
-							'type'    => 'text',
-						),
-						array(
-							'name'    => __( 'Offline Mailing Address', 'give' ),
-							'id'      => "contact_offline_mailing_address",
-							'desc'    => __( 'Set the Offline Mailing Address. Use the {offline_mailing_address} tag to use this in the email templates.', 'give' ),
-							'type'    => 'wysiwyg',
-							'default' => '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . get_bloginfo( 'sitename' ) . '</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>',
-						),
-						array(
-							'id'   => 'give_title_general_settings_4',
-							'type' => 'sectionend'
-						)
-					);
 			}
 
 			/**
@@ -482,7 +443,7 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 				'currency-settings'   => __( 'Currency', 'give' ),
 				'access-control'      => __( 'Access Control', 'give' ),
 				'sequential-ordering' => __( 'Sequential Ordering', 'give' ),
-				'contact'             => __( 'Contact', 'give' ),
+				'contact'             => __( 'Contact Information', 'give' ),
 			);
 
 			return apply_filters( 'give_get_sections_' . $this->id, $sections );

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -442,6 +442,27 @@ function give_setup_email_tags() {
 			'context'     => 'general',
 		),
 
+		array(
+			'tag'         => 'admin_email',
+			'description' => esc_html__( 'The admin email.', 'give' ),
+			'function'    => 'give_email_admin_email',
+			'context'     => 'general',
+		),
+
+		array(
+			'tag'         => 'site_url',
+			'description' => esc_html__( 'The website URL.', 'give' ),
+			'function'    => 'give_email_site_url',
+			'context'     => 'general',
+		),
+
+		array(
+			'tag'         => 'offline_mailing_address',
+			'description' => esc_html__( 'Offline Mailing Address.', 'give' ),
+			'function'    => 'give_email_offline_mailing_address',
+			'context'     => 'general',
+		),
+
 	);
 
 	// Apply give_email_tags filter
@@ -1401,6 +1422,50 @@ function give_get_reset_password_url( $user_id ) {
 	return $reset_password_url;
 }
 
+/**
+ * Get custom admin email.
+ *
+ * @since 2.2
+ *
+ * @return string
+ */
+function give_email_admin_email() {
+	$custom_admin_email = give_is_setting_enabled( give_get_option( 'contact_custom_admin_email' ) );
+	$admin_email        = give_get_option( 'contact_admin_email' );
+
+	return ( true === $custom_admin_email && ! empty( $admin_email ) )
+		? $admin_email
+		: get_bloginfo( 'admin_email' );
+}
+
+/**
+ * Get site URL.
+ *
+ * @since 2.2
+ *
+ * @return string
+ */
+function give_email_site_url() {
+	return get_bloginfo( 'url' );
+}
+
+
+/**
+ * Get custom offline mailing address.
+ *
+ * @since 2.2
+ *
+ * @return string
+ */
+function give_email_offline_mailing_address() {
+	$offline_address = give_get_option( 'contact_offline_mailing_address' );
+
+	if ( false === $offline_address ) {
+		return '<em>' . get_bloginfo( 'sitename' ) . '</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>';
+	}
+
+	return $offline_address;
+}
 
 /**
  * This function helps to render meta data with from dynamic meta data email tag.

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -444,7 +444,7 @@ function give_setup_email_tags() {
 
 		array(
 			'tag'         => 'admin_email',
-			'description' => esc_html__( 'The admin email.', 'give' ),
+			'description' => esc_html__( 'The custom admin email which is set inside Emails > Contact Information. By default this tag will use your WordPress admin email.', 'give' ),
 			'function'    => 'give_email_admin_email',
 			'context'     => 'general',
 		),
@@ -458,7 +458,7 @@ function give_setup_email_tags() {
 
 		array(
 			'tag'         => 'offline_mailing_address',
-			'description' => esc_html__( 'Offline Mailing Address.', 'give' ),
+			'description' => esc_html__( 'The Offline Mailing Address which is used for the Offline Donations Payment Gateway.', 'give' ),
 			'function'    => 'give_email_offline_mailing_address',
 			'context'     => 'general',
 		),
@@ -1430,10 +1430,14 @@ function give_get_reset_password_url( $user_id ) {
  * @return string
  */
 function give_email_admin_email() {
-	$custom_admin_email = give_is_setting_enabled( give_get_option( 'contact_custom_admin_email' ) );
-	$admin_email        = give_get_option( 'contact_admin_email' );
 
-	return ( true === $custom_admin_email && ! empty( $admin_email ) )
+	$admin_email = give_get_option( 'contact_admin_email' );
+
+	if ( empty( $admin_email ) ) {
+		give_delete_option( 'contact_admin_email' );
+	}
+
+	return ( ! empty( $admin_email ) )
 		? $admin_email
 		: get_bloginfo( 'admin_email' );
 }

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -85,7 +85,7 @@ add_action( 'give_admin_donation_email', 'give_admin_email_notice' );
 function give_get_default_donation_notification_email() {
 
 	$default_email_body = __( 'Hi there,', 'give' ) . "\n\n";
-	$default_email_body .= __( 'This email is to inform you that a new donation has been made on your website:', 'give' ) . ' <a href="' . get_bloginfo( 'url' ) . '" target="_blank">' . get_bloginfo( 'url' ) . '</a>' . ".\n\n";
+	$default_email_body .= __( 'This email is to inform you that a new donation has been made on your website:', 'give' ) . ' {site_url}' . ".\n\n";
 	$default_email_body .= '<strong>' . __( 'Donor:', 'give' ) . '</strong> {name}' . "\n";
 	$default_email_body .= '<strong>' . __( 'Donation:', 'give' ) . '</strong> {donation}' . "\n";
 	$default_email_body .= '<strong>' . __( 'Amount:', 'give' ) . '</strong> {amount}' . "\n";

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -363,19 +363,16 @@ function give_get_default_offline_donation_content() {
 	$default_text .= '<li>';
 	$default_text .= sprintf(
 	/* translators: %s: site name */
-		__( 'Make a check payable to "%s"', 'give' ),
-		$sitename
-	);
+		__( 'Make a check payable to "{sitename}"', 'give' ) );
 	$default_text .= '</li>';
 	$default_text .= '<li>';
 	$default_text .= sprintf(
 	/* translators: %s: site name */
-		__( 'On the memo line of the check, please indicate that the donation is for "%s"', 'give' ),
-		$sitename
-	);
+		__( 'On the memo line of the check, please indicate that the donation is for "{sitename}"', 'give' ) );
 	$default_text .= '</li>';
 	$default_text .= '<li>' . __( 'Please mail your check to:', 'give' ) . '</li>';
 	$default_text .= '</ol>';
+	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;{offline_mailing_address}<br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . $sitename . '</em><br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>';
@@ -401,25 +398,23 @@ function give_get_default_offline_donation_email_content() {
 	$default_text .= '<li>';
 	$default_text .= sprintf(
 	/* translators: %s: site name */
-		__( 'Make a check payable to "%s"', 'give' ),
-		$sitename
+		__( 'Make a check payable to "{sitename}"', 'give' )
 	);
 	$default_text .= '</li>';
 	$default_text .= '<li>';
 	$default_text .= sprintf(
-	/* translators: %s: site name */
-		__( 'On the memo line of the check, please indicate that the donation is for "%s"', 'give' ),
-		$sitename
+		__( 'On the memo line of the check, please indicate that the donation is for "{sitename}"', 'give' )
 	);
 	$default_text .= '</li>';
 	$default_text .= '<li>' . __( 'Please mail your check to:', 'give' ) . '</li>';
 	$default_text .= '</ol>';
+	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;{offline_mailing_address}<br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . $sitename . '</em><br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>';
 	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>';
 	$default_text .= '<p>' . __( 'Once your donation has been received we will mark it as complete and you will receive an email receipt for your records. Please contact us with any questions you may have!', 'give' ) . '</p>';
 	$default_text .= '<p>' . __( 'Sincerely,', 'give' ) . '</p>';
-	$default_text .= '<p>' . $sitename . '</p>';
+	$default_text .= '<p>{sitename}</p>';
 
 	return apply_filters( 'give_default_offline_donation_content', $default_text );
 

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -361,21 +361,18 @@ function give_get_default_offline_donation_content() {
 	$default_text = '<p>' . __( 'In order to make an offline donation we ask that you please follow these instructions', 'give' ) . ': </p>';
 	$default_text .= '<ol>';
 	$default_text .= '<li>';
-	$default_text .= sprintf(
+	$default_text .= give_do_email_tags( sprintf(
 	/* translators: %s: site name */
-		__( 'Make a check payable to "{sitename}"', 'give' ) );
+		__( 'Make a check payable to "{sitename}"', 'give' ) ), null );
 	$default_text .= '</li>';
 	$default_text .= '<li>';
-	$default_text .= sprintf(
+	$default_text .= give_do_email_tags( sprintf(
 	/* translators: %s: site name */
-		__( 'On the memo line of the check, please indicate that the donation is for "{sitename}"', 'give' ) );
+		__( 'On the memo line of the check, please indicate that the donation is for "{sitename}"', 'give' ) ), null );
 	$default_text .= '</li>';
 	$default_text .= '<li>' . __( 'Please mail your check to:', 'give' ) . '</li>';
 	$default_text .= '</ol>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;{offline_mailing_address}<br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . $sitename . '</em><br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>';
+	$default_text .= give_do_email_tags( '{offline_mailing_address}<br>', null );
 	$default_text .= '<p>' . __( 'All contributions will be gratefully acknowledged and are tax deductible.', 'give' ) . '</p>';
 
 	return apply_filters( 'give_default_offline_donation_content', $default_text );
@@ -408,10 +405,7 @@ function give_get_default_offline_donation_email_content() {
 	$default_text .= '</li>';
 	$default_text .= '<li>' . __( 'Please mail your check to:', 'give' ) . '</li>';
 	$default_text .= '</ol>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;{offline_mailing_address}<br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>' . $sitename . '</em><br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>111 Not A Real St.</em><br>';
-	$default_text .= '&nbsp;&nbsp;&nbsp;&nbsp;<em>Anytown, CA 12345 </em><br>';
+	$default_text .= '{offline_mailing_address}<br>';
 	$default_text .= '<p>' . __( 'Once your donation has been received we will mark it as complete and you will receive an email receipt for your records. Please contact us with any questions you may have!', 'give' ) . '</p>';
 	$default_text .= '<p>' . __( 'Sincerely,', 'give' ) . '</p>';
 	$default_text .= '<p>{sitename}</p>';


### PR DESCRIPTION
Closes #3070 

## Description
This PR adds a feature to add **admin email** address and **offline mailing address** in a common place. This makes it easier to export Give Settings from one URL and import it to a different URL without the need to manually change the admin email address, site URL, site name and the offline mailing address. More details can be found in the video below. 

### The following email tags are added in this feature:
1. `{admin_email}`
2. `{offline_mailing_address}`
3. `{site_url}`

## How Has This Been Tested?
By sending and previewing emails.

## Video:
https://www.useloom.com/share/d9756dd20a874037bd9a15c8fa17c78c

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.