### PR TITLE
fix(donation): Modal and Button display modes improperly showing payment errors #3006

### DIFF
--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -75,6 +75,12 @@ Layout
 		margin: 20px 0 0 0;
 	}
 
+	&.give-display-modal {
+		form .give_notices {
+			display: none;
+		}
+	}
+
 	&.give-display-reveal, &.give-display-modal {
 		.give-btn {
 			margin: 0 0 15px;
@@ -762,6 +768,9 @@ div.mfp-content {
 		}
 	}
 
+	form[id*='give-form'] .give_notices {
+		display: block !important;
+	}
 }
 
 /*---------------------------------

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -57,7 +57,7 @@ class Give_Notices {
 		add_action( 'give_dismiss_notices', array( $this, 'dismiss_notices' ) );
 
 		add_action( 'give_frontend_notices', array( $this, 'render_frontend_notices' ), 999 );
-		add_action( 'init', array( $this, 'load_actions_for_notices' ) );
+		add_action( 'give_pre_form_output', array( $this, 'render_frontend_form_notices' ), 10, 1 );
 		add_action( 'give_ajax_donation_errors', array( $this, 'render_frontend_notices' ) );
 
 		/**
@@ -289,15 +289,14 @@ class Give_Notices {
 	 * the type of form display option.
 	 *
 	 * @since 2.2
-	 *
 	 * @access public
+	 *
+	 * @param int $form_id Form ID.
 	 *
 	 * @return void
 	 */
-	public function load_actions_for_notices() {
-		$request_form_id = isset( $_REQUEST['form-id'] ) ? absint( $_REQUEST['form-id'] ) : 0;
-
-		$display_option = give_get_meta( $request_form_id, '_give_payment_display', true );
+	public function render_frontend_form_notices( $form_id ) {
+		$display_option = give_get_meta( $form_id, '_give_payment_display', true );
 
 		if ( 'modal' === $display_option ) {
 			add_action( 'give_payment_mode_top', array( $this, 'render_frontend_notices' ) );

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -57,7 +57,7 @@ class Give_Notices {
 		add_action( 'give_dismiss_notices', array( $this, 'dismiss_notices' ) );
 
 		add_action( 'give_frontend_notices', array( $this, 'render_frontend_notices' ), 999 );
-		add_action( 'give_pre_form', array( $this, 'render_frontend_notices' ), 11 );
+		add_action( 'init', array( $this, 'load_actions_for_notices' ) );
 		add_action( 'give_ajax_donation_errors', array( $this, 'render_frontend_notices' ) );
 
 		/**
@@ -281,6 +281,28 @@ class Give_Notices {
 			self::print_frontend_errors( $errors );
 
 			give_clear_errors();
+		}
+	}
+
+	/**
+	 * Renders notices for different actions depending on
+	 * the type of form display option.
+	 *
+	 * @since 2.2
+	 *
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function load_actions_for_notices() {
+		$request_form_id = isset( $_REQUEST['form-id'] ) ? absint( $_REQUEST['form-id'] ) : 0;
+
+		$display_option = give_get_meta( $request_form_id, '_give_payment_display', true );
+
+		if ( 'modal' === $display_option ) {
+			add_action( 'give_payment_mode_top', array( $this, 'render_frontend_notices' ) );
+		} else {
+			add_action( 'give_pre_form', array( $this, 'render_frontend_notices' ), 11 );
 		}
 	}
 


### PR DESCRIPTION
Closes #3006 

## Description
This PR fixes the overlapping of modal over front-end error notices when the form display option is set to `modal` 

CC: @samsmith89 

## How Has This Been Tested?
1. Payment Gateway: Authorize.net CC
2. CC number: `4000 0000 0000 0002`
3. CVC number: `901`
4. Form display options: `modal` and `button`

The above settings will generate a transaction failure which will throw a front-end error notice.

## Video
https://www.useloom.com/share/e75c465bcb564ce59114100df1d7c9c9

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.