### PR TITLE
fix(email): send user registration email after donor registration

### DIFF
--- a/includes/admin/emails/class-donor-register-email.php
+++ b/includes/admin/emails/class-donor-register-email.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'Give_Donor_Register_Email' ) ) :
 		public function setup_email_notification( $user_id, $user_data ) {
 			$this->setup_email_data();
 
-			$this->recipient_email = $user_data['user_email'];
+			$this->recipient_email = $user_data['email'];
 			$this->send_email_notification( array(
 				'user_id' => $user_id,
 			) );

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -531,25 +531,33 @@ function give_get_donor_address( $donor_id = null, $args = array() ) {
  *
  * Sends the new user notification email when a user registers within the donation form
  *
- * @param int   $user_id   User ID.
- * @param array $user_data An Array of User Data.
+ * @param int   $donation_id
+ * @param array $donation_data
  *
  * @access public
  * @since  1.0
  *
  * @return void
  */
-function give_new_user_notification( $user_id = 0, $user_data = array() ) {
+function give_new_user_notification( $donation_id = 0, $donation_data = array() ) {
 	// Bailout.
-	if ( empty( $user_id ) || empty( $user_data ) ) {
+	if (
+		empty( $donation_id )
+		|| empty( $donation_data )
+		|| ! isset( $_POST['give_create_account'] )
+		|| 'on' !== give_clean( $_POST['give_create_account'] )
+	) {
 		return;
 	}
 
-	do_action( 'give_new-donor-register_email_notification', $user_id, $user_data );
-	do_action( 'give_donor-register_email_notification', $user_id, $user_data );
+	// @todo add user data for backward compatibility in $donation_data['user_info']
+	// @todo for example previous array contains user_email but current contains email.
+
+	do_action( 'give_new-donor-register_email_notification', $donation_data['user_info']['id'], $donation_data['user_info'] );
+	do_action( 'give_donor-register_email_notification', $donation_data['user_info']['id'], $donation_data['user_info'] );
 }
 
-add_action( 'give_insert_user', 'give_new_user_notification', 10, 2 );
+add_action( 'give_insert_payment', 'give_new_user_notification', 10, 2 );
 
 
 /**


### PR DESCRIPTION
Closes #2997 

## Description
The code is updated with correct hooks for the email tags to work.

## How Has This Been Tested?
Registration new user 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.