### PR TITLE
compat(muffin-builder): ensure compatibility with BeTheme's MuffinBuilder #3353

### DIFF
--- a/assets/src/js/admin/admin-export.js
+++ b/assets/src/js/admin/admin-export.js
@@ -9,7 +9,6 @@
  * @license:     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-jQuery.noConflict();
 jQuery( document ).ready( function ( $ ) {
 
 	/**

--- a/assets/src/js/admin/admin-forms.js
+++ b/assets/src/js/admin/admin-forms.js
@@ -8,7 +8,6 @@
  * @license:     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-jQuery.noConflict();
 (function( $ ) {
 	/**
 	 * Default Radio Button

--- a/assets/src/js/admin/admin-importer.js
+++ b/assets/src/js/admin/admin-importer.js
@@ -17,16 +17,14 @@ import {GiveWarningAlert, GiveErrorAlert, GiveConfirmModal} from '../plugins/mod
 
 var give_setting_edit = true;
 
-jQuery.noConflict();
-(
-	function ( $ ) {
+( function ( $ ) {
 
 		// On DOM Ready.
 		$( function () {
 			give_import_donation_onload();
 		} );
 	}
-)( jQuery );
+) ( jQuery );
 
 /**
  * Run when user click on submit button.

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -8,8 +8,6 @@
  */
 import {GiveWarningAlert, GiveErrorAlert, GiveConfirmModal} from '../plugins/modal';
 
-jQuery.noConflict();
-
 // Provided access to global level.
 var give_setting_edit = false;
 

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -10,7 +10,6 @@
  */
 import {GiveWarningAlert, GiveErrorAlert, GiveConfirmModal, GiveSuccessAlert} from '../plugins/modal';
 
-jQuery.noConflict();
 jQuery(document).ready(function ($) {
 
 	/**

--- a/assets/src/js/admin/admin-widgets.js
+++ b/assets/src/js/admin/admin-widgets.js
@@ -8,7 +8,6 @@
  * @license:     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-jQuery.noConflict();
 (function ( $ ) {
 
 	/**


### PR DESCRIPTION
Closes #3353 

## Description
Fixes plugin incompatibility with BeTheme's Muffin Builder. The issue was caused by the usage of `jQuery.noConflict()` which was unnecessarily used in Give plugin since we are already using IIFE pattern in many of Give's JS files and also scoping `$` within the function using the following methods:

```JS
jQuery(document).ready( function( $ ) {

});
```
**OR**
```JS
jQuery( function( $ ) {

});
```

## How Has This Been Tested?
By using Muffin Builder and checking the console for any errors.
Also tested Give Shortcode button, Give settings and Form Meta settings.

## Video
https://www.useloom.com/share/6c6185d5a7034315acbea25c4747a854

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.