### PR TITLE
fix(donation): don't block login form after first failed login #3423

### DIFF
--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -736,6 +736,14 @@ User Login
 	}
 }
 
+.give-user-login-fields-container {
+	&:after {
+		display: block;
+		content: '';
+		clear: both;
+	}
+}
+
 /* Login Shortcode Form */
 #give-login-form,
 #give-register-form {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1406,41 +1406,44 @@ function give_get_login_fields( $form_id ) {
 		 *
 		 * @param int $form_id The form ID.
 		 */
-		do_action( 'give_checkout_login_fields_before', $form_id );
+		// do_action( 'give_checkout_login_fields_before', $form_id );
 		?>
-		<div id="give-user-login-wrap-<?php echo $form_id; ?>" class="form-row form-row-first form-row-responsive">
-			<label class="give-label" for="give-user-login-<?php echo $form_id; ?>">
-				<?php _e( 'Username', 'give' ); ?>
-				<?php if ( give_logged_in_only( $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
-				<?php } ?>
-			</label>
+		<div class="give-user-login-fields-container">
+			<div id="give-user-login-wrap-<?php echo $form_id; ?>" class="form-row form-row-first form-row-responsive">
+				<label class="give-label" for="give-user-login-<?php echo $form_id; ?>">
+					<?php _e( 'Username', 'give' ); ?>
+					<?php if ( give_logged_in_only( $form_id ) ) { ?>
+						<span class="give-required-indicator">*</span>
+					<?php } ?>
+				</label>
 
-			<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>" type="text"
-				   name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" value=""
-				   placeholder="<?php _e( 'Your username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+				<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>" type="text"
+					   name="give_user_login" id="give-user-login-<?php echo $form_id; ?>" value=""
+					   placeholder="<?php _e( 'Your username', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+			</div>
+
+			<div id="give-user-pass-wrap-<?php echo $form_id; ?>"
+				 class="give_login_password form-row form-row-last form-row-responsive">
+				<label class="give-label" for="give-user-pass-<?php echo $form_id; ?>">
+					<?php _e( 'Password', 'give' ); ?>
+					<?php if ( give_logged_in_only( $form_id ) ) { ?>
+						<span class="give-required-indicator">*</span>
+					<?php } ?>
+				</label>
+				<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>"
+					   type="password" name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>"
+					   placeholder="<?php _e( 'Your password', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
+				<input type="hidden" name="give-purchase-var" value="needs-to-login"/>
+			</div>
+
+			<div id="give-forgot-password-wrap-<?php echo $form_id; ?>" class="give_login_forgot_password">
+				 <span class="give-forgot-password ">
+					 <a href="<?php echo wp_lostpassword_url() ?>"
+						target="_blank"><?php _e( 'Reset Password', 'give' ) ?></a>
+				 </span>
+			</div>
 		</div>
 
-		<div id="give-user-pass-wrap-<?php echo $form_id; ?>"
-			 class="give_login_password form-row form-row-last form-row-responsive">
-			<label class="give-label" for="give-user-pass-<?php echo $form_id; ?>">
-				<?php _e( 'Password', 'give' ); ?>
-				<?php if ( give_logged_in_only( $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
-				<?php } ?>
-			</label>
-			<input class="give-input<?php echo ( give_logged_in_only( $form_id ) ) ? ' required' : ''; ?>"
-				   type="password" name="give_user_pass" id="give-user-pass-<?php echo $form_id; ?>"
-				   placeholder="<?php _e( 'Your password', 'give' ); ?>"<?php echo ( give_logged_in_only( $form_id ) ) ? ' required aria-required="true" ' : ''; ?>/>
-			<input type="hidden" name="give-purchase-var" value="needs-to-login"/>
-		</div>
-
-		<div id="give-forgot-password-wrap-<?php echo $form_id; ?>" class="give_login_forgot_password">
-			 <span class="give-forgot-password ">
-				 <a href="<?php echo wp_lostpassword_url() ?>"
-					target="_blank"><?php _e( 'Reset Password', 'give' ) ?></a>
-			 </span>
-		</div>
 
 		<div id="give-user-login-submit-<?php echo $form_id; ?>" class="give-clearfix">
 			<input type="submit" class="give-submit give-btn button" name="give_login_submit"


### PR DESCRIPTION
Closes #3423 

## Description
This issue was caused because the height of parent of the floated children was collapsed. This has been fixed by adding another parent container and adding the clearfix CSS fix.

## How Has This Been Tested?
By making a failed login attempt and trying to reenter login details.


## Video
https://www.useloom.com/share/1cdcb9214d7e450694c7f97126e7c04e

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.