### PR TITLE
fix(admin-donation): show proper email in donor detail metabox on donation detail page

### DIFF
--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -616,12 +616,15 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 											<p>
 												<strong><?php esc_html_e( 'Donor Email:', 'give' ); ?></strong><br>
 												<?php
-												$donor_primary_email  = $donor->email;
-												$donor_donation_email = give_get_payment_user_email( $payment_id );
-
 												// Show Donor donation email first and Primary email on parenthesis if not match both email.
-												echo ( hash_equals( $donor_primary_email, $donor_donation_email ) ) ? $donor_donation_email :
-													give_get_payment_user_email( $payment_id ) . ' (' . $donor_primary_email . ')';
+												echo hash_equals( $donor->email, $payment->email )
+													? $payment->email
+													: sprintf(
+														'%1$s (<a href="%2$s" target="_blank">%3$s</a>)',
+														$payment->email,
+														esc_url( admin_url( "edit.php?post_type=give_forms&page=give-donors&view=overview&id={$donor_id}" ) ),
+														$donor->email
+													);
 												?>
 											</p>
 										</div>

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -615,7 +615,14 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 											</p>
 											<p>
 												<strong><?php esc_html_e( 'Donor Email:', 'give' ); ?></strong><br>
-												<?php echo esc_attr( $donor->email ); ?>
+												<?php
+												$donor_primary_email  = $donor->email;
+												$donor_donation_email = give_get_payment_user_email( $payment_id );
+
+												// Show Donor donation email first and Primary email on parenthesis if not match both email.
+												echo ( hash_equals( $donor_primary_email, $donor_donation_email ) ) ? $donor_donation_email :
+													give_get_payment_user_email( $payment_id ) . ' (' . $donor_primary_email . ')';
+												?>
 											</p>
 										</div>
 										<div class="column">

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -600,12 +600,9 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 												// Check whether the donor name and WP_User name is same or not.
 												if ( $donor_billing_name !== $donor_name ) {
 													echo sprintf(
-														'%1$s (<a href="%2$s">%3$s</a>)',
+														'%1$s (<a href="%2$s" target="_blank">%3$s</a>)',
 														esc_html( $donor_billing_name ),
-														sprintf(
-															esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=%s' ) ),
-															intval( $donor_id )
-														),
+														esc_url( admin_url( "edit.php?post_type=give_forms&page=give-donors&view=overview&id={$donor_id}" ) ),
 														esc_html( $donor_name )
 													);
 												} else {


### PR DESCRIPTION
## Description
This PR will fix #2985 

- Show email address as @ravinderk suggested on issue

![donor_email](https://user-images.githubusercontent.com/15060983/43316694-b4529850-91b7-11e8-9eca-14c1b94f808a.png)


## How Has This Been Tested?
- Manually tested

## Types of changes
- Bug fix (non-breaking change which fixes an issue

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.