### PR TITLE
add action for additional widget table rows

### DIFF
--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -203,20 +203,20 @@ function give_reports_graph() {
 			</div>
 			<table class="widefat reports-table alignleft" style="max-width:450px">
 				<tbody>
-				<tr>
+				<tr class="total-income">
 					<th scope="row"><strong><?php _e( 'Total income for period:', 'give' ); ?></strong></th>
 					<td><?php echo give_currency_filter( give_format_amount( $earnings_totals, array( 'sanitize' => false ) ) ); ?></td>
 				</tr>
-				<tr class="alternate">
+				<tr class="total-donations alternate">
 					<th scope="row"><strong><?php _e( 'Total donations for period:', 'give' ); ?><strong></th>
 					<td><?php echo $sales_totals; ?></td>
 				</tr>
 				<?php if ( 'this_month' === $dates['range'] ) : ?>
-					<tr>
+					<tr class="estimated-monthly-income">
 						<th scope="row"><strong><?php _e( 'Estimated monthly income:', 'give' ); ?></strong></th>
 						<td><?php echo give_currency_filter( give_format_amount( $estimated['earnings'], array( 'sanitize' => false ) ) ); ?></td>
 					</tr>
-					<tr class="alternate">
+					<tr class="estimated-monthly-donations alternate">
 						<th scope="row"><strong><?php _e( 'Estimated monthly donations:', 'give' ); ?></strong></th>
 						<td><?php echo floor( $estimated['sales'] ); ?></td>
 					</tr>

--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -221,6 +221,18 @@ function give_reports_graph() {
 						<td><?php echo floor( $estimated['sales'] ); ?></td>
 					</tr>
 				<?php endif; ?>
+
+				<?php
+				/**
+				 * Fires in report graphs widget table.
+				 *
+				 * Allows you to add additional rows to the table.
+				 *
+				 * @since 2.3
+				 */
+				do_action( 'give_reports_graph_additional_rows' );
+				?>
+
 			</table>
 
 			<?php


### PR DESCRIPTION
## Description
- Adds an action hook for additional graphing widget table rows.
- Adds classes to the existing `<tr>` elements to enable CSS styling

## How Has This Been Tested?
I added an action hook in my theme’s `functions.php` to insert another row into the table, and it worked exactly as expected.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.