### PR TITLE
feat(donor-wall): allow to set donor as anonymous only per form basic #3613

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2968,7 +2968,8 @@ function give_v224_update_donor_meta_forms_id_callback() {
 		}
 
 		wp_reset_postdata();
+	} else{
+		give_set_upgrade_complete( 'v224_update_donor_meta_forms_id' );
 	}
 
-	give_set_upgrade_complete( 'v224_update_donor_meta_forms_id' );
 }

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -395,6 +395,7 @@ function give_show_upgrade_notices( $give_updates ) {
 			'id'       => 'v224_update_donor_meta_forms_id',
 			'version'  => '2.2.4',
 			'callback' => 'give_v224_update_donor_meta_forms_id_callback',
+			'depend'   => 'v224_update_donor_meta',
 		)
 	);
 }
@@ -2919,6 +2920,14 @@ function give_v224_update_donor_meta_callback() {
 	}
 }
 
+
+/**
+ * Update donor meta
+ * Set "_give_anonymous_donor_forms" meta key if not exist
+ *
+ *
+ * @since 2.2.4
+ */
 function give_v224_update_donor_meta_forms_id_callback() {
 	$give_updates = Give_Updates::get_instance();
 

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2936,7 +2936,7 @@ function give_v224_update_donor_meta_forms_id_callback() {
 			'status'         => 'any',
 			'order'          => 'ASC',
 			'post_type'      => array( 'give_payment' ),
-			'posts_per_page' => 100,
+			'posts_per_page' => 20,
 		)
 	);
 

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -2946,30 +2946,20 @@ function give_v224_update_donor_meta_forms_id_callback() {
 		while ( $donations->have_posts() ) {
 			$donations->the_post();
 
-			$form_id    = give_get_meta( get_the_ID(), '_give_payment_form_id', true );
-			$donor_id   = give_get_meta( get_the_ID(), '_give_payment_donor_id', true );
-			$anon       = give_get_meta( get_the_ID(), '_give_anonymous_donation', true );
-			$donor_meta = Give()->donor_meta->get_meta( $donor_id, '_give_anonymous_donor_forms', true );
-
-			if ( '1' === $anon ) {
-				if ( is_string( $donor_meta ) && empty( $donor_meta ) ) {
-					$donor_meta = array();
-				}
+			if ( give_is_anonymous_donation( get_the_ID() ) ) {
+				$form_id    = give_get_meta( get_the_ID(), '_give_payment_form_id', true );
+				$donor_id   = give_get_meta( get_the_ID(), '_give_payment_donor_id', true );
+				$donor_meta = (array) Give()->donor_meta->get_meta( $donor_id, '_give_anonymous_donor_forms', true );
 
 				if ( ! in_array( $form_id, $donor_meta ) ) {
 					$donor_meta[] = $form_id;
 					Give()->donor_meta->update_meta( $donor_id, '_give_anonymous_donor_forms', $donor_meta );
 				}
-			} else {
-				if ( is_string( $donor_meta ) && empty( $donor_meta ) ) {
-					Give()->donor_meta->update_meta( $donor_id, '_give_anonymous_donor_forms', array() );
-				}
 			}
 		}
 
 		wp_reset_postdata();
-	} else{
+	} else {
 		give_set_upgrade_complete( 'v224_update_donor_meta_forms_id' );
 	}
-
 }

--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -29,11 +29,7 @@ function __give_insert_donor_donation_comment( $donation_id, $donation_data ) {
 	Give()->donor_meta->update_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor', $is_anonymous_donation );
 
 	if ( $is_anonymous_donation ) {
-		$donor_meta = Give()->donor_meta->get_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor_forms', true );
-
-		if ( is_string( $donor_meta ) && empty( $donor_meta ) ) {
-			$donor_meta = array();
-		}
+		$donor_meta = (array) Give()->donor_meta->get_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor_forms', true );
 
 		if ( ! in_array( $donation_data['give_form_id'], $donor_meta ) ) {
 			$donor_meta[] = $donation_data['give_form_id'];

--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -27,6 +27,19 @@ function __give_insert_donor_donation_comment( $donation_id, $donation_data ) {
 
 	give_update_meta( $donation_id, '_give_anonymous_donation', $is_anonymous_donation );
 	Give()->donor_meta->update_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor', $is_anonymous_donation );
+
+	if ( $is_anonymous_donation ) {
+		$donor_meta = Give()->donor_meta->get_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor_forms', true );
+
+		if ( is_string( $donor_meta ) && empty( $donor_meta ) ) {
+			$donor_meta = array();
+		}
+
+		if ( ! in_array( $donation_data['give_form_id'], $donor_meta ) ) {
+			$donor_meta[] = $donation_data['give_form_id'];
+			Give()->donor_meta->update_meta( $donation_data['user_info']['donor_id'], '_give_anonymous_donor_forms', $donor_meta );
+		}
+	}
 }
 
 add_action( 'give_insert_payment', '__give_insert_donor_donation_comment', 10, 2 );

--- a/includes/donors/class-give-donor-stats.php
+++ b/includes/donors/class-give-donor-stats.php
@@ -71,6 +71,7 @@ class Give_Donor_Stats {
 		$args['status'] = 'publish';
 		$args['fields'] = 'ids';
 		$args['number'] = - 1;
+		$show_anonymous = isset( $args['show_anonymous'] ) && $args['show_anonymous'];
 
 		$donation_query  = new Give_Payments_Query( $args );
 		$donations       = $donation_query->get_payments();
@@ -86,7 +87,7 @@ class Give_Donor_Stats {
 		if ( ! empty( $donated_amounts ) ) {
 			foreach ( $donated_amounts as $donation ) {
 				// Do not include anonymous donation in calculation.
-				if ( give_is_anonymous_donation( $donation['id'] ) && isset( $args['show_anonymous'] ) && ! $args['show_anonymous'] ) {
+				if ( give_is_anonymous_donation( $donation['id'] ) && ! $show_anonymous ) {
 					continue;
 				}
 

--- a/includes/donors/class-give-donor-stats.php
+++ b/includes/donors/class-give-donor-stats.php
@@ -86,7 +86,7 @@ class Give_Donor_Stats {
 		if ( ! empty( $donated_amounts ) ) {
 			foreach ( $donated_amounts as $donation ) {
 				// Do not include anonymous donation in calculation.
-				if( give_is_anonymous_donation( $donation['id']) ){
+				if ( give_is_anonymous_donation( $donation['id'] ) && isset( $args['show_anonymous'] ) && ! $args['show_anonymous'] ) {
 					continue;
 				}
 

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -185,6 +185,7 @@ class Give_Donor_Wall {
 				'show_total'      => true,
 				'show_time'       => true,
 				'show_comments'   => true,
+				'show_anonymous'  => false,
 				'comment_length'  => 20,
 				'only_comments'   => false,
 				'readmore_text'   => esc_html__( 'Read More', 'give' ),
@@ -208,6 +209,7 @@ class Give_Donor_Wall {
 			'show_time',
 			'show_comments',
 			'show_comments',
+			'show_anonymous',
 			'hide_empty',
 			'only_comments',
 			'only_donor_html',
@@ -245,7 +247,7 @@ class Give_Donor_Wall {
 			'order'      => $atts['order'],
 		);
 
-		if ( 0 == $atts['form_id'] ) {
+		if ( ! $atts['show_anonymous'] ) {
 			$donor_args['meta_query'] = array(
 				// Hide anonymous donor.
 				array(

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -243,15 +243,18 @@ class Give_Donor_Wall {
 			'paged'      => $atts['paged'],
 			'orderby'    => $atts['orderby'],
 			'order'      => $atts['order'],
-			'meta_query' => array(
+		);
+
+		if ( 0 == $atts['form_id'] ) {
+			$donor_args['meta_query'] = array(
 				// Hide anonymous donor.
 				array(
-					'key'   => '_give_anonymous_donor',
-					'value' => '1',
+					'key'     => '_give_anonymous_donor',
+					'value'   => '1',
 					'compare' => '!='
 				)
-			),
-		);
+			);
+		}
 
 		// Hide donors with zero donation amount.
 		if ( $atts['hide_empty'] ) {

--- a/includes/install.php
+++ b/includes/install.php
@@ -146,7 +146,8 @@ function give_run_install() {
 			'v213_delete_donation_meta',
 			'v215_update_donor_user_roles',
 			'v220_rename_donation_meta_type',
-			'v224_update_donor_meta'
+			'v224_update_donor_meta',
+			'v224_update_donor_meta_forms_id'
 		);
 
 		foreach ( $upgrade_routines as $upgrade ) {

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -21,7 +21,7 @@ $is_anonymous  = false;
 	<div class="give-donor">
 		<div class="give-donor__header">
 			<?php
-			if ( 0 != $atts['form_id'] ) {
+			if ( '0' !== $atts['form_id'] ) {
 				$form_list = Give()->donor_meta->get_meta( $donor->id, '_give_anonymous_donor_forms', true );
 
 				if ( is_string( $form_list ) && empty( $form_list ) ) {

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -14,21 +14,34 @@ $donor = new Give_Donor( $donor->id );
 
 $give_settings = $args[1]; // Give settings.
 $atts          = $args[2]; // Shortcode attributes.
+$is_anonymous  = false;
 ?>
 
 <div class="give-grid__item">
 	<div class="give-donor">
 		<div class="give-donor__header">
 			<?php
+			if ( 0 != $atts['form_id'] ) {
+				$form_list = Give()->donor_meta->get_meta( $donor->id, '_give_anonymous_donor_forms', true );
+
+				if ( is_string( $form_list ) && empty( $form_list ) ) {
+					$form_list = array();
+				}
+
+				if ( in_array( $atts['form_id'], $form_list ) ) {
+					$is_anonymous = true;
+				}
+			}
+
 			// Maybe display the Avatar.
 			if ( true === $atts['show_avatar'] ) {
-				echo give_get_donor_avatar( $donor );
+				echo $is_anonymous ? sprintf( '<div class="give-donor__image">%s</div>', get_avatar( 'user@example.com' ) ) : give_get_donor_avatar( $donor );
 			}
 			?>
 
 			<div class="give-donor__details">
 				<?php if ( true === $atts['show_name'] ) : ?>
-					<h3 class="give-donor__name"><?php esc_html_e( $donor->name ); ?></h3>
+					<h3 class="give-donor__name"><?php $is_anonymous ? esc_html_e( 'Anonymous', 'give' ) : esc_html_e( $donor->name ); ?></h3>
 				<?php endif; ?>
 
 				<?php if ( true === $atts['show_total'] ) : ?>
@@ -41,8 +54,9 @@ $atts          = $args[2]; // Shortcode attributes.
 						if ( ! empty( $atts['form_id'] ) ) {
 							$donated_amount = Give_Donor_Stats::donated(
 								array(
-									'donor'      => $donor->id,
-									'give_forms' => $atts['form_id']
+									'donor'          => $donor->id,
+									'give_forms'     => $atts['form_id'],
+									'show_anonymous' => true,
 								)
 							);
 						}

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -21,27 +21,38 @@ $is_anonymous  = false;
 	<div class="give-donor">
 		<div class="give-donor__header">
 			<?php
-			if ( '0' !== $atts['form_id'] ) {
-				$form_list = Give()->donor_meta->get_meta( $donor->id, '_give_anonymous_donor_forms', true );
+			if( true === $atts['show_anonymous'] ) {
+				$is_anonymous = (bool) Give()->donor_meta->get_meta( $donor->id, '_give_anonymous_donor', true ) ;
 
-				if ( is_string( $form_list ) && empty( $form_list ) ) {
-					$form_list = array();
-				}
+				// Check if donor is anonymous for specific form or not.
+				if ( 0 !== absint( $atts['form_id'] ) ) {
+					// Default value.
+					$is_anonymous  = false;
+					$form_list = (array) Give()->donor_meta->get_meta( $donor->id, '_give_anonymous_donor_forms', true );
 
-				if ( in_array( $atts['form_id'], $form_list ) ) {
-					$is_anonymous = true;
+					if ( ! empty( $form_list ) && in_array( $atts['form_id'], $form_list ) ) {
+						$is_anonymous = true;
+					}
 				}
 			}
 
 			// Maybe display the Avatar.
 			if ( true === $atts['show_avatar'] ) {
-				echo $is_anonymous ? sprintf( '<div class="give-donor__image">%s</div>', get_avatar( 'user@example.com' ) ) : give_get_donor_avatar( $donor );
+				echo $is_anonymous ?
+					sprintf( '<div class="give-donor__image">%s</div>', get_avatar( 'user@example.com' ) ) :
+					give_get_donor_avatar( $donor );
 			}
 			?>
 
 			<div class="give-donor__details">
 				<?php if ( true === $atts['show_name'] ) : ?>
-					<h3 class="give-donor__name"><?php $is_anonymous ? esc_html_e( 'Anonymous', 'give' ) : esc_html_e( $donor->name ); ?></h3>
+					<h3 class="give-donor__name">
+						<?php
+						$is_anonymous ?
+							esc_html_e( 'Anonymous', 'give' ) :
+							esc_html_e( $donor->name );
+						?>
+					</h3>
 				<?php endif; ?>
 
 				<?php if ( true === $atts['show_total'] ) : ?>
@@ -56,11 +67,11 @@ $is_anonymous  = false;
 								array(
 									'donor'          => $donor->id,
 									'give_forms'     => $atts['form_id'],
-									'show_anonymous' => true,
+									'show_anonymous' => $atts['show_anonymous'],
+									'is_anonymous'   => $is_anonymous,
 								)
 							);
 						}
-
 						echo give_currency_filter( give_format_amount( $donated_amount, array( 'sanitize' => false ) ) );
 						?>
 					</span>


### PR DESCRIPTION
Closes #3613 

## Description
What this PR fixes:

If the `form_id` parameter is set in the shortcode, then the donors who have anonymously donated are displayed with the name `Anonymous` and their gravatar is set to default. Example:

![anon](https://user-images.githubusercontent.com/17757960/44440196-bc97ed80-a5e4-11e8-830a-2505505803ac.png)

If the donor wall does not have any `form_id` specified, then by default it will skip all anonymous donors. This will be determined if the donor meta `_give_anonymous_donor` is set to `1`  

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.