### PR TITLE
fix: save setting successfully message not coming up when only give plugin is being activate #3687

### DIFF
--- a/assets/src/js/plugins/give-api/notice.js
+++ b/assets/src/js/plugins/give-api/notice.js
@@ -1,6 +1,22 @@
 /* globals Give, jQuery */
 export default {
 	fn: {
+
+		/**
+		 * Print notices
+		 *
+		 * @since 2.2.6
+		 */
+		printNotice: function () {
+			// Fix notice appearance issue.
+			window.setTimeout(
+				function () {
+					$( '.give-notice' ).slideDown();
+				},
+				1000
+			);
+		},
+
 		/**
 		 * Render notice
 		 * @since 1.8.17

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -176,7 +176,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 			if ( 0 < count( self::$errors ) ) {
 				foreach ( self::$errors as $code => $message ) {
 					$notice_html .= sprintf(
-						'<div id="setting-error-%1$s" class="%2$s error" style="display: none"><p><strong>%3$s</strong></p></div>',
+						'<div id="setting-error-%1$s" class="%2$s error" data-dismissible="auto" style="display: none"><p><strong>%3$s</strong></p></div>',
 						$code,
 						$classes,
 						$message
@@ -187,7 +187,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 			if ( 0 < count( self::$messages ) ) {
 				foreach ( self::$messages as $code => $message ) {
 					$notice_html .= sprintf(
-						'<div id="setting-error-%1$s" class="%2$s updated" data-notice-id="setting-error-%1$s" style="display: block"><p><strong>%3$s</strong></p></div>',
+						'<div id="setting-error-%1$s" class="%2$s updated" data-dismissible="auto" style="display: block"><p><strong>%3$s</strong></p></div>',
 						$code,
 						$classes,
 						$message

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -187,7 +187,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 			if ( 0 < count( self::$messages ) ) {
 				foreach ( self::$messages as $code => $message ) {
 					$notice_html .= sprintf(
-						'<div id="setting-error-%1$s" class="%2$s updated" style="display: none"><p><strong>%3$s</strong></p></div>',
+						'<div id="setting-error-%1$s" class="%2$s updated" data-notice-id="setting-error-%1$s" style="display: block"><p><strong>%3$s</strong></p></div>',
 						$code,
 						$classes,
 						$message

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -396,12 +396,7 @@ class Give_Notices {
 		<script>
 			jQuery(document).ready(function($){
 				// Fix notice appearance issue.
-				window.setTimeout(
-					function(){
-						$('.give-notice').slideDown();
-					},
-					1000
-				);
+				Give.notice.fn.printNotice();
 			});
 		</script>
 		<?php


### PR DESCRIPTION
## Description
PR to fix #3687 

## How Has This Been Tested?
Tested by saving the setting with only Give Core plugin activate and with other add-on activate too 

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFQFYHqNAY
![image](https://user-images.githubusercontent.com/22215595/45689410-8745d780-bb71-11e8-9c92-812bf6a4d974.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.