### PR TITLE
Long transaction id in donation detail page goes outside the metabox #3692

### DIFF
--- a/assets/src/css/admin/payment-history.scss
+++ b/assets/src/css/admin/payment-history.scss
@@ -397,6 +397,7 @@ Responsiveness
   padding: 3px 10px;
   clear: both;
   border-bottom: 1px solid #eee;
+  word-break: break-word;
 }
 
 .give-admin-box-inside .strong {


### PR DESCRIPTION
## Description
This PR resolves #3692 

## How Has This Been Tested?
I've tested this PR and is no longer having the long transaction id getting outside of meta box.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/45682838-290ff900-bb5f-11e8-8103-f28d7a03bb81.png)

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.