### PR TITLE
Feature: add support for gateway transaction ID in the donations import tool

### DIFF
--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -400,6 +400,7 @@ function give_import_donations_options() {
 	/**
 	 * Filter to modify donations option in the import dropdown
 	 *
+	 * @unreleased Add gateway transaction id option
 	 * @since 1.8.13
 	 *
 	 * @return array
@@ -485,6 +486,11 @@ function give_import_donations_options() {
 				__( 'Payment Gateway', 'give' ),
 				__( 'Gateway', 'give' ),
 			],
+			'gateway_transaction_id' => [
+				__( 'Transaction ID', 'give' ),
+				__( 'Gateway Transaction ID', 'give' ),
+				__( 'Transaction Identifier', 'give' ),
+			],
 			'notes'        => __( 'Notes', 'give' ),
 			'mode'         => [
 				__( 'Payment Mode', 'give' ),
@@ -492,7 +498,7 @@ function give_import_donations_options() {
 				__( 'Test Mode', 'give' ),
 			],
 			'donor_ip'     => __( 'Donor IP Address', 'give' ),
-			'post_meta'    => __( 'Import as Meta', 'give' ),
+			'post_meta'    => __( 'Import as Meta', 'give' ),			
 		]
 	);
 }
@@ -817,7 +823,8 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 
 	/**
 	 * Filter to modify payment Data before getting imported.
-	 *
+	 * 
+	 * @unreleased Add gateway transaction id to payment data
 	 * @since 2.1.0
 	 *
 	 * @param array $payment_data payment data
@@ -879,6 +886,11 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 				// Insert Donor IP address.
 				if ( ! empty( $data['donor_ip'] ) ) {
 					$payment->update_meta( '_give_payment_donor_ip', $data['donor_ip'] );
+				}				
+
+				// Insert Transaction ID.
+				if ( ! empty( $data['gateway_transaction_id'] ) ) {
+					give_set_payment_transaction_id( $payment_id, $data['gateway_transaction_id'] );					
 				}
 
 				// Insert Notes.


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2620]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds support for a new Transaction ID column in the donations import tool. So now it is possible to add the transaction ID to CSV import files and map it in the column mapping step of the import tool.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The import donations tool.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![import-donations-tool-transaction-id-support](https://github.com/user-attachments/assets/855a0369-0b81-41ee-adfd-bfb13a67c96c)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a new campaign/form with this name: `Import Donation Tests`
2. Import the attached sample file with two donations 
3. Make sure the imported donations from the previous step have the proper transaction IDs: `ABC001` and `DEF002`

**Sample import file:** [donations-with-transaction-id.csv](https://github.com/user-attachments/files/21065373/donations-with-transaction-id.csv)



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2620]: https://stellarwp.atlassian.net/browse/GIVE-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ