### PR TITLE
fix(admin-tools): all donation forms should be listed on Export screen #1970

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -207,7 +207,7 @@ var give_setting_edit = false;
 
 					// Don't fire if short or is a modifier key (shift, ctrl, apple command key, or arrow keys).
 					if (
-						val.length <= 3 ||
+						( val.length > 0 && val.length <= 3 ) ||
 						!search_type.length ||
 						(
 							(9 === lastKey) || // Tab.
@@ -266,10 +266,13 @@ var give_setting_edit = false;
 
 									if (data.length) {
 										$.each(data, function (key, item) {
-
 											// Add any option that doesn't already exist.
 											if (!$('option[value="' + item.id + '"]', select).length) {
-												select.prepend('<option value="' + item.id + '">' + item.name + '</option>');
+												if ( 0 === val.length ) {
+													select.append(`<option value="${item.id}">${item.name}</option>`);
+												} else {
+													select.prepend(`<option value="${item.id}">${item.name}</option>`);
+												}
 											}
 										});
 

--- a/includes/admin/tools/views/html-admin-page-data.php
+++ b/includes/admin/tools/views/html-admin-page-data.php
@@ -56,7 +56,6 @@ do_action( 'give_tools_recount_stats_before' );
 						$args = array(
 							'class'       => 'tools-form-dropdown-recount-form-select',
 							'name'        => 'form_id',
-							'number'      => - 1,
 							'chosen'      => true,
 							'placeholder' => __( 'Select Form', 'give' ),
 						);

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -289,16 +289,6 @@ function give_ajax_form_search() {
 	$results = array();
 	$search  = esc_sql( sanitize_text_field( $_POST['s'] ) );
 
-	/**
-	 * If the search term is empty, then return 30 posts,
-	 * else return all posts matching the search term.
-	 */
-	if ( empty( $search ) ) {
-		$posts_per_page = 30;
-	} else {
-		$posts_per_page = -1;
-	}
-
 	$args = array(
 		'post_type'              => 'give_forms',
 		's'                      => $search,
@@ -309,7 +299,7 @@ function give_ajax_form_search() {
 		'post_status'            => 'publish',
 		'orderby'                => 'title',
 		'order'                  => 'ASC',
-		'posts_per_page'         => $posts_per_page,
+		'posts_per_page'         => empty( $search ) ? 30 : -1,
 	);
 
 	/**

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -289,6 +289,16 @@ function give_ajax_form_search() {
 	$results = array();
 	$search  = esc_sql( sanitize_text_field( $_POST['s'] ) );
 
+	/**
+	 * If the search term is empty, then return 30 posts,
+	 * else return all posts matching the search term.
+	 */
+	if ( empty( $search ) ) {
+		$posts_per_page = 30;
+	} else {
+		$posts_per_page = -1;
+	}
+
 	$args = array(
 		'post_type'              => 'give_forms',
 		's'                      => $search,
@@ -297,6 +307,9 @@ function give_ajax_form_search() {
 		'cache_results'          => false,
 		'no_found_rows'          => true,
 		'post_status'            => 'publish',
+		'orderby'                => 'title',
+		'order'                  => 'ASC',
+		'posts_per_page'         => $posts_per_page,
 	);
 
 	/**


### PR DESCRIPTION
Closes #1970

## Description
All form dropdowns will now fetch 30 forms by default. If the input field is kept empty then the select field will be reset to its original state.

## How Has This Been Tested?
By testing the select fields mentioned in the issue.

## Video
https://www.useloom.com/share/9cae9025da144c0dbea9942ccfb049eb

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.