### PR TITLE
fix(db): delete row from give meta table when donation are being deleted #3638

### DIFF
--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -128,6 +128,12 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 						$sql[] = "DELETE FROM $wpdb->postmeta WHERE post_id IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->comments WHERE comment_post_ID IN ($ids)";
 						$sql[] = "DELETE FROM $wpdb->commentmeta WHERE comment_id NOT IN (SELECT comment_ID FROM $wpdb->comments)";
+						$sql[] = "DELETE FROM $wpdb->formmeta WHERE form_id IN ($ids)";
+						$sql[] = "DELETE FROM $wpdb->logmeta WHERE meta_key = '_give_log_form_id' AND meta_value IN ($ids)";
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_logs WHERE log_parent IN ($ids)";
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_sequential_ordering WHERE payment_id IN ($ids)";
+						$sql[] = "DELETE FROM {$wpdb->prefix}give_donationmeta WHERE donation_id IN ($ids)";
+
 						$sql[] = $wpdb->prepare(
 							"
 							DELETE FROM $wpdb->terms
@@ -141,6 +147,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 							",
 							array( 'give_forms_category', 'give_forms_tag' )
 						);
+
 						$sql[] = $wpdb->prepare(
 							"
 							DELETE FROM $wpdb->term_taxonomy
@@ -149,6 +156,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 							",
 							array( 'give_forms_category', 'give_forms_tag' )
 						);
+
 						break;
 				}
 


### PR DESCRIPTION
Closes #3638 

## Description
This PR removes the redundant data from the following tables:

- [x] wp_give_donationmeta
- [x] wp_give_formmeta
- [x] wp_give_logmeta
- [x] wp_give_logs
- [x] wp_give_sequential_ordering


## How Has This Been Tested?
By making 3 donations, and deleting all data as explained in the video linked in the issue. I've cross-checked it with the data in the database.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.