### PR TITLE
Use Sass math.div for division instead of deprecated slash operator

### DIFF
--- a/assets/src/css/admin/grids.scss
+++ b/assets/src/css/admin/grids.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $width: 98%;
 $gutter: 2%;
 $breakpoint-small: 33.75em; // 540px
@@ -22,17 +24,17 @@ $breakpoint-large: 60em; // 960px
 }
 
 
-.give-grid-col-1 { width:($width / 12) - ($gutter * 11 / 12); }
-.give-grid-col-2 { width: ($width / 6) - ($gutter * 10 / 12); }
-.give-grid-col-3 { width: ($width / 4) - ($gutter * 9 / 12); }
-.give-grid-col-4 { width: ($width / 3) - ($gutter * 8 / 12); }
-.give-grid-col-5 { width: ($width / (12 / 5)) - ($gutter * 7 / 12); }
-.give-grid-col-6 { width: ($width / 2) - ($gutter * 6 / 12); }
-.give-grid-col-7 { width: ($width / (12 / 7)) - ($gutter * 5 / 12); }
-.give-grid-col-8 { width: ($width / (12 / 8)) - ($gutter * 4 / 12); }
-.give-grid-col-9 { width: ($width / (12 / 9)) - ($gutter * 3 / 12); }
-.give-grid-col-10 { width: ($width / (12 / 10)) - ($gutter * 2 / 12); }
-.give-grid-col-11 { width: ($width / (12 / 11)) - ($gutter * 1 / 12); }
+.give-grid-col-1 { width:math.div($width, 12) - math.div($gutter * 11, 12); }
+.give-grid-col-2 { width: math.div($width, 6) - math.div($gutter * 10, 12); }
+.give-grid-col-3 { width: ($width * 0.25) - math.div($gutter * 9, 12); }
+.give-grid-col-4 { width: math.div($width, 3) - math.div($gutter * 8, 12); }
+.give-grid-col-5 { width: math.div($width, (12 * 0.2)) - math.div($gutter * 7, 12); }
+.give-grid-col-6 { width: ($width * 0.5) - math.div($gutter * 6, 12); }
+.give-grid-col-7 { width: math.div($width, math.div(12, 7)) - math.div($gutter * 5, 12); }
+.give-grid-col-8 { width: math.div($width, (12 * 0.125)) - math.div($gutter * 4, 12); }
+.give-grid-col-9 { width: math.div($width, math.div(12, 9)) - math.div($gutter * 3, 12); }
+.give-grid-col-10 { width: math.div($width, (12 * 0.1)) - math.div($gutter * 2, 12); }
+.give-grid-col-11 { width: math.div($width, math.div(12, 11)) - math.div($gutter * 1, 12); }
 .give-grid-col-12 { width: $width; }
 
 @media only screen and (max-width: $breakpoint-small) {

--- a/assets/src/css/icons/fa/_larger.scss
+++ b/assets/src/css/icons/fa/_larger.scss
@@ -2,9 +2,11 @@
 // -------------------------
 
 // makes the font 33% larger relative to the icon container
+@use "sass:math";
+
 .#{$fa-css-prefix}-lg {
-	font-size: (4em / 3);
-	line-height: (3em / 4);
+	font-size: math.div(4em, 3);
+	line-height: (3em * 0.25);
 	vertical-align: -0.0667em;
 }
 

--- a/assets/src/css/icons/fa/_list.scss
+++ b/assets/src/css/icons/fa/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
 	list-style-type: none;
-	margin-left: $fa-li-width * 5/4;
+	margin-left: $fa-li-width * 5*0.25;
 	padding-left: 0;
 
 	> li {

--- a/assets/src/css/icons/fa/_variables.scss
+++ b/assets/src/css/icons/fa/_variables.scss
@@ -1,6 +1,8 @@
 // Variables
 // --------------------------
 
+@use "sass:math";
+
 $fa-font-path: '../../fonts' !default;
 $fa-font-size-base: 16px !default;
 $fa-font-display: auto !default;
@@ -9,7 +11,7 @@ $fa-version: '5.12.1' !default;
 $fa-border-color: #eee !default;
 $fa-inverse: #fff !default;
 $fa-li-width: 2em !default;
-$fa-fw-width: (20em / 16);
+$fa-fw-width: math.div(20em, 16);
 $fa-primary-opacity: 1 !default;
 $fa-secondary-opacity: 0.4 !default;
 

--- a/assets/src/css/plugins/_settings.scss
+++ b/assets/src/css/plugins/_settings.scss
@@ -3,6 +3,8 @@
 ////////////////////////
 
 // overlay
+@use "sass:math";
+
 $mfp-overlay-color:                   #0b0b0b !default;                    // Color of overlay screen
 $mfp-overlay-opacity:                 0.8 !default;                        // Opacity of overlay screen
 $mfp-shadow:                          0 0 8px rgba(0, 0, 0, 0.6) !default; // Shadow on image or iframe
@@ -27,7 +29,7 @@ $mfp-include-iframe-type:             true !default;                       // En
 $mfp-iframe-padding-top:              40px !default;                       // Iframe padding top
 $mfp-iframe-background:               #000 !default;                       // Background color of iframes
 $mfp-iframe-max-width:                900px !default;                      // Maximum width of iframes
-$mfp-iframe-ratio:                    9/16 !default;                       // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
+$mfp-iframe-ratio:                    math.div(9, 16) !default;                       // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
 
 // Image-type options
 $mfp-include-image-type:              true !default;                       // Enable Image-type popups

--- a/assets/src/css/plugins/float-labels.scss
+++ b/assets/src/css/plugins/float-labels.scss
@@ -57,7 +57,7 @@ $float-labels-defaults: (
 		top: fl(border-width);
 		left: fl(border-width) + fl(base-padding)*1.5;
 		background-color: transparent;
-		padding: fl(base-padding)*2 fl(base-padding)/2;
+		padding: fl(base-padding)*2 fl(base-padding)*0.5;
 	}
 	label.#{fl(prefix)}label:before {
 		content: '';
@@ -70,10 +70,10 @@ $float-labels-defaults: (
 		background-color: fl(color-background);
 		z-index: -1;
 	}
-	$label-top: round((fl(base-padding) + fl(font-size-small))/2);
+	$label-top: round((fl(base-padding) + fl(font-size-small))*0.5);
 	.#{fl(prefix)}is-active label.#{fl(prefix)}label {
 		top: - $label-top;
-		padding: fl(base-padding)/2;
+		padding: fl(base-padding)*0.5;
 	}
 	.#{fl(prefix)}is-active label.#{fl(prefix)}label:before {
 		top: $label-top;
@@ -97,7 +97,7 @@ $float-labels-defaults: (
 	label.#{fl(prefix)}label {
 		top: fl(border-width);
 		left: fl(border-width) + fl(base-padding)*1.5;
-		padding: fl(base-padding) fl(base-padding)/2 fl(base-padding)/2;
+		padding: fl(base-padding) fl(base-padding)*0.5 fl(base-padding)*0.5;
 	}
 	.#{fl(prefix)}is-required:before {
 		padding-top: fl(base-padding)*2;
@@ -193,7 +193,7 @@ $float-labels-defaults: (
 	display: block;
 	position: absolute;
 	top: fl(border-width);
-	right: fl(base-height)/2 + fl(base-padding)/2;
+	right: fl(base-height)*0.5 + fl(base-padding)*0.5;
 	font-size: fl(font-size);
 	line-height: 1.75;
 	color: fl(color-required);
@@ -221,7 +221,7 @@ $float-labels-defaults: (
 	top: fl(border-width);
 	right: 6px;
 	height: calc(100% - #{fl(border-width)*2});
-	width: fl(base-height)/2;
+	width: fl(base-height)*0.5;
 	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 16'><path fill='#{fl(color-placeholder)}' d='M 4 0 L 0 6.5 L 8 6.5 L 4 0 z M 0 9.5 L 4 16 L 4 16 L 8 9.5 z'/></svg>") no-repeat;
 	background-position: 100% 50%;
 	background-size: 7px 14px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/icons/_larger.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/icons/_larger.scss
@@ -2,9 +2,11 @@
 // -------------------------
 
 // makes the font 33% larger relative to the icon container
+@use "sass:math";
+
 .#{$fa-css-prefix}-lg {
-	font-size: (4em / 3);
-	line-height: (3em / 4);
+	font-size: math.div(4em, 3);
+	line-height: (3em * 0.25);
 	vertical-align: -0.0667em;
 }
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/icons/_list.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/icons/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
 	list-style-type: none;
-	margin-left: $fa-li-width * 5/4;
+	margin-left: $fa-li-width * 5*0.25;
 	padding-left: 0;
 
 	> li {

--- a/src/Views/Form/Templates/Sequoia/assets/css/icons/_variables.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/icons/_variables.scss
@@ -1,6 +1,8 @@
 // Variables
 // --------------------------
 
+@use "sass:math";
+
 $fa-font-path: '../fonts' !default;
 $fa-font-size-base: 16px !default;
 $fa-font-display: auto !default;
@@ -9,7 +11,7 @@ $fa-version: '5.12.1' !default;
 $fa-border-color: #eee !default;
 $fa-inverse: #fff !default;
 $fa-li-width: 2em !default;
-$fa-fw-width: (20em / 16);
+$fa-fw-width: math.div(20em, 16);
 $fa-primary-opacity: 1 !default;
 $fa-secondary-opacity: 0.4 !default;
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I used the Sass Migrator to change all the deprecated uses of the slash operator to use the function instead. This cleans up the build console.

See: https://sass-lang.com/documentation/breaking-changes/slash-div

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Everything that uses those CSS files. Seems like there is no difference when comparing the built CSS.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
