### PR TITLE
feat(shortcode): ensure user can set the display order of the donor wall #3622

### DIFF
--- a/includes/donors/class-give-donors-query.php
+++ b/includes/donors/class-give-donors-query.php
@@ -443,7 +443,7 @@ class Give_Donors_Query {
 				unset( $ordersby[$orderby] );
 			}
 
-			$ordersby[ esc_sql( $orderby ) ] = esc_sql( $this->args['order'] );
+			$ordersby[ esc_sql( $orderby ) ] = esc_sql( $order );
 		}
 
 		if( empty( $ordersby ) ) {


### PR DESCRIPTION
Closes #3622 

## Description
This PR fixes the `order` attribute, it was being overridden and always set to `DESC`.

## How Has This Been Tested?
Tested as shown in the video below

## Screenshots (jpeg or gifs if applicable):
https://www.useloom.com/share/b93e6053f08349f4b4a6e218c77835b9

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.