### PR TITLE
fix(emails): Remove Give shortcode button from Emails Settings Page

### DIFF
--- a/includes/admin/emails/filters.php
+++ b/includes/admin/emails/filters.php
@@ -70,3 +70,24 @@ function give_decode_email_tags( $message, $email_obj ) {
 }
 
 add_filter( 'give_email_message', 'give_decode_email_tags', 10, 2 );
+
+/**
+ * This removes the shortcode button from the emails settings page.
+ *
+ * @since 2.2
+ *
+ * @return boolean
+ */
+function give_remove_shortcode_button_on_email_settings_page() {
+
+	$page = give_get_current_setting_page();
+	$tab  = give_get_current_setting_tab();
+
+	if ( 'give-settings' === $page && 'emails' === $tab ) {
+		return false;
+	}
+
+	return true;
+}
+
+add_filter( 'give_enable_shortcode_button', 'give_remove_shortcode_button_on_email_settings_page' );

--- a/includes/admin/shortcodes/class-shortcode-button.php
+++ b/includes/admin/shortcodes/class-shortcode-button.php
@@ -47,7 +47,10 @@ final class Give_Shortcode_Button {
 
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_assets' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_localize_scripts' ), 13 );
-			add_action( 'media_buttons', array( $this, 'shortcode_button' ) );
+
+			if ( true === apply_filters( 'give_enable_shortcode_button', true ) ) {
+				add_action( 'media_buttons', array( $this, 'shortcode_button' ) );
+			}
 		}
 
 		add_action( "wp_ajax_give_shortcode", array( $this, 'shortcode_ajax' ) );


### PR DESCRIPTION
Closes #3422 

## Description
This PR removes the **Give Shortcode** button from the Email Settings Page.

## How Has This Been Tested?
By visiting any of the Email Notifications Settings pages.

## Screenshots (jpeg or gifs if applicable):
![noshortcodebutton](https://snag.gy/e4yKcZ.jpg)

**As you can see, the Give Shortcode button no longer exists.**

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.