### PR TITLE
fix(admin-form): 2.2 ensure name title prefixes can be removed once saved #3466

### DIFF
--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -339,6 +339,7 @@ function give_chosen_input( $field ) {
 			<?php echo wp_kses_post( $field['name'] ); ?>
 		</label>
 		<?php echo esc_attr( $field['before_field'] ); ?>
+		<input type="hidden" name="<?php echo esc_attr( give_get_field_name( $field ) ); ?>" value="">
 		<select
 				class="give-select-chosen give-chosen-settings"
 				style="<?php echo esc_attr( $field['style'] ); ?>"


### PR DESCRIPTION
Closes #3466 

## Description
Empty multi-select fields are not part of the `$_POST` array and this is what caused the issue. I have added a hidden field with an empty value which will be part of `POST` array if the multi-select field is empty.

## How Has This Been Tested?
I have tested this by creating a form which has Title prefixes created and deleted through form metabox.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.