### PR TITLE
fix(admin-form): 2.2 ensure name title prefixes can be removed once saved #3466

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -796,6 +796,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 
 						// Get option value.
 						$option_value     = self::get_option( $option_name, $value['id'], $value['default'] );
+						$option_value     = array_fill_keys( $option_value, 'selected' );
 						$wrapper_class    = ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '';
 						$type             = '';
 						$allow_new_values = '';
@@ -803,14 +804,16 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 
 						// Set attributes based on multiselect datatype.
 						if ( 'multiselect' === $value['data_type'] ) {
-							$type = 'multiple';
+							$type             = 'multiple';
 							$allow_new_values = 'data-allows-new-values="true"';
 							$name             = $name . '[]';
-
-							$option_value = empty( $option_value ) ? array() : $option_value;
+							$option_value     = empty( $option_value ) ? array() : $option_value;
 						}
 
-						$value['options'] = array_merge( $value['options'], array_combine( array_values( $option_value ), array_values( $option_value ) ) );
+						$title_prefixes_value = ( is_array( $option_value ) && count( $option_value ) > 0 ) ?
+							array_merge( $value['options'], $option_value ) :
+							$value['options'];
+
 						?>
 						<tr valign="top" <?php echo $wrapper_class; ?>>
 							<th scope="row" class="titledesc">
@@ -818,28 +821,26 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 							</th>
 							<td class="give-forminp give-forminp-<?php echo esc_attr( $value['type'] ); ?>">
 								<select
-									class="give-select-chosen give-chosen-settings"
-									style="<?php echo esc_attr( $value['style'] ); ?>"
-									name="<?php echo esc_attr( $name ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									<?php echo esc_attr( $type ) . ' ' . $allow_new_values; ?>
-									<?php echo implode( ' ', $custom_attributes ); ?>
+										class="give-select-chosen give-chosen-settings"
+										style="<?php echo esc_attr( $value['style'] ); ?>"
+										name="<?php echo esc_attr( $name ); ?>"
+										id="<?php echo esc_attr( $value['id'] ); ?>"
+									<?php
+									echo "{$type} {$allow_new_values}";
+									echo implode( ' ', $custom_attributes );
+									?>
 								>
-									<?php foreach ( $value['options'] as $key => $item_value ) : ?>
-										<option
-											value="<?php echo esc_attr( $key ); ?>"
-											<?php
-											if ( is_array( $option_value ) ) {
-												selected( in_array( $key, $option_value, true ) );
-											} else {
-												selected( $option_value, $key );
-											}
-											?>
-										>
-											<?php echo esc_html( $item_value ); ?>
-										</option>
-									<?php endforeach; ?>
-
+									<?php
+									if ( is_array( $title_prefixes_value ) && count( $title_prefixes_value ) > 0 ) {
+										foreach ( $title_prefixes_value as $key => $item_value ) {
+											echo sprintf(
+												'<option %1$s value="%2$s">%2$s</option>',
+												( 'selected' === $item_value ) ? 'selected="selected"' : '',
+												esc_attr( $key )
+											);
+										}
+									}
+									?>
 								</select>
 								<?php echo wp_kses_post( $description ); ?>
 							</td>

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -822,7 +822,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 									style="<?php echo esc_attr( $value['style'] ); ?>"
 									name="<?php echo esc_attr( $name ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
-									<?php echo esc_attr( $type ) . ' ' . esc_attr( $allow_new_values ); ?>
+									<?php echo esc_attr( $type ) . ' ' . $allow_new_values; ?>
 									<?php echo implode( ' ', $custom_attributes ); ?>
 								>
 									<?php foreach ( $value['options'] as $key => $item_value ) : ?>

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -926,8 +926,8 @@ class Give_MetaBox_Form_Data {
 
 				// Set default value for checkbox fields.
 				if (
-					! isset( $_POST[ $form_meta_key ] )
-					&& ( 'checkbox' === $this->get_field_type( $form_meta_key ) )
+					! isset( $_POST[ $form_meta_key ] ) &&
+					in_array( $this->get_field_type( $form_meta_key ), array( 'checkbox', 'chosen' ) )
 				) {
 					$_POST[ $form_meta_key ] = '';
 				}

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -337,6 +337,7 @@ function give_chosen_input( $field ) {
 		$type = 'multiple';
 		$allow_new_values = 'data-allows-new-values="true"';
 	}
+
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
 		<label for="<?php echo esc_attr( give_get_field_name( $field ) ); ?>">
@@ -348,20 +349,16 @@ function give_chosen_input( $field ) {
 				style="<?php echo esc_attr( $field['style'] ); ?>"
 				name="<?php echo esc_attr( give_get_field_name( $field ) ); ?>[]"
 				id="<?php echo esc_attr( $field['id'] ); ?>"
-			<?php echo esc_attr( $type ) . ' ' . $allow_new_values . ' ' . $placeholder; ?>
+			<?php echo "{$type} {$allow_new_values} {$placeholder}"; ?>
 		>
 			<?php
 			if ( is_array( $title_prefixes_value ) && count( $title_prefixes_value ) > 0 ) {
 				foreach ( $title_prefixes_value as $key => $value ) {
-					$selected_title_prefix = '';
-					if ( 'selected' === $value ) {
-						$selected_title_prefix = 'selected="selected"';
-					}
-					?>
-					<option value="<?php echo esc_attr( $key ); ?>" <?php echo $selected_title_prefix; ?>>
-						<?php echo esc_html( $key ); ?>
-					</option>
-					<?php
+					echo sprintf(
+						'<option %1$s value="%2$s">%2$s</option>',
+						( 'selected' === $value ) ? 'selected="selected"' : '',
+						esc_attr( $key )
+					);
 				}
 			}
 			?>

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -320,13 +320,17 @@ function give_chosen_input( $field ) {
 	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = give_get_field_value( $field, $thepostid );
+	$field['value']         = array_filter( give_get_field_value( $field, $thepostid ) );
+	$field['value']         = array_fill_keys( $field['value'], 'selected' );
 	$field['before_field']  = '';
 	$field['after_field']   = '';
 	$placeholder            = isset( $field['placeholder'] ) ? 'data-placeholder="' . $field['placeholder'] . '"' : '';
 	$data_type              = ! empty( $field['data_type'] ) ? $field['data_type'] : '';
 	$type                   = '';
 	$allow_new_values       = '';
+	$title_prefixes_value   = ( is_array( $field['value'] ) && count( $field['value'] ) > 0 ) ?
+		array_merge( $field['options'], $field['value'] ) :
+		$field['options'];
 
 	// Set attributes based on multiselect datatype.
 	if ( 'multiselect' === $data_type ) {
@@ -344,21 +348,23 @@ function give_chosen_input( $field ) {
 				style="<?php echo esc_attr( $field['style'] ); ?>"
 				name="<?php echo esc_attr( give_get_field_name( $field ) ); ?>[]"
 				id="<?php echo esc_attr( $field['id'] ); ?>"
-			<?php echo esc_attr( $type ) . ' ' . esc_attr( $allow_new_values ) . ' ' . esc_attr( $placeholder ); ?>
+			<?php echo esc_attr( $type ) . ' ' . $allow_new_values . ' ' . $placeholder; ?>
 		>
-			<?php foreach ( $field['options'] as $key => $value ) { ?>
-				<option value="<?php echo esc_attr( $key ); ?>"
-					<?php
-					if ( is_array( $field['value'] ) ) {
-						selected( in_array( $key, $field['value'], true ) );
-					} else {
-						selected( $field['value'], $key, true );
+			<?php
+			if ( is_array( $title_prefixes_value ) && count( $title_prefixes_value ) > 0 ) {
+				foreach ( $title_prefixes_value as $key => $value ) {
+					$selected_title_prefix = '';
+					if ( 'selected' === $value ) {
+						$selected_title_prefix = 'selected="selected"';
 					}
 					?>
-				>
-					<?php echo esc_html( $value ); ?>
-				</option>
-			<?php } ?>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php echo $selected_title_prefix; ?>>
+						<?php echo esc_html( $key ); ?>
+					</option>
+					<?php
+				}
+			}
+			?>
 		</select>
 		<?php echo esc_attr( $field['after_field'] ); ?>
 		<?php echo give_get_field_description( $field ); ?>


### PR DESCRIPTION
## Description
This PR resolves #3466 

## How Has This Been Tested?
I've tested this PR with empty and default values and newly added values of title prefixes. Also, checked that on focusing the chosen field shows default values.

## Screenshots (jpeg or gifs if applicable):
![gif](http://g.recordit.co/qFOPXeR33w.gif)

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.