### PR TITLE
fix(donation): approved comment mail are getting send when making new donation from Give Core 2.2 #3421

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -333,7 +333,7 @@ class Give_MetaBox_Form_Data {
 							),
 						),
 						array(
-							'name'    => __( 'Donor Thought', 'give' ),
+							'name'    => __( 'Donor Comment', 'give' ),
 							'desc'    => __( 'Would you like donors to give option to add his/her thought while donaitng.', 'give' ),
 							'id'      => "{$prefix}donor_thought",
 							'type'    => 'radio_inline',

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 							),
 						),
 						array(
-							'name'    => __( 'Donation Note', 'give' ),
+							'name'    => __( 'Donation Comment', 'give' ),
 							'desc'    => __( 'Do you want to provide donors the ability to add a note to his/her donation? The note will display publicly on the donor wall if they do not select to give anonymously.', 'give' ),
 							'id'      => 'donor_thought',
 							'type'    => 'radio_inline',

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 							),
 						),
 						array(
-							'name'    => __( 'Donation Comment', 'give' ),
+							'name'    => __( 'Donor Comment', 'give' ),
 							'desc'    => __( 'Do you want to provide donors the ability to add a note to his/her donation? The note will display publicly on the donor wall if they do not select to give anonymously.', 'give' ),
 							'id'      => 'donor_thought',
 							'type'    => 'radio_inline',


### PR DESCRIPTION
## Description
PR to fix #3421 

## Task
- [x] Text change in Global setting page from `Donor Note` to `Donor Comment`
- [x] Text change in form setting page from `Donor Thought` to `Donor Comment`
- [x] EMail are not getting send so did not fix that issues

## How Has This Been Tested?
Tested by making a donation with donor comment and without donor comment 

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/42164398-8a6b8cd8-7e23-11e8-98d2-55ff6fa7a5d0.png)

![image](https://user-images.githubusercontent.com/22215595/42164437-a0c52160-7e23-11e8-9ddc-d1b9d252e38d.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.