### PR TITLE
'Netherlands Antilles' is replaced by 'Curaçao' since 2010

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -2333,6 +2333,7 @@ function give_get_spain_states_list() {
 		'CR' => esc_html__( 'Ciudad Real', 'give' ),
 		'CO' => esc_html__( 'C&oacute;rdoba', 'give' ),
 		'CU' => esc_html__( 'Cuenca', 'give' ),
+        'CW' => esc_html__( 'Curaçao', 'give' ),
 		'GI' => esc_html__( 'Girona', 'give' ),
 		'GR' => esc_html__( 'Granada', 'give' ),
 		'GU' => esc_html__( 'Guadalajara', 'give' ),


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Cura%C3%A7ao

I don't know if it's necessary to keep  'Netherlands Antilles' for donations with this country. 