### PR TITLE
fix(shortcode): provide grid fallback styles for `[give_form_grid]` #3504

### DIFF
--- a/assets/src/css/frontend/_grid.scss
+++ b/assets/src/css/frontend/_grid.scss
@@ -16,6 +16,63 @@
 	}
 }
 
+.give-wrap {
+	&:before {
+		display: block;
+		content: '';
+		clear: both;
+	}
+}
+
+// IE 11 browser support.
+@media ( min-width: 30rem ) {
+	.give-grid {
+		display: flex;
+		flex-flow: row wrap;
+		margin-bottom: 1.5rem;
+		max-width: 100%;
+
+		&__item {
+			padding: 0 .75rem;
+			display: flex;
+		}
+
+		&--2,
+		&--3,
+		&--4 {
+			.give-grid__item {
+				@media ( min-width: 40rem ) {
+					width: 50%;
+				}
+			}
+		}
+
+		&--3,
+		&--4 {
+			.give-grid__item {
+				@media ( min-width: 72rem ) {
+					width: calc( 100% / 3 );
+				}
+			}
+		}
+
+		&--4 {
+			.give-grid__item {
+				@media ( min-width: 90rem ) {
+					width: 25%;
+				}
+			}
+		}
+
+		&__item {
+			.give-grid__item {
+				display: flex;
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
 // Modern styles for browsers that support CSS Grid.
 @supports (display: grid) {
 	@media ( min-width: 30rem ) {
@@ -25,6 +82,12 @@
 			grid-gap: 1.5rem;
 			margin-bottom: 1.5rem;
 			max-width: 100%;
+
+			&__item {
+				display: block;
+				padding: 0;
+				width: auto !important;
+			}
 
 			// Fit as many columns as possible in the available space.
 			&--best-fit {

--- a/assets/src/css/frontend/give-frontend.scss
+++ b/assets/src/css/frontend/give-frontend.scss
@@ -36,3 +36,13 @@
 #give-receipt{
 	@import '../../../../blocks/components/container-placeholder-animation/style';
 }
+
+.give-grid-ie-utility {
+	margin: 0 -12px;
+}
+
+@supports (display: grid) {
+	.give-grid-ie-utility {
+		margin: 0;
+	}
+}

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -152,7 +152,7 @@ class Give_Donor_Wall {
 
 		$html = $html
 			? sprintf(
-				'<div class="give-wrap"><div class="give-grid give-grid--%1$s">%2$s</div>%3$s</div>',
+				'<div class="give-wrap give-grid-ie-utility"><div class="give-grid give-grid--%1$s">%2$s</div>%3$s</div>',
 				esc_attr( $atts['columns'] ),
 				$html,
 				$more_btn_html

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -16,75 +16,77 @@ $give_settings = $args[1]; // Give settings.
 $atts          = $args[2]; // Shortcode attributes.
 ?>
 
-<div class="give-donor">
-	<div class="give-donor__header">
+<div class="give-grid__item">
+	<div class="give-donor">
+		<div class="give-donor__header">
+			<?php
+			// Maybe display the Avatar.
+			if ( true === $atts['show_avatar'] ) {
+				echo give_get_donor_avatar( $donor );
+			}
+			?>
+
+			<div class="give-donor__details">
+				<?php if ( true === $atts['show_name'] ) : ?>
+					<h3 class="give-donor__name"><?php esc_html_e( $donor->name ); ?></h3>
+				<?php endif; ?>
+
+				<?php if ( true === $atts['show_total'] ) : ?>
+					<span class="give-donor__total">
+						<?php
+						// If not filtered by form ID then display total donations
+						// Else filtered by form ID, only display donations made for this form.
+						$donated_amount = $donor->purchase_value;
+
+						if ( ! empty( $atts['form_id'] ) ) {
+							$donated_amount = Give_Donor_Stats::donated(
+								array(
+									'donor'      => $donor->id,
+									'give_forms' => $atts['form_id']
+								)
+							);
+						}
+
+						echo give_currency_filter( give_format_amount( $donated_amount, array( 'sanitize' => false ) ) );
+						?>
+					</span>
+				<?php endif; ?>
+
+				<?php if ( true === $atts['show_time'] ) : ?>
+					<span class="give-donor__timestamp">
+						<?php
+						// If not filtered by form ID then display the "Donor Since" text.
+						// If filtered by form ID then display the last donation date.
+						echo $donor->get_last_donation_date( true );
+						?>
+					</span>
+				<?php endif; ?>
+			</div>
+		</div>
+
 		<?php
-		// Maybe display the Avatar.
-		if ( true === $atts['show_avatar'] ) {
-			echo give_get_donor_avatar( $donor );
-		}
+		$comment = give_get_donor_latest_comment( $donor->id, $atts['form_id'] );
+
+		if ( true === $atts['show_comments'] && absint( $atts['comment_length'] ) && $comment instanceof WP_Comment ) :
 		?>
-
-		<div class="give-donor__details">
-			<?php if ( true === $atts['show_name'] ) : ?>
-				<h3 class="give-donor__name"><?php esc_html_e( $donor->name ); ?></h3>
-			<?php endif; ?>
-
-			<?php if ( true === $atts['show_total'] ) : ?>
-				<span class="give-donor__total">
+			<div class="give-donor__content">
 					<?php
-					// If not filtered by form ID then display total donations
-					// Else filtered by form ID, only display donations made for this form.
-					$donated_amount = $donor->purchase_value;
-
-					if ( ! empty( $atts['form_id'] ) ) {
-						$donated_amount = Give_Donor_Stats::donated(
-							array(
-								'donor'      => $donor->id,
-								'give_forms' => $atts['form_id']
-							)
+					if ( $atts['comment_length'] < strlen( $comment->comment_content ) ) {
+						echo sprintf(
+							'<p class="give-donor__comment_excerpt">%s&hellip;<span>&nbsp;<a class="give-donor__read-more">%s</a></span></p>',
+							substr( $comment->comment_content, 0, $atts['comment_length'] ),
+							$atts['readmore_text']
 						);
+
+						echo sprintf(
+							'<div class="give-donor__comment" style="display: none">%s</div>',
+							apply_filters( 'the_content', $comment->comment_content )
+						);
+					} else {
+						echo apply_filters( 'the_content', $comment->comment_content );
 					}
-
-					echo give_currency_filter( give_format_amount( $donated_amount, array( 'sanitize' => false ) ) );
 					?>
-				</span>
-			<?php endif; ?>
-
-			<?php if ( true === $atts['show_time'] ) : ?>
-				<span class="give-donor__timestamp">
-					<?php
-					// If not filtered by form ID then display the "Donor Since" text.
-					// If filtered by form ID then display the last donation date.
-					echo $donor->get_last_donation_date( true );
-					?>
-				</span>
-			<?php endif; ?>
-		</div>
+			</div>
+		<?php endif; ?>
 	</div>
-
-	<?php
-	$comment = give_get_donor_latest_comment( $donor->id, $atts['form_id'] );
-
-	if ( true === $atts['show_comments'] && absint( $atts['comment_length'] ) && $comment instanceof WP_Comment ) :
-	?>
-		<div class="give-donor__content">
-				<?php
-				if ( $atts['comment_length'] < strlen( $comment->comment_content ) ) {
-					echo sprintf(
-						'<p class="give-donor__comment_excerpt">%s&hellip;<span>&nbsp;<a class="give-donor__read-more">%s</a></span></p>',
-						substr( $comment->comment_content, 0, $atts['comment_length'] ),
-						$atts['readmore_text']
-					);
-
-					echo sprintf(
-						'<div class="give-donor__comment" style="display: none">%s</div>',
-						apply_filters( 'the_content', $comment->comment_content )
-					);
-				} else {
-					echo apply_filters( 'the_content', $comment->comment_content );
-				}
-				?>
-		</div>
-	<?php endif; ?>
 </div>


### PR DESCRIPTION
Closes #3504 

## Description
In this PR, `flex` has been used as a fallback for Grid to support form grid on IE 11 browser.
Although IE does not fully support flex model layout, all the flex CSS properties I have used in this PR are supported by IE 11. 

## Screenshots (jpeg or gifs if applicable):
![screenshot from 2018-07-31 21-42-32](https://user-images.githubusercontent.com/17757960/43472477-26d2bcec-950b-11e8-88e0-97c763ac5f53.png)
![screenshot from 2018-07-31 21-41-42](https://user-images.githubusercontent.com/17757960/43472480-28e8a9e2-950b-11e8-889f-0a21675e7279.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.