### PR TITLE
Fix: state hidden for Hungary

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -650,7 +650,6 @@ function give_get_country_locale() {
 			'HU' => [
 				'state' => [
 					'label'  => __( 'County', 'give' ),
-					'hidden' => true,
 				],
 			],
 			'ID' => [


### PR DESCRIPTION
If the default country is Hungary, or if the donor has a saved address in Hungary, the 'State' field (named 'County' for Hungary) is hidden. But it's required, and the form doesn't answer with this message in the console:

<img width="732" height="64" alt="image" src="https://github.com/user-attachments/assets/c0d493e0-24b7-411d-85d6-39bf742bdfe7" />

If the donor change the country, then comes back to Hungary, the field is visible.

If I remove this 'hidden' attribute, the 'County' field is display without having to change countries.
