### PR TITLE
Pin Node at 12 and npm at 7 for Volta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "give",
             "license": "ISC",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -125,5 +125,9 @@
         "styled-components": "^5.2.1",
         "swr": "^0.4.1",
         "uiblocker": "latest"
+    },
+    "volta": {
+        "node": "12.22.6",
+        "npm": "7.24.2"
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This pins the Node version to 12 and the npm version to 7 as an **optional** convenience for developers who use [Volta] for their JavaScript tooling management.

Yes, this does create a new maintenance task: these versions will also need to be manually updated if the required versions for building the plugin’s assets change. These changes are _incredibly infrequent_ and when compared to how often a developer might need to manually set these versions for their environment when switching between (first-party and third-party; related and unrelated) projects with differing Node requirements, the benefits of providing the convenience greatly outweigh the cost of maintenance. Further, since this is an optional convenience, the mainenance is also optional since it has no effect on those who do not use Volta. Developers who benefit from the convenience will maintain it.

[Volta]: https://volta.sh

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `package.json`
- `package-lock.json`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
