### PR TITLE
fix(admin-tool): deleting all data doesn't remove form categories or tags #3145

### DIFF
--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -128,6 +128,14 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 						$sql[] = "DELETE FROM $wpdb->postmeta WHERE post_id IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->comments WHERE comment_post_ID IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)";
+						$sql[] = "DELETE
+							FROM $wpdb->terms
+							WHERE $wpdb->terms.term_id IN
+							(SELECT $wpdb->term_taxonomy.term_id
+							FROM $wpdb->term_taxonomy
+							WHERE $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_category'
+							OR $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_tag')";
+						$sql[] = "DELETE FROM $wpdb->term_taxonomy WHERE $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_category' OR $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_tag'";
 						break;
 				}
 


### PR DESCRIPTION
Closes #3145 

## Description
This PR adds a feature to delete the form categories and tags when an admin wants to delete and reset Give. 

## How Has This Been Tested?
By deleting and resetting Give, all the form categories and tags have been deleted from the database.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.