### PR TITLE
fix: use the customized global email content as a starting point for per-form emails #3653

### DIFF
--- a/includes/admin/emails/class-new-donation-email.php
+++ b/includes/admin/emails/class-new-donation-email.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'Give_New_Donation_Email' ) ) :
 				'notification_status'   => 'enabled',
 				'form_metabox_setting'  => true,
 				'default_email_subject' => esc_attr__( 'New Donation - #{payment_id}', 'give' ),
-				'default_email_message' => give_get_default_donation_notification_email(),
+				'default_email_message' => ( false !== give_get_option( 'new-donation_email_message' ) ) ? give_get_option( 'new-donation_email_message' ) : give_get_default_donation_notification_email(),
 				'default_email_header'  => __( 'New Donation!', 'give' ),
 			) );
 

--- a/includes/admin/emails/class-new-offline-donation-email.php
+++ b/includes/admin/emails/class-new-offline-donation-email.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Give_New_Offline_Donation_Email' ) ) :
 					'payment_method' => esc_html__( 'Offline', 'give' ),
 				),
 				'default_email_subject'        => $this->get_default_email_subject(),
-				'default_email_message'        => $this->get_default_email_message(),
+				'default_email_message'        => ( false !== give_get_option( 'new-offline-donation_email_message' ) ) ? give_get_option( 'new-offline-donation_email_message' ) : give_get_default_donation_notification_email(),
 				'default_email_header'         => __( 'New Offline Donation!', 'give' ),
 				'notices' => array(
 					'non-notification-status-editable' => sprintf(


### PR DESCRIPTION
Closes #3653 

## Description
This PR makes the global email content of New Donation and Offline New Donation as the starting point content for per form New Donation and Offline Donation Content. 

## How Has This Been Tested?
Edited content of global New Donation and Offline New Donation and tested this by checking preview, Sending Test Email from the form itself and by making a donation. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.