### PR TITLE
Fix: MCP server console errors with Angie v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/react-fontawesome": "^0.1.12",
                 "@givewp/design-system-foundation": "^1.2.0",
                 "@givewp/form-builder-library": "^1.7.1",
-                "@givewp/mcp-server": "^1.1.1",
+                "@givewp/mcp-server": "^2.0.1",
                 "@hookform/error-message": "^2.0.1",
                 "@hookform/resolvers": "^2.9.10",
                 "@paypal/paypal-js": "^8.2.0",
@@ -2058,9 +2058,9 @@
             }
         },
         "node_modules/@dotenvx/dotenvx": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.49.0.tgz",
-            "integrity": "sha512-M1cyP6YstFQCjih54SAxCqHLMMi8QqV8tenpgGE48RTXWD7vfMYJiw/6xcCDpS2h28AcLpTsFCZA863Ge9yxzA==",
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.51.0.tgz",
+            "integrity": "sha512-CbMGzyOYSyFF7d4uaeYwO9gpSBzLTnMmSmTVpCZjvpJFV69qYbjYPpzNnCz1mb2wIvEhjWjRwQWuBzTO0jITww==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "commander": "^11.1.0",
@@ -2911,17 +2911,17 @@
             }
         },
         "node_modules/@givewp/mcp-server": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@givewp/mcp-server/-/mcp-server-1.1.1.tgz",
-            "integrity": "sha512-YNe3KaXnWt0CgXM2pZJ0HQdvyzNLuIGO+4iBRv+/rgSXggnweWYt010uRMwJTxG9N1Wa+v60Tr9ffo/UtqrZyA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@givewp/mcp-server/-/mcp-server-2.0.1.tgz",
+            "integrity": "sha512-Nl7WaCM/CO6eTdWpka+iBVvc6WM925GFdQmIXyVv9TkIwLx1UZ5dufnQslrjHa+9IZh3x35qxzyTrIam7Tnb7w==",
             "license": "ISC",
             "dependencies": {
                 "@elementor/angie-sdk": "^1.0.2",
                 "@modelcontextprotocol/sdk": "1.17.4",
-                "@stellarwp/mcp-api-fetch": "^1.0.1",
-                "@stellarwp/mcp-logger": "^1.0.1",
-                "@stellarwp/mcp-node-config": "^1.0.1",
-                "@stellarwp/mcp-toolkit": "^1.0.1",
+                "@stellarwp/mcp-api-fetch": "^2.0.0",
+                "@stellarwp/mcp-logger": "^2.0.0",
+                "@stellarwp/mcp-node-config": "^2.0.0",
+                "@stellarwp/mcp-toolkit": "^2.0.0",
                 "zod": "^3.25.76"
             },
             "bin": {
@@ -6960,11 +6960,11 @@
             }
         },
         "node_modules/@stellarwp/mcp-api-fetch": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-api-fetch/-/mcp-api-fetch-1.0.1.tgz",
-            "integrity": "sha512-V544N4gtYl3sAoBqEU0/7cvspSs+9HNX9POZIF42pZD6tSlDOzDWQ7lUPaSoIyxJhTkpAdJHJSMcAZHm/iAoYQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-api-fetch/-/mcp-api-fetch-2.0.0.tgz",
+            "integrity": "sha512-wZri04zvCXJJAXd9oJKTVGOv0AQOBFoQL3xiJDi9cUMpLPOiXknQUFTj4MYSrJVaLLjVJmHo9zFAIH9TBUs0Dg==",
             "dependencies": {
-                "@stellarwp/mcp-node-config": "1.0.1",
+                "@stellarwp/mcp-node-config": "2.0.0",
                 "@wordpress/api-fetch": "^7.28.0",
                 "@wordpress/url": "^4.28.0"
             },
@@ -6973,9 +6973,9 @@
             }
         },
         "node_modules/@stellarwp/mcp-api-fetch/node_modules/@wordpress/url": {
-            "version": "4.30.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.30.0.tgz",
-            "integrity": "sha512-oFiQQBy/2G9fct1Df52ypu3d2nYiq2k2GkOdfMHRFYI1N3k0JP7rinwyePU+37mHPCzYuJK6TuMDxoKh8oMpKg==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.32.0.tgz",
+            "integrity": "sha512-B7Q6sKzBqSLUdQiW8oL69LFuky/IRrXDbBhPpOJruwV4l6eH6UhTlnY4QZYi1Ke91c/VJZRjUKx1fNWPJx5d9w==",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@babel/runtime": "7.25.7",
@@ -6993,28 +6993,31 @@
             "license": "MIT"
         },
         "node_modules/@stellarwp/mcp-logger": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-logger/-/mcp-logger-1.0.1.tgz",
-            "integrity": "sha512-0WxQ8XDtbqEFtJMPaZ45XYVmcGnod3L0O/Zhdj/mAkchhAmls0rrDex/q9SJUPslNLQVEk+HFKvS+19g3Xjnog==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-logger/-/mcp-logger-2.0.0.tgz",
+            "integrity": "sha512-A7AY16o1Kx84jMvvSm36v44C7/KWy7apPinsnfU/81Oh1tG2IXTS50OALGX7VpWn+ANMSVRpfB+OOA7SNLcfSg==",
             "dependencies": {
                 "pino": "^9.8.0",
                 "pino-pretty": "^13.1.1"
             }
         },
         "node_modules/@stellarwp/mcp-node-config": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-node-config/-/mcp-node-config-1.0.1.tgz",
-            "integrity": "sha512-MrwRArHzDtP1Pn1cQgpCqKQ6UuY8kAVaKqukOv+yMDX4ihnClBTRYP4othjY0YyIqnqq/2uQumwCOF/umjd5cg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-node-config/-/mcp-node-config-2.0.0.tgz",
+            "integrity": "sha512-QouTfcPOu2zZzwJYAY6S7IbpYcuRrkP5EclO8u+MpSFFULMDOk3vXGlp5kBysLEXmPHId5sTVKE2pXJKQlG5HQ==",
             "dependencies": {
                 "@dotenvx/dotenvx": "^1.48.4"
             }
         },
         "node_modules/@stellarwp/mcp-toolkit": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-toolkit/-/mcp-toolkit-1.0.1.tgz",
-            "integrity": "sha512-3iDuk4H0BDrtrt7222u0GHfYPU4v5oywakytXiKGwp7mkYIQtw/F9yrcIXIatpTx4Z6RLbL3ffp9I0Nvbj/8Dg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@stellarwp/mcp-toolkit/-/mcp-toolkit-2.0.0.tgz",
+            "integrity": "sha512-S6Dv7QdZfcgqJ9+QTjvI8JDI8dh/GE8c0rudMRco7q6bchdFYjK/9ttz/Ii8MDRemhTszgGTaTae8shQgUdKxw==",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "1.17.4"
+                "@modelcontextprotocol/sdk": "1.17.4",
+                "@stellarwp/mcp-api-fetch": "2.0.0",
+                "@stellarwp/mcp-logger": "2.0.0",
+                "@stellarwp/mcp-node-config": "2.0.0"
             }
         },
         "node_modules/@stripe/react-stripe-js": {
@@ -17204,9 +17207,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.2.2",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-            "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -17251,14 +17254,14 @@
             "dev": true
         },
         "node_modules/eciesjs": {
-            "version": "0.4.15",
-            "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
-            "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.16.tgz",
+            "integrity": "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw==",
             "license": "MIT",
             "dependencies": {
-                "@ecies/ciphers": "^0.2.3",
+                "@ecies/ciphers": "^0.2.4",
                 "@noble/ciphers": "^1.3.0",
-                "@noble/curves": "^1.9.1",
+                "@noble/curves": "^1.9.7",
                 "@noble/hashes": "^1.8.0"
             },
             "engines": {
@@ -18654,15 +18657,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
-        },
-        "node_modules/fast-redact": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
@@ -26027,13 +26021,12 @@
             }
         },
         "node_modules/pino": {
-            "version": "9.9.5",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-            "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+            "version": "9.13.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
+            "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
             "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.1.1",
                 "on-exit-leak-free": "^2.1.0",
                 "pino-abstract-transport": "^2.0.0",
                 "pino-std-serializers": "^7.0.0",
@@ -26041,6 +26034,7 @@
                 "quick-format-unescaped": "^4.0.3",
                 "real-require": "^0.2.0",
                 "safe-stable-stringify": "^2.3.1",
+                "slow-redact": "^0.3.0",
                 "sonic-boom": "^4.0.1",
                 "thread-stream": "^3.0.0"
             },
@@ -26058,9 +26052,9 @@
             }
         },
         "node_modules/pino-pretty": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.1.tgz",
-            "integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.2.tgz",
+            "integrity": "sha512-3cN0tCakkT4f3zo9RXDIhy6GTvtYD6bK4CRBLN9j3E/ePqN1tugAXD5rGVfoChW6s0hiek+eyYlLNqc/BG7vBQ==",
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.7",
@@ -28915,9 +28909,9 @@
             "dev": true
         },
         "node_modules/secure-json-parse": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
-            "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
             "funding": [
                 {
                     "type": "github",
@@ -29465,6 +29459,12 @@
             "engines": {
                 "node": ">=7.0.0"
             }
+        },
+        "node_modules/slow-redact": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+            "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+            "license": "MIT"
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "@fortawesome/react-fontawesome": "^0.1.12",
         "@givewp/design-system-foundation": "^1.2.0",
         "@givewp/form-builder-library": "^1.7.1",
-        "@givewp/mcp-server": "^1.1.1",
+        "@givewp/mcp-server": "^2.0.1",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^2.9.10",
         "@paypal/paypal-js": "^8.2.0",


### PR DESCRIPTION
## Description

Bumps the give-mcp server to [v2.0.1](https://github.com/impress-org/mcp-server/releases/tag/2.0.1) to fix console errors when running with Angie v1.0.1.

## Affects

- Angie and the Give MCP server.

## Visuals

No more errors
<img width="1397" height="526" alt="image" src="https://github.com/user-attachments/assets/b947c1dd-5dda-45b4-b796-aa3b3ec2ab9c" />


## Testing Instructions

1. Update to [Angie v1.0.1](https://wordpress.org/plugins/angie/#developers).
2. Use this build.
3. Verify the version in the console logs: 🌀 INFO (GiveWP MCP): Registered MCP Server v2.0.1 with Angie
4. View the browser console, you should not see any `Failed to register server` errors flooding the console.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

