### PR TITLE
Need HTML for Terms&Cond Agreement Label for GDPR #3225

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -448,7 +448,7 @@ ASIDE
 				margin: 0;
 			}
 
-			.mce-container iframe, textarea {
+			.mce-container iframe {
 				min-height: 250px !important;
 			}
 

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -487,24 +487,25 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
 
 						?>
-					<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
-						<th scope="row" class="titledesc">
-							<label
-									for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
-						</th>
-						<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
-									<textarea
-											name="<?php echo esc_attr( $value['id'] ); ?>"
-											id="<?php echo esc_attr( $value['id'] ); ?>"
-											style="<?php echo esc_attr( $value['css'] ); ?>"
-											class="<?php echo esc_attr( $value['class'] ); ?>"
-											rows="10"
-											cols="60"
-										<?php echo implode( ' ', $custom_attributes ); ?>
-									><?php echo esc_textarea( $option_value ); ?></textarea>
-							<?php echo $description; ?>
-						</td>
-						</tr><?php
+						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
+							<th scope="row" class="titledesc">
+								<label
+										for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo self::get_field_title( $value ); ?></label>
+							</th>
+							<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+										<textarea
+												name="<?php echo esc_attr( $value['id'] ); ?>"
+												id="<?php echo esc_attr( $value['id'] ); ?>"
+												style="<?php echo esc_attr( $value['css'] ); ?>"
+												class="<?php echo esc_attr( $value['class'] ); ?>"
+												rows="10"
+												cols="60"
+											<?php echo implode( ' ', $custom_attributes ); ?>
+										><?php echo esc_textarea( $option_value ); ?></textarea>
+								<?php echo $description; ?>
+							</td>
+						</tr>
+						<?php
 						break;
 
 					// Select boxes.

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -485,7 +485,11 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					case 'textarea':
 
 						$option_value = self::get_option( $option_name, $value['id'], $value['default'] );
-
+						$default_attributes = array(
+							'rows' => 10,
+							'cols' => 60
+						);
+						$textarea_attributes = isset( $value['attributes'] ) ? $value['attributes'] : array();
 						?>
 						<tr valign="top" <?php echo ! empty( $value['wrapper_class'] ) ? 'class="' . $value['wrapper_class'] . '"' : '' ?>>
 							<th scope="row" class="titledesc">
@@ -494,13 +498,11 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 							</th>
 							<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ) ?>">
 										<textarea
-												name="<?php echo esc_attr( $value['id'] ); ?>"
-												id="<?php echo esc_attr( $value['id'] ); ?>"
-												style="<?php echo esc_attr( $value['css'] ); ?>"
-												class="<?php echo esc_attr( $value['class'] ); ?>"
-												rows="10"
-												cols="60"
-											<?php echo implode( ' ', $custom_attributes ); ?>
+											name="<?php echo esc_attr( $value['id'] ); ?>"
+											id="<?php echo esc_attr( $value['id'] ); ?>"
+											style="<?php echo esc_attr( $value['css'] ); ?>"
+											class="<?php echo esc_attr( $value['class'] ); ?>"
+											<?php echo give_get_attribute_str( $textarea_attributes, $default_attributes ); ?>
 										><?php echo esc_textarea( $option_value ); ?></textarea>
 								<?php echo $description; ?>
 							</td>

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -580,10 +580,10 @@ class Give_MetaBox_Form_Data {
 						'id'            => $prefix . 'agree_label',
 						'name'          => __( 'Agreement Label', 'give' ),
 						'desc'          => __( 'The label shown next to the agree to terms check box. Add your own to customize or leave blank to use the default text placeholder.', 'give' ),
-						'type'          => 'text',
-						'size'          => 'regular',
+						'type'          => 'textarea',
 						'attributes'    => array(
 							'placeholder' => __( 'Agree to Terms?', 'give' ),
+							'rows'        => 1
 						),
 						'wrapper_class' => 'give-hidden',
 					),

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -576,7 +576,10 @@ function give_textarea_input( $field ) {
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
 	$field['value']         = give_get_field_value( $field, $thepostid );
-
+	$default_attributes = array(
+		'cols' => 20,
+		'rows' => 10
+	);
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">
 	<label for="<?php echo give_get_field_name( $field ); ?>"><?php echo wp_kses_post( $field['name'] ); ?></label>
@@ -584,9 +587,7 @@ function give_textarea_input( $field ) {
 			style="<?php echo esc_attr( $field['style'] ); ?>"
 			name="<?php echo give_get_field_name( $field ); ?>"
 			id="<?php echo esc_attr( $field['id'] ); ?>"
-			rows="10"
-			cols="20"
-		<?php echo give_get_custom_attributes( $field ); ?>
+		<?php echo give_get_attribute_str( $field, $default_attributes ); ?>
 	><?php echo esc_textarea( $field['value'] ); ?></textarea>
 	<?php
 	echo give_get_field_description( $field );

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -324,8 +324,9 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 							'id'         => 'agree_to_terms_label',
 							'attributes' => array(
 								'placeholder' => esc_attr__( 'Agree to Terms?', 'give' ),
+								'rows'        => 1
 							),
-							'type'       => 'text',
+							'type'       => 'textarea',
 						),
 						array(
 							'name' => __( 'Agreement Text', 'give' ),

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1544,11 +1544,20 @@ function give_recount_form_income_donation( $form_id = 0 ) {
  * @since 1.8.17
  *
  * @param array $attributes
+ * @param array $default_attributes
  *
  * @return string
  */
-function give_get_attribute_str( $attributes ) {
+function give_get_attribute_str( $attributes, $default_attributes = array() ) {
 	$attribute_str = '';
+
+	if( isset( $attributes['attributes'] ) ) {
+		$attributes = $attributes['attributes'];
+	}
+
+	if( ! empty( $default_attributes ) ) {
+		$attributes = wp_parse_args( $attributes, $default_attributes );
+	}
 
 	if ( empty( $attributes ) ) {
 		return $attribute_str;


### PR DESCRIPTION
## Description
This PR will fix #3225

**Note: term label setting in admin and form is `textarea` but they look like text input because there row set to `1`.**

## How Has This Been Tested?
Adding HTML in global admin and form term label setting.

## Screenshots (jpeg or gifs if applicable):

Admin setting
![image](https://user-images.githubusercontent.com/1784821/42813319-3db87c04-89de-11e8-8ab5-5fd70d2d72d2.png)

Form setting
![image](https://user-images.githubusercontent.com/1784821/42813327-44524ec8-89de-11e8-8fff-a5d0685876aa.png)

Frontend
![image](https://user-images.githubusercontent.com/1784821/42813337-4f54aa5a-89de-11e8-9615-082671005e41.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.