### PR TITLE
add give_reports_graph_additional_stats to individual form stats

### DIFF
--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -469,6 +469,18 @@ function give_reports_graph_of_form( $form_id = 0 ) {
 				</tr>
 				</tbody>
 			</table>
+
+			<?php
+			/**
+			 * Fires on report graphs widget.
+			 *
+			 * Allows you to add additional stats to the widget.
+			 *
+			 * @since 1.0
+			 */
+			do_action( 'give_reports_graph_additional_stats' );
+			?>
+
 		</div>
 	</div>
 	<?php

--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -476,7 +476,7 @@ function give_reports_graph_of_form( $form_id = 0 ) {
 			 *
 			 * Allows you to add additional stats to the widget.
 			 *
-			 * @since 1.0
+			 * @since 2.2.1
 			 */
 			do_action( 'give_reports_graph_additional_stats' );
 			?>


### PR DESCRIPTION
## Description
Add `give_reports_graph_additional_stats` action to specific form reports.

## How Has This Been Tested?
I added an action hook in my theme’s functions.php to insert another row into the table, and it worked exactly as expected.

## Types of changes
- New feature: in that it’s a non-breaking change which adds functionality
- Bugfix: in that it adds feature parity between default reports view and specific form report view


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.