### PR TITLE
Feature: add form id to multi step form template

### DIFF
--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepForm.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepForm.tsx
@@ -51,6 +51,7 @@ export default function StepForm({
             <DonationFormErrorBoundary>
                 <MultiStepFormTemplate
                     formProps={{
+                        id: 'give-next-gen',
                         className: 'givewp-layouts-multiStepForm__form',
                         onSubmit: handleSubmit((values: any) =>
                             handleSubmitRequest(


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Potentially resolves [GIVE-2091]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds the missing parity form ID `#give-next-gen` used by the classic form design to the multi-step form design.  The reason is there are several gateways[ targeting the submit button](https://github.com/search?q=org%3Aimpress-org%20%23give-next-gen&type=code) using this form ID, which will result in unexpected behavior on multi-step form designs.  

Although the `give-next-gen` ID was not intentionally supposed to be used this way, it's important to be consistent.  In the future, i'd like to revisit how we are targeting the submit button and offer a suggestion for gateways.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Multi-step enabled form designs & gateways targeting this ID (currently: paypal, blink, razorpay)

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/13124037939

**Let's QA a gateway like razorpay who is targeting the submit button this way**
- Setup a v3 form using 2 column layout / multi-step
- Make sure gateway goes through without any error about `scrollIntoView`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2091]: https://stellarwp.atlassian.net/browse/GIVE-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ