### PR TITLE
Fix: prevent donation details page fatal error

### DIFF
--- a/src/Campaigns/CampaignsAdminPage.php
+++ b/src/Campaigns/CampaignsAdminPage.php
@@ -52,6 +52,6 @@ class CampaignsAdminPage
      */
     public static function isShowingDetailsPage(): bool
     {
-        return isset($_GET['id']) && isset($_GET['page']) && 'give-campaigns' == isset($_GET['page']);
+        return isset($_GET['id'], $_GET['page']) && 'give-campaigns' === $_GET['page'];
     }
 }

--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -194,7 +194,7 @@ class DonationFormsAdminPage
         ];
 
         if (CampaignsAdminPage::isShowingDetailsPage()) {
-            $queryParameters['campaignId'] = absint($_GET['id']);
+            $queryParameters['campaignId'] = isset($_GET['id']) ? absint($_GET['id']) : null;
         }
 
         $request = WP_REST_Request::from_url(

--- a/src/DonationForms/V2/Endpoints/ListDonationForms.php
+++ b/src/DonationForms/V2/Endpoints/ListDonationForms.php
@@ -130,9 +130,11 @@ class ListDonationForms extends Endpoint
     {
         $this->request = $request;
         $this->listTable = give(DonationFormsListTable::class);
-        $this->defaultForm = $this->request->get_param('campaignId')
-            ? Campaign::find((int)$this->request->get_param('campaignId'))->defaultForm()->id
-            : 0;
+        $campaignId = (int)($this->request->get_param('campaignId'));
+        $campaign = $campaignId ? Campaign::find($campaignId) : null;
+        $defaultCampaignForm = $campaign ? $campaign->defaultForm() : null;
+
+        $this->defaultForm = $defaultCampaignForm->id ?? 0;
 
         $forms = $this->getForms();
         $totalForms = $this->getTotalFormsCount();
@@ -143,8 +145,6 @@ class ListDonationForms extends Endpoint
         } else {
             $this->listTable->items($forms, $this->request->get_param('locale') ?? '');
             $items = $this->listTable->getItems();
-
-            $defaultCampaignForm = ($campaignId = $this->request->get_param('campaignId')) ? Campaign::find($campaignId)->defaultForm() : false;
 
             foreach ($items as $i => &$item) {
                 $item['name'] = get_the_title($item['id']);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: [GIVE-2137]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes a fatal error on the donation details page.  The problem was our check for the campaign details page was returning true in cases it should not be.  So it was adding a campaignId to the request that was not correct. 

There was also some logic in the request itself that could have prevented a fatal error by conditionally checking params and model instances.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The donations list table & details page.
- The donation forms list table within a campaign page (should only show related forms)

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Original problem this fixes:

https://github.com/user-attachments/assets/d3b8449b-4fa3-4d8f-bdb8-dcf33803bcee


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a campaign and donate using the campaign form
- Navigate to the donations list and click on edit donation
- You should not be presented with any fatal errors

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2137]: https://stellarwp.atlassian.net/browse/GIVE-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ