### PR TITLE
Fix: Sort campaigns list table by revenue column

### DIFF
--- a/src/Campaigns/ListTable/Routes/GetCampaignsListTable.php
+++ b/src/Campaigns/ListTable/Routes/GetCampaignsListTable.php
@@ -5,6 +5,7 @@ namespace Give\Campaigns\ListTable\Routes;
 use Give\API\REST\V3\Routes\Campaigns\ValueObjects\CampaignRoute;
 use Give\API\RestRoute;
 use Give\Campaigns\ListTable\CampaignsListTable;
+use Give\Campaigns\ListTable\Columns\RevenueColumn;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\Campaigns\Repositories\CampaignsDataRepository;
@@ -90,12 +91,15 @@ class GetCampaignsListTable implements RestRoute
     }
 
     /**
+     * @unreleased add support for sorting by revenue column
      * @since 4.0.0
      */
     public function handleRequest(WP_REST_Request $request): WP_REST_Response
     {
         $this->request = $request;
         $this->listTable = give(CampaignsListTable::class);
+        $sortColumns = $this->listTable->getSortColumnById($request->get_param('sortColumn') ?: 'id');
+        $sortDirection = $request->get_param('sortDirection') ?: 'desc';
 
         $campaignsCount = $this->getTotalCampaignsCount();
 
@@ -118,6 +122,15 @@ class GetCampaignsListTable implements RestRoute
 
         $campaignsData = CampaignsDataRepository::campaigns($ids);
 
+        // Sort by revenue column
+        if (in_array(RevenueColumn::getId(), $sortColumns)) {
+            usort($campaigns, function(Campaign $a, Campaign $b) use ($campaignsData, $sortDirection) {
+                return $sortDirection === 'asc'
+                    ? $campaignsData->getRevenue($a) <=> $campaignsData->getRevenue($b)
+                    : $campaignsData->getRevenue($b) <=> $campaignsData->getRevenue($a);
+            });
+        }
+
         $this->listTable
             ->setData($campaignsData)
             ->items($campaigns, $this->request->get_param('locale') ?? '');
@@ -138,6 +151,7 @@ class GetCampaignsListTable implements RestRoute
     }
 
     /**
+     * @unreleased remove revenue column from sort
      * @since 4.0.0
      */
     public function getCampaigns(): array
@@ -151,6 +165,10 @@ class GetCampaignsListTable implements RestRoute
         $query = $this->getWhereConditions($query);
 
         foreach ($sortColumns as $sortColumn) {
+            if (RevenueColumn::getId() === $sortColumn) {
+                continue;
+            }
+
             $query->orderBy($sortColumn, $sortDirection);
         }
 


### PR DESCRIPTION

## Description

This pull request adds support for sorting campaigns by the revenue column in the campaigns list table API endpoint. It introduces logic to handle sorting by revenue directly in the response, while ensuring that revenue is not used in the database query sort to avoid issues with non-database fields.


## Affects

Campaigns list table endpoint

## Visuals

https://github.com/user-attachments/assets/cca68abb-8398-450d-a237-90456b0fa65f


<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Navigate to the campaigns list table and try to sort by the revenue column 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

