### PR TITLE
fix: [Give - 2.3.0] prevent donation amount error when try to make a donation in new sites in #3672

### DIFF
--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1397,7 +1397,7 @@ function give_validate_donation_amount( $valid_data ) {
 		$variable_price_option_amount = give_maybe_sanitize_amount( give_get_price_option_amount( $post_data['give-form-id'], $post_data['give-price-id'] ), array( 'currency' => $form_currency ) );
 		$new_price_id                 = '';
 
-		if ( $post_data['give-amount'] === $variable_price_option_amount ) {
+		if ( give_sanitize_amount_for_db( $post_data['give-amount'] ) === $variable_price_option_amount ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Description
PR to fix #3672 

## How Has This Been Tested?
- [x] Tested by making a donation via  Multi-level Donation
- [x] Tested by making a donation via  Set Donation

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFQl6PqHZP

## Types of changes
Bug fix (non-breaking change which fixes an issue )

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.