### PR TITLE
fix: allow 8 number of decimal position for bitcoin #3602

### DIFF
--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -40,8 +40,9 @@ function __give_sanitize_number_decimals_setting_field( $value ) {
 		Give_Admin_Settings::add_error( 'give-number-decimal', __( 'The \'Number of Decimals\' option has been automatically set to zero because the \'Decimal Separator\' is not set.', 'give' ) );
 	}
 
-	$value           = absint( $value );
-	$number_decimals = 'BTC' === give_get_option( 'currency' ) || 'BTC' === $_POST['currency'] ? 8 : 6;
+	$value                      = absint( $value );
+	$is_currency_set_to_bitcoin = ( 'BTC' === give_get_option( 'currency' ) && ! isset( $_POST['currency'] ) ) || 'BTC' === $_POST['currency'];
+	$number_decimals            = $is_currency_set_to_bitcoin ? 8 : 6;
 
 	if ( $number_decimals <= $value ) {
 		$value = $number_decimals;

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -40,11 +40,18 @@ function __give_sanitize_number_decimals_setting_field( $value ) {
 		Give_Admin_Settings::add_error( 'give-number-decimal', __( 'The \'Number of Decimals\' option has been automatically set to zero because the \'Decimal Separator\' is not set.', 'give' ) );
 	}
 
-	$value = absint( $value );
+	$value           = absint( $value );
+	$number_decimals = 'BTC' === give_get_option( 'currency' ) || 'BTC' === $_POST['currency'] ? 8 : 6;
 
-	if ( 8 <= $value ) {
-		$value = 8;
-		Give_Admin_Settings::add_error( 'give-number-decimal', __( 'The \'Number of Decimals\' option has been automatically set to 8 because you entered a number higher than the maximum allowed.', 'give' ) );
+	if ( $number_decimals <= $value ) {
+		$value = $number_decimals;
+		Give_Admin_Settings::add_error(
+			'give-number-decimal',
+			sprintf(
+				__( 'The \'Number of Decimals\' option has been automatically set to %s because you entered a number higher than the maximum allowed.', 'give' ),
+				$number_decimals
+			)
+		);
 	}
 
 	return absint( $value );

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -206,7 +206,7 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 											<p>
 												<label for="give-payment-total" class="strong"><?php _e( 'Total Donation:', 'give' ); ?></label>&nbsp;
 												<?php echo give_currency_symbol( $payment->currency ); ?>
-												&nbsp;<input id="give-payment-total" name="give-payment-total" type="text" class="small-text give-price-field" value="<?php echo esc_attr( give_format_decimal( give_donation_amount( $payment_id ), false, false ) ); ?>"/>
+												&nbsp;<input id="give-payment-total" name="give-payment-total" type="text" class="small-text give-price-field" value="<?php echo esc_attr( give_format_decimal( array( 'donation_id' => $payment_id ) ) ); ?>"/>
 											</p>
 										</div>
 

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -214,7 +214,7 @@ function give_maybe_sanitize_amount( $number, $args = array() ) {
 	$thousand_separator = give_get_price_thousand_separator( $args['currency'] );
 	$decimal_separator  = give_get_price_decimal_separator( $args['currency'] );
 	$number_decimals    = is_bool( $args['number_decimals'] ) ?
-		give_get_price_decimals() :
+		give_get_price_decimals( $args['currency'] ) :
 		$args['number_decimals'];
 
 	// Explode number by . decimal separator.

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -240,16 +240,16 @@ function give_maybe_sanitize_amount( $number, $args = array() ) {
 		&& false === strpos( $number, $decimal_separator )
 		&& 2 === count( $number_parts )
 		&& ( $number_decimals >= strlen( $number_parts[1] ) )
-	){
+	) {
 		return number_format( $number, $number_decimals, '.', '' );
 	}
 
 	// Handle thousand separator as '.'
 	// Handle sanitize database values.
 	$is_db_sanitize_val = ( 2 === count( $number_parts ) &&
-							is_numeric( $number_parts[0] ) &&
-							is_numeric( $number_parts[1] ) &&
-							( 6 === strlen( $number_parts[1] ) ) );
+	                        is_numeric( $number_parts[0] ) &&
+	                        is_numeric( $number_parts[1] ) &&
+	                        ( in_array( strlen( $number_parts[1] ), array( 6, 10 ) ) ) );
 
 	if ( $is_db_sanitize_val ) {
 		// Sanitize database value.

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -159,12 +159,19 @@ function give_get_price_decimal_separator( $id_or_currency_code = null ) {
  * @since      1.8.12
  *
  * @param  int|float|string $number Expects either a float or a string with a decimal separator only (no thousands)
- * @param  array|bool $args It accepts 'number_decimals', 'trim_zeros', 'currency'.
+ * @param  array|bool       $args   It accepts 'number_decimals', 'trim_zeros', 'currency'.
  *
  * @return string $amount Newly sanitized amount
  */
 function give_sanitize_amount_for_db( $number, $args = array() ) {
-	$args['number_decimals'] = 8;
+	$args['number_decimals'] = 6;
+
+	if (
+		( isset( $args['currency'] ) && 'BTC' === $args['currency'] )
+		|| 'BTC' === give_get_currency()
+	) {
+		$args['number_decimals'] = 10;
+	}
 
 	return give_maybe_sanitize_amount( $number, $args );
 }


### PR DESCRIPTION
## Description
This pr will resolve #3602 #3672 

## How Has This Been Tested?
- [x] Process multiple donations with Bitcoin currency
- [x] Switch currency to Bitcoin and other after process few donations
- [x] Change number of decimal setting when currency set to (or not) Bitcoin.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.