### PR TITLE
fix(form): exclude honeypot field from floating labels js #2230

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -224,7 +224,7 @@ window.give_open_form_modal = function ( $form_wrap, $form ) {
 /**
  * Floating Labels Custom Events
  */
-window.give_fl_trigger = function() {
+window.give_fl_trigger = function () {
 	window.give_float_labels = 'undefined' === typeof window.give_float_labels ? {} : window.give_float_labels;
 
 	if ( window.give_float_labels instanceof FloatLabels ) {
@@ -232,7 +232,7 @@ window.give_fl_trigger = function() {
 	}
 	else {
 		window.give_float_labels = new FloatLabels( '.float-labels-enabled', {
-			exclude: '#give-amount, .give-select-level, [multiple]',
+			exclude: '#give-amount, .give-select-level, [multiple], .give-honeypot',
 			prioritize: 'placeholder',
 			prefix: 'give-fl-',
 			style: 'give',


### PR DESCRIPTION
## Description
PR to fix #2230 

## How Has This Been Tested?
Tested by enabling the **Floating Labels** and also disabling the **Floating Labels**

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/22215595/43771051-9e3c2cdc-9a5b-11e8-9446-acaac2596472.png)


![image](https://user-images.githubusercontent.com/22215595/43771033-963bef22-9a5b-11e8-9789-ad2324174e63.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.