### PR TITLE
Fix: Conditionally update to block_categories_all filter for WP 5.8+. 

### DIFF
--- a/blocks/load.php
+++ b/blocks/load.php
@@ -18,7 +18,11 @@ function give_blocks_category( $categories, $post ) {
 		)
 	);
 }
-add_filter( 'block_categories', 'give_blocks_category', 10, 2 );
+if ( version_compare( get_bloginfo( 'version' ), '5.8', '>=' ) ) {
+	add_filter( 'block_categories_all', 'give_blocks_category', 10, 2 );
+} else {
+    add_filter( 'block_categories', 'give_blocks_category', 10, 2 );
+}
 
 /**
 * Blocks


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6053

## Description

`block_categories` filter is deprecated in WP 5.8. This updates the filter to `block_categories_all` for WP 5.8+

## Testing Instructions

with `WP_DEBUG` and `WP_DEBUG_LOG` enabled you will see the deprecation notice when editing a page in the block editor. It should disappear with this PR. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

