### PR TITLE
Fix: prevent batches with p2p campaigns

### DIFF
--- a/src/Campaigns/Migrations/CacheCampaignsData.php
+++ b/src/Campaigns/Migrations/CacheCampaignsData.php
@@ -53,6 +53,7 @@ class CacheCampaignsData extends BatchMigration implements ReversibleMigration
     /**
      * @inheritDoc
      *
+     * @unreleased add early return if no campaigns found
      * @since 4.8.0
      *
      * @throws DatabaseMigrationException
@@ -73,6 +74,10 @@ class CacheCampaignsData extends BatchMigration implements ReversibleMigration
             $campaignIds = array_map(function ($campaign) {
                 return $campaign->id;
             }, $campaigns);
+
+            if (empty($campaignIds)) {
+                return;
+            }
 
             $donations = CampaignsDataQuery::donations($campaignIds);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2927]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes an error that was happening in the `Cache campaign data` migration when the `runBatch` method was trying to perform a query with an empty where in statement, like in this sample:

`WHERE donation.post_status IN ('publish','give_subscription') AND campaignId.meta_value IN ()`

So, the first solution thought for this problem was just to add an earlier return in the  `runBatch` method when the `$campaignIds` is empty.

However, it would not fix the problem at the root source since the batches should not be created with the invalid campaign IDs. 

So, to solve it at the root source, we needed to update the `getBatchItemsAfter` to filter only core campaigns in the same way we are doing in the query method: 

https://github.com/impress-org/givewp/blob/f5828cbec475b47486d188e849a6e81fdd36acd3/src/Campaigns/Migrations/CacheCampaignsData.php#L48-L51

This way, we can ensure that the batches will be created only with valid campaign IDs (only core campaigns).

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Cache campaign data migration

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create 10 p2p campaigns or more
2. Create 2 core campaigns
3. Run the `Cache campaign data` migration and make sure it gets finished as expected.

**Recommended:** you can also check the Slack thread attached to the Jira task, where it is possible to get a website export that has the problem to test if the fix of this PR is working as expected there.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2927]: https://stellarwp.atlassian.net/browse/GIVE-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ