### PR TITLE
fix(admin-tools): fix PHP notices when recalculating total donation income amount #3611

### DIFF
--- a/includes/admin/tools/data/class-give-tools-recount-form-stats.php
+++ b/includes/admin/tools/data/class-give-tools-recount-form-stats.php
@@ -90,7 +90,6 @@ class Give_Tools_Recount_Form_Stats extends Give_Batch_Export {
 			'number'     => $this->per_step,
 			'status'     => $accepted_statuses,
 			'paged'      => $this->step,
-			'fields'     => 'ids',
 		) );
 
 		$payments = new Give_Payments_Query( $args );

--- a/includes/admin/tools/data/class-give-tools-recount-form-stats.php
+++ b/includes/admin/tools/data/class-give-tools-recount-form-stats.php
@@ -90,6 +90,7 @@ class Give_Tools_Recount_Form_Stats extends Give_Batch_Export {
 			'number'     => $this->per_step,
 			'status'     => $accepted_statuses,
 			'paged'      => $this->step,
+			'fields'     => 'ids',
 		) );
 
 		$payments = new Give_Payments_Query( $args );

--- a/includes/admin/tools/data/class-give-tools-recount-income.php
+++ b/includes/admin/tools/data/class-give-tools-recount-income.php
@@ -78,7 +78,6 @@ class Give_Tools_Recount_Income extends Give_Batch_Export {
 			'number' => $this->per_step,
 			'page'   => $this->step,
 			'status' => $accepted_statuses,
-			'fields' => 'ids'
 		) );
 
 		$payments = give_get_payments( $args );


### PR DESCRIPTION
## Description
PR to fix #3611 

## How Has This Been Tested?
Tested by **recalculating total donation income amount** from the drop down option 

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFjFbRqbYL

![image](https://user-images.githubusercontent.com/22215595/44301992-66a21c00-a33e-11e8-81f7-2b4d27f1c39f.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.