### PR TITLE
fix(admin-form): delete form meta when we delete the donation form #3641

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1488,3 +1488,35 @@ function give_is_name_title_prefix_required( $form_id = 0 ) {
 
 	return ( ! $is_optional );
 }
+
+/**
+ * Deletes form meta when the form is permanently deleted from the trash.
+ *
+ * @since 2.3.0
+ *
+ * @param integer $post_id Post ID of the post being deleted.
+ *
+ * @return void
+ */
+function give_delete_form_meta_on_form_delete( $post_id ) {
+
+	global $wpdb;
+
+	// Get the post object of the revision post.
+	$post = get_post( $post_id );
+
+	// Get parent post ID of the revision post.
+	$post_parent_id = $post->post_parent;
+
+	// Get post type of the form being deleted.
+	$post_type = get_post_type( $post_parent_id );
+
+	if (
+		'give_forms' === $post_type
+		&& $wpdb->get_var( $wpdb->prepare( "SELECT form_id FROM $wpdb->formmeta WHERE form_id = %d", $post_id ) )
+	) {
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->formmeta WHERE form_id = %d", $post_id ) );
+	}
+}
+
+add_action( 'delete_post', 'give_delete_form_meta_on_form_delete', 10 );


### PR DESCRIPTION
Closes #3641 

## Description
This PR deletes the form meta when the form is deleted permanently from the trash.

## How Has This Been Tested?
Tested by moving forms to trash and then deleting from trash.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.