### PR TITLE
Fix: Check for numeric value before comapring to zero.

### DIFF
--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -281,7 +281,7 @@ function give_currency_filter( $price = '', $args = [] ) {
 
 	/**
 	 * @unreleased Check for a numeric value before comparing to zero.
-	 * Note: PHP 8 changes how an empty string is evaluated when comparing to zero.
+	 * @link https://www.php.net/manual/en/migration80.incompatible.php
 	 */
 	$negative = is_numeric( $price ) && $price < 0;
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6030

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

https://www.php.net/manual/en/migration80.incompatible.php

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This only affects calls to `give_currency_filter()` that do not pass a numeric `$price` argument (which defaults to an empty string.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/137011883-1693135d-5813-4f96-8ba1-9fa7d39e628c.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

