### PR TITLE
Fix error to connect a PayPal sandbox account 

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -214,9 +214,6 @@ EOT;
      */
     private function getPartnerJsUrl()
     {
-        return sprintf(
-            '%1$swebapps/merchantboarding/js/lib/lightbox/partner.js',
-            give(PayPalClient::class)->getHomePageUrl()
-        );
+        return 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js';
     }
 }


### PR DESCRIPTION
https://sandbox.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js returns a 503 error. In test mode, use also https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js


