### PR TITLE
Fix: campaign stats error handling

### DIFF
--- a/src/API/REST/V3/Routes/Campaigns/GetCampaignStatistics.php
+++ b/src/API/REST/V3/Routes/Campaigns/GetCampaignStatistics.php
@@ -53,6 +53,7 @@ class GetCampaignStatistics implements RestRoute
     }
 
     /**
+     * @unreleased return 404 error if campaign is not found
      * @since 4.0.0
      *
      * @throws Exception
@@ -60,6 +61,10 @@ class GetCampaignStatistics implements RestRoute
     public function handleRequest($request): WP_REST_Response
     {
         $campaign = Campaign::find($request->get_param('id'));
+
+        if (!$campaign) {
+            return new WP_REST_Response('Campaign not found', 404);
+        }
 
         $query = new CampaignDonationQuery($campaign);
 


### PR DESCRIPTION

## Description
This pull request improves the error handling in the campaign statistics API endpoint by ensuring that a 404 error is returned when a campaign is not found, instead of proceeding with a null campaign object.

Error handling improvements:


## Affects
campaign stats endpoint

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

