### PR TITLE
Fix: PHP warning

### DIFF
--- a/src/DonationSpam/Akismet/DataTransferObjects/CommentCheckArgs.php
+++ b/src/DonationSpam/Akismet/DataTransferObjects/CommentCheckArgs.php
@@ -3,8 +3,10 @@
 namespace Give\DonationSpam\Akismet\DataTransferObjects;
 
 /**
+ * @unreleased add #[AllowDynamicProperties]
  * @since 3.15.0
  */
+#[\AllowDynamicProperties]
 class CommentCheckArgs
 {
     public $blog;


### PR DESCRIPTION

## Description

This pull request introduces a small change to the `CommentCheckArgs` data transfer object to improve compatibility with dynamic properties in PHP. The most important change is:

- Compatibility Improvement:
  * Added the `#[AllowDynamicProperties]` attribute to the `CommentCheckArgs` class to explicitly allow dynamic properties, addressing potential issues with newer PHP versions.
## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

