### PR TITLE
fix(form): 2.2 ensure name title prefix field doesn't wrap to new line on button display #3465

### DIFF
--- a/assets/src/css/frontend/modal.scss
+++ b/assets/src/css/frontend/modal.scss
@@ -44,7 +44,7 @@
 	background: #FFF;
 	padding: 20px;
 	width: auto;
-	max-width: 500px;
+	max-width: 650px;
 	margin: 40px auto;
 	z-index: $mfp-z-index-base + 2147482600;
 


### PR DESCRIPTION
Closes #3465 

## Description
Increased the max-width of the modal.

## How Has This Been Tested?
Tested with `Modal` and `Button` display options.

## Screenshots (jpeg or gifs if applicable):
![maxwidth](https://user-images.githubusercontent.com/17757960/42686615-13ca369e-86b4-11e8-90fe-8b0481e91c4a.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.