### PR TITLE
fix(shortcode): exclude fee-recovery income from give_totals #208

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -679,6 +679,17 @@ function give_totals_shortcode( $atts ) {
 
 	}
 
+	/**
+	 * Update Form earnings.
+	 *
+	 * @since 2.1.5
+	 *
+	 * @param string $form_earning Total earning of Form.
+	 *
+	 * @return string $form_earning Total earning of Form.
+	 */
+	$total = apply_filters( 'give_totals_goal_earning', $total );
+
 	// Append link with text.
 	$donate_link = '';
 	if ( ! empty( $atts['link'] ) ) {


### PR DESCRIPTION
## Description
PR to fix issues https://github.com/WordImpress/Give-Fee-Recovery/issues/208

## How Has This Been Tested?
Tested by view the Give Totals Goal amount 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.