### PR TITLE
fix(admin-donation): ensure users can edit company name #3413

### DIFF
--- a/includes/admin/donors/donor-actions.php
+++ b/includes/admin/donors/donor-actions.php
@@ -106,6 +106,9 @@ function give_edit_donor( $args ) {
 
 	$donor->update_meta( '_give_anonymous_donor', absint( $args['give_anonymous_donor'] ) );
 
+	// Save company name in when admin update donor company name from dashboard.
+	$donor->update_meta( '_give_donor_company', sanitize_text_field( $args['give_donor_company'] ) );
+
 	// If First name of donor is empty, then fetch the current first name of donor.
 	if ( empty( $donor_info['first_name'] ) ) {
 		$donor_info['first_name'] = $donor->get_first_name();

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -173,11 +173,12 @@ function give_donors_list() {
 		?>
 
 		<hr class="wp-header-end">
-		<form id="give-donors-search-filter" method="get" action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors' ); ?>">
+		<form id="give-donors-search-filter" method="get"
+		      action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors' ); ?>">
 			<?php $donors_table->search_box( __( 'Search Donors', 'give' ), 'give-donors' ); ?>
-			<input type="hidden" name="post_type" value="give_forms" />
-			<input type="hidden" name="page" value="give-donors" />
-			<input type="hidden" name="view" value="donors" />
+			<input type="hidden" name="post_type" value="give_forms"/>
+			<input type="hidden" name="page" value="give-donors"/>
+			<input type="hidden" name="view" value="donors"/>
 		</form>
 		<form id="give-donors-filter" method="get">
 			<?php $donors_table->display(); ?>
@@ -202,8 +203,8 @@ function give_donors_list() {
  *
  * @since  1.0
  *
- * @param  string $view      The View being requested.
- * @param  array  $callbacks The Registered views and their callback functions.
+ * @param  string $view The View being requested.
+ * @param  array $callbacks The Registered views and their callback functions.
  *
  * @return void
  */
@@ -329,7 +330,8 @@ function give_donor_view( $donor ) {
 	}
 	?>
 	<div id="donor-summary" class="info-wrapper donor-section postbox">
-		<form id="edit-donor-info" method="post" action="<?php echo esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) ); ?>">
+		<form id="edit-donor-info" method="post"
+		      action="<?php echo esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) ); ?>">
 			<div class="donor-info">
 				<div class="donor-bio-header clearfix">
 					<div class="avatar-wrap left" id="donor-avatar">
@@ -340,22 +342,23 @@ function give_donor_view( $donor ) {
 							<select name="donor_info[title]">
 								<option value="0"><?php esc_html_e( 'Title', 'give' ); ?></option>
 								<?php foreach ( $title_prefixes as $title ) { ?>
-									<option <?php selected( $title_prefix, $title ); ?> value="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $title ); ?></option>
+									<option <?php selected( $title_prefix, $title ); ?>
+										value="<?php echo esc_html( $title ); ?>"><?php echo esc_html( $title ); ?></option>
 								<?php } ?>
 							</select>
 							<input <?php echo $read_only; ?> size="15" data-key="first_name"
-									name="donor_info[first_name]" type="text"
-									value="<?php echo esc_html( $donor->get_first_name() ); ?>"
-									placeholder="<?php esc_html_e( 'First Name', 'give' ); ?>"/>
+							                                 name="donor_info[first_name]" type="text"
+							                                 value="<?php echo esc_html( $donor->get_first_name() ); ?>"
+							                                 placeholder="<?php esc_html_e( 'First Name', 'give' ); ?>"/>
 							<?php if ( $donor->user_id ) : ?>
 								<a href="#" class="give-lock-block">
 									<i class="give-icon give-icon-locked"></i>
 								</a>
 							<?php endif; ?>
 							<input <?php echo $read_only; ?> size="15" data-key="last_name"
-									name="donor_info[last_name]" type="text"
-									value="<?php echo esc_html( $donor->get_last_name() ); ?>"
-									placeholder="<?php esc_html_e( 'Last Name', 'give' ); ?>"/>
+							                                 name="donor_info[last_name]" type="text"
+							                                 value="<?php echo esc_html( $donor->get_last_name() ); ?>"
+							                                 placeholder="<?php esc_html_e( 'Last Name', 'give' ); ?>"/>
 							<?php if ( $donor->user_id ) : ?>
 								<a href="#" class="give-lock-block">
 									<i class="give-icon give-icon-locked"></i>
@@ -383,11 +386,13 @@ function give_donor_view( $donor ) {
 					<table class="widefat striped">
 						<tbody>
 						<tr>
-							<th scope="col"><label for="tablecell"><?php esc_html_e( 'Donor ID:', 'give' ); ?></label></th>
+							<th scope="col"><label for="tablecell"><?php esc_html_e( 'Donor ID:', 'give' ); ?></label>
+							</th>
 							<td><?php echo intval( $donor->id ); ?></td>
 						</tr>
 						<tr>
-							<th scope="col"><label for="tablecell"><?php esc_html_e( 'User ID:', 'give' ); ?></label></th>
+							<th scope="col"><label for="tablecell"><?php esc_html_e( 'User ID:', 'give' ); ?></label>
+							</th>
 							<td>
 									<span class="donor-user-id info-item edit-item">
 										<?php
@@ -415,9 +420,11 @@ function give_donor_view( $donor ) {
 
 								<span class="donor-user-id info-item editable">
 										<?php if ( ! empty( $userdata ) ) : ?>
-											<span data-key="user_id">#<?php echo $donor->user_id . ' - ' . $userdata->display_name; ?></span>
+											<span
+												data-key="user_id">#<?php echo $donor->user_id . ' - ' . $userdata->display_name; ?></span>
 										<?php else : ?>
-											<span data-key="user_id"><?php esc_html_e( 'Unregistered', 'give' ); ?></span>
+											<span
+												data-key="user_id"><?php esc_html_e( 'Unregistered', 'give' ); ?></span>
 										<?php endif; ?>
 									<?php if ( current_user_can( $donor_edit_role ) && intval( $donor->user_id ) > 0 ) :
 
@@ -442,18 +449,21 @@ function give_donor_view( $donor ) {
 
 						<?php
 						$donor_company = $donor->get_meta( '_give_donor_company', true );
-
-						if ( ! empty( $donor_company ) ) {
-							?>
-							<tr class="alternate">
-								<th scope="col">
-									<label for="tablecell"><?php esc_html_e( 'Company Name:', 'give' ); ?></label>
-								</th>
-								<td><?php echo $donor_company; ?></td>
-							</tr>
-							<?php
-						}
 						?>
+						<tr class="alternate">
+							<th scope="col">
+								<label for="tablecell"><?php esc_html_e( 'Company Name:', 'give' ); ?></label>
+							</th>
+							<td>
+								<span class="donor-user-id info-item edit-item">
+									<input name="give_donor_company" value="<?php echo $donor_company ?>" type="text">
+								</span>
+
+								<span class="donor-user-id info-item editable">
+									<?php echo $donor_company; ?>
+								</span>
+							</td>
+						</tr>
 
 						<?php $anonymous_donor = absint( $donor->get_meta( '_give_anonymous_donor', true ) ); ?>
 						<tr class="alternate">
@@ -476,9 +486,9 @@ function give_donor_view( $donor ) {
 										<li>
 											<label>
 												<input
-														name="give_anonymous_donor"
-														value="0"
-														type="radio"
+													name="give_anonymous_donor"
+													value="0"
+													type="radio"
 													<?php checked( 0, $anonymous_donor ) ?>
 												><?php _e( 'No', 'give' ); ?>
 											</label>
@@ -502,7 +512,7 @@ function give_donor_view( $donor ) {
 				<?php wp_nonce_field( 'edit-donor', '_wpnonce', false, true ); ?>
 				<input type="hidden" name="give_action" value="edit-donor"/>
 				<input type="submit" id="give-edit-donor-save" class="button-secondary"
-						value="<?php esc_html_e( 'Update Donor', 'give' ); ?>"/>
+				       value="<?php esc_html_e( 'Update Donor', 'give' ); ?>"/>
 				<a id="give-edit-donor-cancel" href="" class="delete"><?php esc_html_e( 'Cancel', 'give' ); ?></a>
 			</span>
 
@@ -675,7 +685,8 @@ function give_donor_view( $donor ) {
 								?>
 								<tr class="give-field-wrap">
 									<th class="col">
-										<label for="state"><?php esc_html_e( 'State / Province / County:', 'give' ); ?></label>
+										<label
+											for="state"><?php esc_html_e( 'State / Province / County:', 'give' ); ?></label>
 									</th>
 									<td>
 										<?php
@@ -726,8 +737,8 @@ function give_donor_view( $donor ) {
 									<input type="hidden" name="address-action" value="add">
 									<input type="hidden" name="address-id" value="">
 									<input type="submit" class="button button-primary js-save"
-											value="<?php _e( 'Save', 'give' ); ?>">&nbsp;&nbsp;<button
-											class="button js-cancel"><?php _e( 'Cancel', 'give' ); ?></button>
+									       value="<?php _e( 'Save', 'give' ); ?>">&nbsp;&nbsp;<button
+										class="button js-cancel"><?php _e( 'Cancel', 'give' ); ?></button>
 								</td>
 							</tr>
 							</tbody>
@@ -810,12 +821,12 @@ function give_donor_view( $donor ) {
 							<input type="hidden" name="donor-id" value="<?php echo $donor->id; ?>"/>
 							<?php wp_nonce_field( 'give_add_donor_email', 'add_email_nonce', false, true ); ?>
 							<input type="email" name="additional-email" value=""
-									placeholder="<?php _e( 'Email Address', 'give' ); ?>"/>&nbsp;
+							       placeholder="<?php _e( 'Email Address', 'give' ); ?>"/>&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1"
-									id="make-additional-primary"/>&nbsp;<label
-									for="make-additional-primary"><?php _e( 'Make Primary', 'give' ); ?></label>
+							       id="make-additional-primary"/>&nbsp;<label
+								for="make-additional-primary"><?php _e( 'Make Primary', 'give' ); ?></label>
 							<button class="button-secondary give-add-donor-email"
-									id="add-donor-email"><?php _e( 'Add Email', 'give' ); ?></button>
+							        id="add-donor-email"><?php _e( 'Add Email', 'give' ); ?></button>
 							<span class="spinner"></span>
 						</div>
 						<div class="notice-wrap"></div>
@@ -853,7 +864,11 @@ function give_donor_view( $donor ) {
 				<?php foreach ( $payments as $payment ) : ?>
 					<tr>
 						<td><?php echo Give()->seq_donation_number->get_serial_code( $payment->ID ); ?></td>
-						<td><?php echo give_donation_amount( $payment->ID, array( 'currency' => true, 'amount' => true, 'type' => 'donor' ) ); ?></td>
+						<td><?php echo give_donation_amount( $payment->ID, array(
+								'currency' => true,
+								'amount'   => true,
+								'type'     => 'donor'
+							) ); ?></td>
 						<td><?php echo date_i18n( give_date_format(), strtotime( $payment->post_date ) ); ?></td>
 						<td><?php echo give_get_payment_status( $payment, true ); ?></td>
 						<td>
@@ -878,7 +893,7 @@ function give_donor_view( $donor ) {
 							 *
 							 * @since 1.0
 							 *
-							 * @param object $donor   The donor object being displayed.
+							 * @param object $donor The donor object being displayed.
 							 * @param object $payment The payment object being displayed.
 							 */
 							do_action( 'give_donor_recent_purchases_actions', $donor, $payment );
@@ -980,7 +995,7 @@ function give_donor_view( $donor ) {
 								'<a href="%1$s" aria-label="%2$s" target="_blank">%3$s</a>',
 								admin_url( "edit.php?post_type=give_forms&page=give-payment-history&view=view-payment-details&id={$donation->ID}#give-payment-donor-comment" ),
 								sprintf(
-									/* translators: %s: Comment ID */
+								/* translators: %s: Comment ID */
 									esc_attr__( 'Edit Comment %s.', 'give' ),
 									$comment->comment_ID
 								),
@@ -1051,7 +1066,7 @@ function give_donor_notes_view( $donor ) {
 		<?php if ( 1 == $paged ) : ?>
 			<div style="display: block; margin-bottom: 55px;">
 				<form id="give-add-donor-note" method="post"
-						action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=notes&id=' . $donor->id ); ?>">
+				      action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=notes&id=' . $donor->id ); ?>">
 					<textarea id="donor-note" name="donor_note" class="donor-note-input" rows="10"></textarea>
 					<br/>
 					<input type="hidden" id="donor-id" name="customer_id" value="<?php echo $donor->id; ?>"/>
@@ -1123,7 +1138,7 @@ function give_donor_delete_view( $donor ) {
 	<div class="info-wrapper donor-section">
 
 		<form id="delete-donor" method="post"
-				action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=delete&id=' . $donor->id ); ?>">
+		      action="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=delete&id=' . $donor->id ); ?>">
 
 			<div class="donor-notes-header">
 				<?php echo get_avatar( $donor->email, 30 ); ?> <span><?php echo $donor->name; ?></span>
@@ -1137,7 +1152,8 @@ function give_donor_delete_view( $donor ) {
 						<?php echo Give()->html->checkbox( array(
 							'name' => 'give-donor-delete-confirm',
 						) ); ?>
-						<label for="give-donor-delete-confirm"><?php _e( 'Are you sure you want to delete this donor?', 'give' ); ?></label>
+						<label
+							for="give-donor-delete-confirm"><?php _e( 'Are you sure you want to delete this donor?', 'give' ); ?></label>
 					</p>
 
 					<p>
@@ -1147,7 +1163,8 @@ function give_donor_delete_view( $donor ) {
 								'disabled' => true,
 							),
 						) ); ?>
-						<label for="give-donor-delete-records"><?php _e( 'Delete all associated donations and records?', 'give' ); ?></label>
+						<label
+							for="give-donor-delete-records"><?php _e( 'Delete all associated donations and records?', 'give' ); ?></label>
 					</p>
 
 					<?php
@@ -1169,10 +1186,10 @@ function give_donor_delete_view( $donor ) {
 					<?php wp_nonce_field( 'give-delete-donor', '_wpnonce', false, true ); ?>
 					<input type="hidden" name="give_action" value="delete_donor"/>
 					<input type="submit" disabled="disabled" id="give-delete-donor" class="button-primary"
-							value="<?php _e( 'Delete Donor', 'give' ); ?>"/>
+					       value="<?php _e( 'Delete Donor', 'give' ); ?>"/>
 					<a id="give-delete-donor-cancel"
-							href="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ); ?>"
-							class="delete"><?php _e( 'Cancel', 'give' ); ?></a>
+					   href="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ); ?>"
+					   class="delete"><?php _e( 'Cancel', 'give' ); ?></a>
 				</span>
 
 			</div>


### PR DESCRIPTION
## Description
PR to fix #3413 

## How Has This Been Tested?
Tested by updating Donor Company Name from Donor admin page

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFiXXmFaWU

![image](https://user-images.githubusercontent.com/22215595/42569239-7d2405bc-852d-11e8-97e2-af39d44afc8f.png)

![image](https://user-images.githubusercontent.com/22215595/42569253-855a9f16-852d-11e8-931c-793d6374c372.png)




## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.