### PR TITLE
fix(modal-api): Make modal API globally available for all addons

### DIFF
--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -10,6 +10,11 @@
  */
 import {GiveWarningAlert, GiveErrorAlert, GiveConfirmModal, GiveSuccessAlert} from '../plugins/modal';
 
+window.GiveWarningAlert = GiveWarningAlert;
+window.GiveErrorAlert   = GiveErrorAlert;
+window.GiveConfirmModal = GiveConfirmModal;
+window.GiveSuccessAlert = GiveSuccessAlert;
+
 jQuery(document).ready(function ($) {
 
 	/**

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -230,6 +230,8 @@ class Give_Scripts {
 			'currency_decimals'                 => give_get_price_decimals(),
 			'ok'                                => __( 'Ok', 'give' ),
 			'cancel'                            => __( 'Cancel', 'give' ),
+			'success'                           => __( 'Success', 'give' ),
+			'error'                             => __( 'Error', 'give' ),
 			'close'                             => __( 'Close', 'give' ),
 			'confirm'                           => __( 'Confirm', 'give' ),
 			'confirm_action'                    => __( 'Confirm Action', 'give' ),


### PR DESCRIPTION
## Description
This PR makes the Give Modal API globally available for all addons.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.