### PR TITLE
fix(admin-tool): Replace LIKE with `=`

### DIFF
--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -128,14 +128,14 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 						$sql[] = "DELETE FROM $wpdb->postmeta WHERE post_id IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->comments WHERE comment_post_ID IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)";
-						$sql[] = "DELETE
+						$sql[] = $wpdb->prepare( "DELETE
 							FROM $wpdb->terms
 							WHERE $wpdb->terms.term_id IN
 							(SELECT $wpdb->term_taxonomy.term_id
 							FROM $wpdb->term_taxonomy
-							WHERE $wpdb->term_taxonomy.taxonomy = 'give_forms_category'
-							OR $wpdb->term_taxonomy.taxonomy = 'give_forms_tag')";
-						$sql[] = "DELETE FROM $wpdb->term_taxonomy WHERE $wpdb->term_taxonomy.taxonomy = 'give_forms_category' OR $wpdb->term_taxonomy.taxonomy = 'give_forms_tag'";
+							WHERE $wpdb->term_taxonomy.taxonomy = '%s'
+							OR $wpdb->term_taxonomy.taxonomy = '%s')", array( 'give_forms_category', 'give_forms_tag' ) );
+						$sql[] = $wpdb->prepare( "DELETE FROM $wpdb->term_taxonomy WHERE $wpdb->term_taxonomy.taxonomy = '%s' OR $wpdb->term_taxonomy.taxonomy = '%s'", array( 'give_forms_category', 'give_forms_tag' ) );
 						break;
 				}
 

--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -133,9 +133,9 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 							WHERE $wpdb->terms.term_id IN
 							(SELECT $wpdb->term_taxonomy.term_id
 							FROM $wpdb->term_taxonomy
-							WHERE $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_category'
-							OR $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_tag')";
-						$sql[] = "DELETE FROM $wpdb->term_taxonomy WHERE $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_category' OR $wpdb->term_taxonomy.taxonomy LIKE 'give_forms_tag'";
+							WHERE $wpdb->term_taxonomy.taxonomy = 'give_forms_category'
+							OR $wpdb->term_taxonomy.taxonomy = 'give_forms_tag')";
+						$sql[] = "DELETE FROM $wpdb->term_taxonomy WHERE $wpdb->term_taxonomy.taxonomy = 'give_forms_category' OR $wpdb->term_taxonomy.taxonomy = 'give_forms_tag'";
 						break;
 				}
 


### PR DESCRIPTION
This is a quick fix.
Related to #3441 

## Description
Replaced `LIKE` with `=` in the SQL query.
