### PR TITLE
fix(admin-donation): Set correct date format for database

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -63,7 +63,7 @@ function give_update_payment_details( $data ) {
 
 	$curr_total = $payment->total;
 	$new_total  = give_maybe_sanitize_amount( ( ! empty( $data['give-payment-total'] ) ? $data['give-payment-total'] : 0 ) );
-	$date       = date( get_option( 'date_format' ), strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
+	$date       = date( 'Y-m-d', strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';
 
 	$curr_donor_id = sanitize_text_field( $data['give-current-donor'] );
 	$new_donor_id  = sanitize_text_field( $data['donor-id'] );

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -947,9 +947,6 @@ final class Give_Payment {
 						break;
 
 					case 'date':
-
-						$date_format = get_option( 'date_format' );
-
 						$args = array(
 							'ID'        => $this->ID,
 							'post_date' => date( 'Y-m-d H:i:s', strtotime( $this->date ) ),

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -947,9 +947,12 @@ final class Give_Payment {
 						break;
 
 					case 'date':
+
+						$date_format = get_option( 'date_format' );
+
 						$args = array(
 							'ID'        => $this->ID,
-							'post_date' => $this->date,
+							'post_date' => date( 'Y-m-d H:i:s', strtotime( $this->date ) ),
 							'edit_date' => true,
 						);
 


### PR DESCRIPTION
## Description
This is a quick fix related to issue #3606 

This PR sets the correct format of data before inserting it into database.
Related: https://github.com/WordImpress/Give/issues/3606#issuecomment-417214966

## How Has This Been Tested?
By checking the debug log.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.