### PR TITLE
fix(shortcode): ensure the donors are showing on the donor wall when they submit a donation #3581

### DIFF
--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -186,7 +186,7 @@ class Give_Donor_Wall {
 				'show_time'       => true,
 				'show_comments'   => true,
 				'comment_length'  => 20,
-				'only_comments'   => true,
+				'only_comments'   => false,
 				'readmore_text'   => esc_html__( 'Read More', 'give' ),
 				'loadmore_text'   => esc_html__( 'Load More', 'give' ),
 				'avatar_size'     => 60,


### PR DESCRIPTION
Closes #3581 

## Description
As discussed over [here](https://github.com/WordImpress/Give/issues/3581#issuecomment-411297665), the default value of `only_comments` have been set to `false` 

## How Has This Been Tested?
By testing the shortcode `[give_donor_wall form_id="584"]` which displays the donor wall.

## Screenshots (jpeg or gifs if applicable):
![donorwall](https://user-images.githubusercontent.com/17757960/43821613-48e0d31c-9b07-11e8-890a-cef22b11e6d2.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.