### PR TITLE
Fix: Charge Refund For Stripe Payment Element

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/ChargeRefunded.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/ChargeRefunded.php
@@ -55,6 +55,7 @@ class ChargeRefunded extends StripeEventListener
     }
 
     /**
+     * @unreleased attempt with payment_intent for StripePaymentElement
      * @since 2.21.0
      * @inerhitDoc
      */
@@ -63,6 +64,9 @@ class ChargeRefunded extends StripeEventListener
         /* @var Charge $stripeCharge */
         $stripeCharge = $event->data->object;
 
-        return give(DonationRepository::class)->getByGatewayTransactionId($stripeCharge->id);
+        // Try payment_intent first,otherwise fall back to charge id
+        $transactionId = $stripeCharge->payment_intent ?: $stripeCharge->id;
+
+        return give(DonationRepository::class)->getByGatewayTransactionId($transactionId);
     }
 }


### PR DESCRIPTION
Resolves [GIVE-]
Reference: https://lw.slack.com/archives/C072VS4FT1A/p1759786010611019

## Description
When processing a refund event from Stripe, the webhook listener is attempting to locate the related donation using the charge_id. In some cases (e.g. one-time donations & subscriptions with Stripe Payment Element), this lookup is returning null, preventing the donation status from being updated to Refunded.

## Specific Problem
- When charge.refunded webhooks were received, they were routed directly to the legacy ChargeRefunded class
- The Payment Element ChargeRefunded class was hooked to `give_stripe_processing_charge_refunded` but this hook is not firing
- Double Processing: Both legacy and Payment Element listeners process the same event
- Inconsistent Logic: Legacy uses $stripeCharge->id, Payment Element uses $stripeCharge->payment_intent
 

This PR updates logic to first attempt resolving the donation using the payment_intent. Since payment_intent is consistently available across both one-time and subscription donations, this ensures refunds are correctly applied. If no donation is found with the payment_intent, the listener falls back to the existing charge_id check for compatibility with legacy flows.

## Affects
Stripe Payment Element Webhooks

## Visuals
https://github.com/user-attachments/assets/488cd1d0-be78-4bed-ba26-62b874b4f9da

## Testing Instructions
- Create one-time and subscription payments with Stripe Payment Element
- Attempt to Refund from the StripeDashboard after correctly setting up your account and webhook config
- Verify that the donation statuses have updated. - Can be viewed on the Donations List Table.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

