### PR TITLE
fix: ensure the give shortcode should display proper title with scroll bar #3876

### DIFF
--- a/includes/admin/shortcodes/admin-shortcodes.js
+++ b/includes/admin/shortcodes/admin-shortcodes.js
@@ -141,6 +141,15 @@ jQuery( function( $ ) {
 						scForm.destroy();
 					},
 					onopen: function() {
+
+						// Hacky way to remove scrollbars when not necessary.
+						let popup = $('.mce-sc-popup');
+						popup.css({
+							width: popup.width(),
+							height: popup.height(),
+							overflow: 'auto'
+						});
+
 						// Conditional fields.
 						render_continue_button_title_field();
 					}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

I added an onopen CSS hack to remove the scrollbars for most resolutions. If you go down really far in size the scrollbars may still appear but this resolves it for most cases. 

Resolves #3876 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually using Mac Chrome

## Screenshots (jpeg or gifs if applicable):

![2018-12-12_14-22-56](https://user-images.githubusercontent.com/1571635/49902758-afb03b80-fe19-11e8-9d5c-86a56892984e.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.