### PR TITLE
fix(admin-email): format address elements in the correct order

### DIFF
--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -710,14 +710,22 @@ function give_email_tag_billing_address( $tag_args ) {
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
 			$donation_address = give_get_donation_address( $tag_args['payment_id'] );
-			$address  = $donation_address['line1'] . "\n";
+
+			$billing_address                   = array();
+			$billing_address['street_address'] = '';
+			$billing_address['street_address'] .= $donation_address['line1'];
 
 			if ( ! empty( $donation_address['line2'] ) ) {
-				$address .= $donation_address['line2'] . "\n";
+				$billing_address['street_address'] .= "\n" . $donation_address['line2'];
 			}
 
-			$address .= $donation_address['city'] . ' ' . $donation_address['zip'] . ' ' . $donation_address['state'] . "\n";
-			$address .= $donation_address['country'];
+			$billing_address['city']        = $donation_address['city'];
+			$billing_address['state']       = $donation_address['state'];
+			$billing_address['postal_code'] = $donation_address['zip'];
+			$billing_address['country']     = $donation_address['country'];
+
+			$address = give_get_formatted_address( $billing_address );
+
 			break;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2280,25 +2280,28 @@ function give_setcookie( $name, $value, $expire = 0, $secure = false ) {
  * @return string Formatted address.
  */
 function give_get_formatted_address( $address = array() ) {
+	$formatted_address = '';
+
 	/**
 	 * Address format.
 	 *
 	 * @since 2.2.0
 	 */
 	$address_format = apply_filters( 'give_address_format_template', "{street_address}\n{city}, {state} {postal_code}\n{country}" );
+	preg_match_all( "/{([A-z0-9\-\_\ ]+)}/s", $address_format, $matches );
 
-	$address_tag_keys = array_keys( $address );
+	if( ! empty( $matches ) && ! empty( $address ) ) {
+		$address_values = array();
 
-	$address_tags = array();
-	foreach ( $address_tag_keys as $key => $address_tag ) {
-		$address_tags[ $key ] = '{' . trim( $address_tag, '"' ) . '}';
-	}
+		foreach ($matches[1] as $address_tag ) {
+			$address_values[ $address_tag ] = '';
 
-	$address_tag_values = array_filter( array_values( $address ) );
+			if( isset( $address[$address_tag] ) ) {
+				$address_values[ $address_tag ] = $address[$address_tag];
+			}
+		}
 
-	$formatted_address = '';
-	if ( ! empty( $address_tag_values ) ) {
-		$formatted_address  = str_ireplace( $address_tags, $address_tag_values, $address_format );
+		$formatted_address  = str_ireplace( $matches[0], $address_values, $address_format );
 	}
 
 	/**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2269,3 +2269,47 @@ function give_setcookie( $name, $value, $expire = 0, $secure = false ) {
 		);
 	}
 }
+
+/**
+ * Get formatted billing address.
+ *
+ * @since 2.2.0
+ *
+ * @param array $address
+ *
+ * @return string Formatted address.
+ */
+function give_get_formatted_address( $address = array() ) {
+	/**
+	 * Address format.
+	 *
+	 * @since 2.2.0
+	 */
+	$address_format = apply_filters( 'give_address_format_template', "{street_address}\n{city}, {state} {postal_code}\n{country}" );
+
+	$address_tag_keys = array_keys( $address );
+
+	$address_tags = array();
+	foreach ( $address_tag_keys as $key => $address_tag ) {
+		$address_tags[ $key ] = '{' . trim( $address_tag, '"' ) . '}';
+	}
+
+	$address_tag_values = array_filter( array_values( $address ) );
+
+	$formatted_address = '';
+	if ( ! empty( $address_tag_values ) ) {
+		$formatted_address  = str_ireplace( $address_tags, $address_tag_values, $address_format );
+	}
+
+	/**
+	 * Give get formatted address.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $formatted_address Formatted address.
+	 * @param string $address_format    Format of the address.
+	 */
+	$formatted_address = apply_filters( 'give_get_formatted_address', $formatted_address, $address_format, $address );
+
+	return $formatted_address;
+}


### PR DESCRIPTION
## Description
This PR will fix #2790 

## How Has This Been Tested?
- Manually tested
- Run Unit test

## Screenshots (jpeg or gifs if applicable):
![formatted_address](https://user-images.githubusercontent.com/15060983/42624209-7446eed6-85e2-11e8-9eae-6db94936a137.png)


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.