### PR TITLE
fix(admin-plugins): fix UI for plugin activation banner #3439

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -633,7 +633,6 @@ class Give_Addon_Activation_Banner {
 				display: inline-block;
 				float: left;
 				background: #fff;
-				height: 100%;
 				position: relative;
 			}
 

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -423,6 +423,11 @@ function give_get_recently_activated_addons() {
  * @since 2.2
  */
 function give_deactivation_popup() {
+
+	// Clean previous data in the output buffer.
+	ob_end_clean();
+
+	// Start output bufering.
 	ob_start();
 	?>
 
@@ -540,7 +545,12 @@ function give_deactivation_popup() {
 	</form>
 
 	<?php
+
+	// Echo content (deactivation form) from the output buffer.
 	echo ob_get_clean();
+
+	// Erase and stop output buffer.
+	ob_end_clean();
 
 	wp_die();
 }


### PR DESCRIPTION
Closes #3439 

## Description
This PR fixes [this](https://github.com/WordImpress/Give/issues/3439#issue-338819095) and [this](https://github.com/WordImpress/Give/issues/3439#issuecomment-404040449)

## How Has This Been Tested?
By forcing an activation error and triggering deactivation survey.

## Screenshot
![addonnotice](https://user-images.githubusercontent.com/17757960/42583479-a8cfa6e6-854e-11e8-8ae1-7f417daea072.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.