### PR TITLE
fix: save setting successfully message not coming up when only give plugin is being activate #3687

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -195,6 +195,9 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 				}
 			}
 
+			// print notices.
+			$notice_html .= Give()->notices->print_notices();
+
 			echo $notice_html;
 		}
 

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -392,21 +392,31 @@ class Give_Notices {
 			</script>
 			<?php
 		endif;
+
+		// Print notices.
+		$this->print_notices();
+	}
+
+	/**
+	 * Print Give Notices
+	 *
+	 * @since 2.2.6
+	 */
+	public function print_notices() {
 		?>
 		<script>
-			jQuery(document).ready(function($){
+			jQuery( document ).ready( function ( $ ) {
 				// Fix notice appearance issue.
 				window.setTimeout(
-					function(){
-						$('.give-notice').slideDown();
+					function() {
+						$( '.give-notice' ).slideDown();
 					},
 					1000
 				);
-			});
+			} );
 		</script>
 		<?php
 	}
-
 
 	/**
 	 * Hide notice.


### PR DESCRIPTION
## Description
PR to fix #3687 

## How Has This Been Tested?
Tested by saving the setting with only Give Core plugin activate and with other add-on activate too 

## Screenshots (jpeg or gifs if applicable):
Video Link: https://screencast-o-matic.com/watch/cFQFYHqNAY

![image](https://user-images.githubusercontent.com/22215595/45752263-8163fb00-bc32-11e8-8219-4ff9f01c91b4.png)

![image](https://user-images.githubusercontent.com/22215595/45752285-99d41580-bc32-11e8-96b3-a94fa31d48a1.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.