### PR TITLE
refactor: removed give_validate_license_when_site_migrated 

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -121,58 +121,6 @@ add_action( 'give_insert_user', 'give_connect_donor_to_wpuser', 10, 2 );
 
 
 /**
- * Setup site home url check
- *
- * Note: if location of site changes then run cron to validate licenses
- *
- * @since   1.7
- * @updated 1.8.15 - Resolved issue with endless looping because of URL mismatches.
- * @return void
- */
-function give_validate_license_when_site_migrated() {
-	// Store current site address if not already stored.
-	$home_url_parts              = parse_url( home_url() );
-	$home_url                    = isset( $home_url_parts['host'] ) ? $home_url_parts['host'] : false;
-	$home_url                    .= isset( $home_url_parts['path'] ) ? $home_url_parts['path'] : '';
-	$site_address_before_migrate = get_option( 'give_site_address_before_migrate' );
-
-	// Need $home_url to proceed.
-	if ( ! $home_url ) {
-		return;
-	}
-
-	// Save site address.
-	if ( ! $site_address_before_migrate ) {
-		// Update site address.
-		update_option( 'give_site_address_before_migrate', $home_url, false );
-
-		return;
-	}
-
-	// Backwards compat. for before when we were storing URL scheme.
-	if ( strpos( $site_address_before_migrate, 'http' ) ) {
-		$site_address_before_migrate = parse_url( $site_address_before_migrate );
-		$site_address_before_migrate = isset( $site_address_before_migrate['host'] ) ? $site_address_before_migrate['host'] : false;
-
-		// Add path for multisite installs.
-		$site_address_before_migrate .= isset( $site_address_before_migrate['path'] ) ? $site_address_before_migrate['path'] : '';
-	}
-
-	// If the two URLs don't match run CRON.
-	if ( $home_url !== $site_address_before_migrate ) {
-		// Immediately run cron.
-		wp_schedule_single_event( time(), 'give_validate_license_when_site_migrated' );
-
-		// Update site address.
-		update_option( 'give_site_address_before_migrate', $home_url, false );
-	}
-
-}
-
-add_action( 'admin_init', 'give_validate_license_when_site_migrated' );
-
-
-/**
  * Processing after donor batch export complete
  *
  * @since 1.8

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -247,11 +247,9 @@ if ( ! class_exists( 'Give_License' ) ) :
 
 			// Check license weekly.
 			Give_Cron::add_weekly_event( array( $this, 'weekly_license_check' ) );
-			add_action( 'give_validate_license_when_site_migrated', array( $this, 'weekly_license_check' ) );
 
 			// Check subscription weekly.
 			Give_Cron::add_weekly_event( array( $this, 'weekly_subscription_check' ) );
-			add_action( 'give_validate_license_when_site_migrated', array( $this, 'weekly_subscription_check' ) );
 
 			// Show addon notice on plugin page.
 			$plugin_name = explode( 'plugins/', $this->file );


### PR DESCRIPTION
Resolves #1851 - removed `give_validate_license_when_site_migrated` which was causing CRON jobs on migrated sites to run excessively hammering our server.

![2018-07-16_21-53-58](https://user-images.githubusercontent.com/1571635/42797858-19819a70-8946-11e8-96fa-8a3c72742120.png)
