### PR TITLE
fix(donation): donation level not show correctly on donation detail page #3617

### DIFF
--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -451,9 +451,9 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 															'name'             => 'give-variable-price',
 															'chosen'           => true,
 															'show_option_all'  => '',
-															'show_option_none' => ( '' === get_post_meta( $payment_id, '_give_payment_price_id', true ) ? __( 'None', 'give' ) : '' ),
+															'show_option_none' => ( '' === $payment->price_id ? __( 'None', 'give' ) : '' ),
 															'select_atts'      => 'data-prices=' . esc_attr( wp_json_encode( $prices_atts ) ),
-															'selected'         => $payment_meta['price_id'],
+															'selected'         => $payment->price_id,
 														);
 														// Render variable prices select tag html.
 														give_get_form_variable_price_dropdown( $variable_price_dropdown_option, true );


### PR DESCRIPTION
## Description
PR to fix #3617 

## How Has This Been Tested?
- [x] Tested by making the new donation dropdown level
- [x] Also tested by checking the old donation dropdown level


## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFjYhvqFAb

![image](https://user-images.githubusercontent.com/22215595/44321738-65b8d980-a467-11e8-9f7e-483e6ae5cc9d.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.