### PR TITLE
fix(admin-donation): ensure updating offline donations from pending to complete doesn't break date #3606

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -63,7 +63,7 @@ function give_update_payment_details( $data ) {
 
 	$curr_total = $payment->total;
 	$new_total  = give_maybe_sanitize_amount( ( ! empty( $data['give-payment-total'] ) ? $data['give-payment-total'] : 0 ) );
-	$date       = date( 'Y-m-d', strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
+	$date       = date( get_option( 'date_format' ), strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
 
 	$curr_donor_id = sanitize_text_field( $data['give-current-donor'] );
 	$new_donor_id  = sanitize_text_field( $data['donor-id'] );


### PR DESCRIPTION
Closes #3606 

## Description
Fixes the date format by using WordPress' date format.

## How Has This Been Tested?
By cross-checking the donation listing and donation details page.

## Screenshots (jpeg or gifs if applicable):
![offline](https://user-images.githubusercontent.com/17757960/44245634-4f0c4b80-a1f7-11e8-852b-d4c7fa97d9c5.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.