### PR TITLE
feat: create template tag to pass the donor comment to email templates #3655

### DIFF
--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -914,6 +914,7 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 					),
 					'admin_email'             => give_email_admin_email(),
 					'offline_mailing_address' => give_email_offline_mailing_address(),
+					'donor_comment'           => $payment_id ? give_email_donor_comment( array( 'payment_id' => $payment_id ) ) : esc_html__( 'Sample Donor Comment', 'give' ),
 				)
 			);
 

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -495,6 +495,13 @@ function give_setup_email_tags() {
 			'context' => 'general',
 		),
 
+		array(
+			'tag'     => 'donor_comment',
+			'desc'    => esc_html__( 'The Donor Comment that was submitted with the donation.', 'give' ),
+			'func'    => 'give_email_donor_comment',
+			'context' => 'donor',
+		),
+
 	);
 
 	// Apply give_email_tags filter
@@ -1609,6 +1616,33 @@ function give_email_offline_mailing_address() {
 	}
 
 	return $offline_address;
+}
+
+/**
+ * Returns the donor comment for a particular donation.
+ *
+ * Email template tag: {donor_comment}
+ *
+ * @param array $tag_args Array of arguments for email tags.
+ *
+ * @since 2.3.0
+ *
+ * @return string
+ */
+function give_email_donor_comment( $tag_args ) {
+
+	// Get the payment ID.
+	$payment_id = $tag_args['payment_id'];
+
+	// Get the comment object for the above payment ID and donor ID.
+	$comment = give_get_donor_donation_comment( $payment_id, give_get_payment_donor_id( $payment_id ) );
+
+	if ( is_array( $comment ) && empty( $comment ) ) {
+		return '';
+	}
+
+	// Return comment content.
+	return $comment->comment_content;
 }
 
 /**


### PR DESCRIPTION
Closes #3655 

## Description
This PR adds a new email template tag called `{donor_comment}` under the `donor` context. This email tag can be used to send the donor comment in emails which are sent to the donor.

## How Has This Been Tested?
- Tested Email Preview
- Tested Send Test Email
- Tested Donation with a Donor Comment
- Tested Donation with an empty donor comment

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.