### PR TITLE
fix(i18n): format dates to WordPress `date_format` #3502

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -105,11 +105,21 @@ var give_setting_edit = false;
 	 * @since: 1.0
 	 */
 	var enable_admin_datepicker = function () {
+		let datepicker = $('.give_datepicker'),
+		    dateFormat = '';
+
+		switch( give_vars.wp_site_language ) {
+			case 'en_GB':
+				dateFormat = 'dd/mm/yy';
+				break;
+
+			default:
+				dateFormat = 'mm/dd/yy';
+		}
 
 		// Date picker.
-		if ($('.give_datepicker').length > 0) {
-			var dateFormat = 'mm/dd/yy';
-			$('.give_datepicker').datepicker({
+		if ( datepicker.length > 0) {
+			datepicker.datepicker({
 				dateFormat: dateFormat
 			});
 		}

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -108,19 +108,10 @@ var give_setting_edit = false;
 		let datepicker = $('.give_datepicker'),
 		    dateFormat = '';
 
-		switch( give_vars.wp_site_language ) {
-			case 'en_GB':
-				dateFormat = 'dd/mm/yy';
-				break;
-
-			default:
-				dateFormat = 'mm/dd/yy';
-		}
-
 		// Date picker.
 		if ( datepicker.length > 0) {
 			datepicker.datepicker({
-				dateFormat: dateFormat
+				dateFormat: give_vars.date_format
 			});
 		}
 	};

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -105,8 +105,7 @@ var give_setting_edit = false;
 	 * @since: 1.0
 	 */
 	var enable_admin_datepicker = function () {
-		let datepicker = $('.give_datepicker'),
-		    dateFormat = '';
+		let datepicker = $('.give_datepicker');
 
 		// Date picker.
 		if ( datepicker.length > 0) {

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -159,6 +159,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 		$donor      = isset( $_GET['donor'] ) ? absint( $_GET['donor'] ) : '';
 		$search     = isset( $_GET['s'] ) ? give_clean( $_GET['s'] ) : '';
 		$form_id    = ! empty( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
+		$localized_date_format = give_get_localized_date_format();
 		?>
 		<div id="give-payment-filters" class="give-filters">
 			<?php $this->search_box( __( 'Search', 'give' ), 'give-payments' ); ?>
@@ -167,12 +168,12 @@ class Give_Payment_History_Table extends WP_List_Table {
 					<label for="start-date"
 					       class="give-start-date-label"><?php _e( 'Start Date', 'give' ); ?></label>
 					<input type="text" id="start-date" name="start-date" class="give_datepicker"
-					       value="<?php echo $start_date; ?>" placeholder="mm/dd/yyyy"/>
+					       value="<?php echo $start_date; ?>" placeholder="<?php echo $localized_date_format; ?>"/>
 				</div>
 				<div class="give-filter give-filter-half">
 					<label for="end-date" class="give-end-date-label"><?php _e( 'End Date', 'give' ); ?></label>
 					<input type="text" id="end-date" name="end-date" class="give_datepicker"
-					       value="<?php echo $end_date; ?>" placeholder="mm/dd/yyyy"/>
+					       value="<?php echo $end_date; ?>" placeholder="<?php echo $localized_date_format; ?>"/>
 				</div>
 			</div>
 			<div id="give-payment-form-filter" class="give-filter">

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -168,12 +168,12 @@ class Give_Payment_History_Table extends WP_List_Table {
 					<label for="start-date"
 					       class="give-start-date-label"><?php _e( 'Start Date', 'give' ); ?></label>
 					<input type="text" id="start-date" name="start-date" class="give_datepicker"
-					       value="<?php echo $start_date; ?>" placeholder="<?php echo $localized_date_format; ?>"/>
+					       value="<?php printf( esc_attr( $start_date ) ); ?>" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 				</div>
 				<div class="give-filter give-filter-half">
 					<label for="end-date" class="give-end-date-label"><?php _e( 'End Date', 'give' ); ?></label>
 					<input type="text" id="end-date" name="end-date" class="give_datepicker"
-					       value="<?php echo $end_date; ?>" placeholder="<?php echo $localized_date_format; ?>"/>
+					       value="<?php printf( esc_attr( $end_date ) ); ?>" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 				</div>
 			</div>
 			<div id="give-payment-form-filter" class="give-filter">

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -159,7 +159,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 		$donor      = isset( $_GET['donor'] ) ? absint( $_GET['donor'] ) : '';
 		$search     = isset( $_GET['s'] ) ? give_clean( $_GET['s'] ) : '';
 		$form_id    = ! empty( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
-		$localized_date_format = give_get_localized_date_format();
+		$localized_date_format = give_get_localized_date_format_to_js();
 		?>
 		<div id="give-payment-filters" class="give-filters">
 			<?php $this->search_box( __( 'Search', 'give' ), 'give-payments' ); ?>

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -174,9 +174,10 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 										</div>
 
 										<div class="give-admin-box-inside">
+											<?php $localized_date_format = give_get_localized_date_format_to_js(); ?>
 											<p>
 												<label for="give-payment-date" class="strong"><?php _e( 'Date:', 'give' ); ?></label>&nbsp;
-												<input type="text" id="give-payment-date" name="give-payment-date" value="<?php echo esc_attr( date( 'm/d/Y', $payment_date ) ); ?>" class="medium-text give_datepicker"/>
+												<input type="text" id="give-payment-date" name="give-payment-date" value="<?php echo esc_attr( date( get_option( 'date_format' ), $payment_date ) ); ?>" class="medium-text give_datepicker" placeholder="<?php printf( esc_attr( $localized_date_format ) ); ?>"/>
 											</p>
 										</div>
 

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -319,7 +319,7 @@ class Give_Scripts {
 			'chosen_add_title_prefix'           => __( 'No result found. Press enter to add', 'give' ),
 			'db_update_nonce'                   => wp_create_nonce( Give_Updates::$background_updater->get_identifier() ),
 			'ajax'                              => give_test_ajax_works(),
-			'date_format'                       => give_get_localized_date_format(),
+			'date_format'                       => give_get_localized_date_format_to_js(),
 		);
 
 		wp_localize_script( 'give-admin-scripts', 'give_vars', $localized_data );

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -319,7 +319,7 @@ class Give_Scripts {
 			'chosen_add_title_prefix'           => __( 'No result found. Press enter to add', 'give' ),
 			'db_update_nonce'                   => wp_create_nonce( Give_Updates::$background_updater->get_identifier() ),
 			'ajax'                              => give_test_ajax_works(),
-			'date_format'                       => give_convert_php_date_format_to_js( get_option( 'date_format' ) ),
+			'date_format'                       => give_get_localized_date_format(),
 		);
 
 		wp_localize_script( 'give-admin-scripts', 'give_vars', $localized_data );

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -318,7 +318,8 @@ class Give_Scripts {
 			),
 			'chosen_add_title_prefix'           => __( 'No result found. Press enter to add', 'give' ),
 			'db_update_nonce'                   => wp_create_nonce( Give_Updates::$background_updater->get_identifier() ),
-			'ajax'                              => give_test_ajax_works()
+			'ajax'                              => give_test_ajax_works(),
+			'wp_site_language'                  => get_locale(),
 		);
 
 		wp_localize_script( 'give-admin-scripts', 'give_vars', $localized_data );

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -319,7 +319,7 @@ class Give_Scripts {
 			'chosen_add_title_prefix'           => __( 'No result found. Press enter to add', 'give' ),
 			'db_update_nonce'                   => wp_create_nonce( Give_Updates::$background_updater->get_identifier() ),
 			'ajax'                              => give_test_ajax_works(),
-			'wp_site_language'                  => get_locale(),
+			'date_format'                       => give_convert_php_date_format_to_js( get_option( 'date_format' ) ),
 		);
 
 		wp_localize_script( 'give-admin-scripts', 'give_vars', $localized_data );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2327,6 +2327,8 @@ function give_get_formatted_address( $address = array() ) {
  * @return string The JS date format.
  */
 function give_convert_php_date_format_to_js( $php_format ) {
+	$js_format = $php_format;
+
 	switch ( $php_format ) {
 		case 'F j, Y':
 			$js_format = 'MM dd, yy';

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2316,3 +2316,41 @@ function give_get_formatted_address( $address = array() ) {
 
 	return $formatted_address;
 }
+
+/**
+ * Converts a PHP date format for use in JavaScript.
+ *
+ * @since 2.2.0
+ *
+ * @param string $php_format The PHP date format.
+ *
+ * @return string The JS date format.
+ */
+function give_convert_php_date_format_to_js( $php_format ) {
+    switch( $php_format ) {
+        case 'F j, Y':
+            $js_format = 'MM dd, yy';
+            break;
+        case 'Y-m-d':
+            $js_format = 'yy-mm-dd';
+            break;
+        case 'm/d/Y':
+            $js_format = 'mm/dd/yy';
+            break;
+        case 'd/m/Y':
+            $js_format = 'dd/mm/yy';
+            break;
+    }
+
+    /**
+     * Filters the date format for use in JavaScript.
+     *
+     * @since 2.2.0
+     *
+     * @param string $js_format  The JS date format.
+     * @param string $php_format The PHP date format.
+     */
+    $js_format = apply_filters( 'give_js_date_format', $js_format, $php_format );
+
+    return $js_format;
+}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2327,30 +2327,30 @@ function give_get_formatted_address( $address = array() ) {
  * @return string The JS date format.
  */
 function give_convert_php_date_format_to_js( $php_format ) {
-    switch( $php_format ) {
-        case 'F j, Y':
-            $js_format = 'MM dd, yy';
-            break;
-        case 'Y-m-d':
-            $js_format = 'yy-mm-dd';
-            break;
-        case 'm/d/Y':
-            $js_format = 'mm/dd/yy';
-            break;
-        case 'd/m/Y':
-            $js_format = 'dd/mm/yy';
-            break;
-    }
+	switch ( $php_format ) {
+		case 'F j, Y':
+			$js_format = 'MM dd, yy';
+			break;
+		case 'Y-m-d':
+			$js_format = 'yy-mm-dd';
+			break;
+		case 'm/d/Y':
+			$js_format = 'mm/dd/yy';
+			break;
+		case 'd/m/Y':
+			$js_format = 'dd/mm/yy';
+			break;
+	}
 
-    /**
-     * Filters the date format for use in JavaScript.
-     *
-     * @since 2.2.0
-     *
-     * @param string $js_format  The JS date format.
-     * @param string $php_format The PHP date format.
-     */
-    $js_format = apply_filters( 'give_js_date_format', $js_format, $php_format );
+	/**
+	 * Filters the date format for use in JavaScript.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param string $js_format  The JS date format.
+	 * @param string $php_format The PHP date format.
+	 */
+	$js_format = apply_filters( 'give_js_date_format', $js_format, $php_format );
 
-    return $js_format;
+	return $js_format;
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2354,3 +2354,15 @@ function give_convert_php_date_format_to_js( $php_format ) {
 
 	return $js_format;
 }
+
+/**
+ * Get localized date format.
+ *
+ * @since 2.2.0
+ *
+ * @return string.
+ */
+function give_get_localized_date_format() {
+
+	return give_convert_php_date_format_to_js( get_option( 'date_format' ) );
+}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2358,13 +2358,13 @@ function give_convert_php_date_format_to_js( $php_format ) {
 }
 
 /**
- * Get localized date format.
+ * Get localized date format for use in JavaScript.
  *
  * @since 2.2.0
  *
  * @return string.
  */
-function give_get_localized_date_format() {
+function give_get_localized_date_format_to_js() {
 
 	return give_convert_php_date_format_to_js( get_option( 'date_format' ) );
 }


### PR DESCRIPTION
Close #3502 

## Description
Added support for locale `en_GB`. By default the format will be `mm/dd/yy`. As more such requests come, we can conditionally support more requests.

## How Has This Been Tested?
By switching from locale `en_US` to `en_GB` and back.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.