### PR TITLE
Fix: Grid block does not show any Campaigns when the Campaign filter is used

### DIFF
--- a/src/Campaigns/Blocks/CampaignGrid/render.php
+++ b/src/Campaigns/Blocks/CampaignGrid/render.php
@@ -3,4 +3,4 @@
  * @var array $attributes
  */
 ?>
-<div data-givewp-campaign-grid data-attributes=<?= json_encode($attributes) ?>></div>
+<div data-givewp-campaign-grid data-attributes='<?= json_encode($attributes) ?>'></div>


### PR DESCRIPTION


## Description

This pull request includes a small change to the `src/Campaigns/Blocks/CampaignGrid/render.php` file. The change updates the `data-attributes` attribute to use single quotes around the JSON-encoded string for consistency and proper HTML attribute formatting.


## Affects

Campaigns Grid Block

## Testing Instructions

- Have at least one core campaign published.
- Create a page on the website.
- Add the Campaign Grid block to the page and add one or more campaigns to the “Filter by Campaign” setting.
- Save/Publish and view the page.

The campaign block should display the selected campaign

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

