### PR TITLE
fix(form): float labels result in too little contrast for inactive placeholders. #2179

### DIFF
--- a/assets/src/css/plugins/float-labels.scss
+++ b/assets/src/css/plugins/float-labels.scss
@@ -21,7 +21,7 @@ $float-labels-defaults: (
 	color-border            : #dfdfdf,
 	color-border-active     : #dfdfdf,
 	color-border-focus      : #1976D2,
-	color-placeholder       : #bbb,
+	color-placeholder       : #757575,
 	color-required          : #D32F2F,
 	color-text              : #444,
 	color-text-focus        : #1976D2,


### PR DESCRIPTION
## Description
PR to fix #2179 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.