### PR TITLE
Fix: prevent shared donations list table from breaking page

### DIFF
--- a/src/Donations/resources/components/DonationRowActions.tsx
+++ b/src/Donations/resources/components/DonationRowActions.tsx
@@ -2,23 +2,18 @@ import {useContext} from 'react';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {__, sprintf} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';
-import { store as coreDataStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
 import { useSWRConfig } from 'swr';
-import ListTableApi from '@givewp/components/ListTable/api';
-
-const donationsApi = new ListTableApi(window.GiveDonations);
 
 /**
  * @unreleased Revert delete action to use Donation Actions API and add trash and restore actions.
  * @since 4.6.0 Soft delete donations with Donation v3 API.
  */
-export const DonationRowActions = ({item, removeRow, setUpdateErrors, parameters}) => {
+export const DonationRowActions = ({item, removeRow, setUpdateErrors, parameters, listTableApi}) => {
     const showConfirmModal = useContext(ShowConfirmModalContext);
     const {mutate} = useSWRConfig();
 
     const fetchAndUpdateErrors = async (parameters, endpoint, id, method) => {
-        const response = await donationsApi.fetchWithArgs(endpoint, {ids: [id]}, method);
+        const response = await listTableApi.fetchWithArgs(endpoint, {ids: [id]}, method);
         setUpdateErrors(response);
         await mutate(parameters);
         return response;

--- a/src/Views/Components/ListTable/ListTable/index.tsx
+++ b/src/Views/Components/ListTable/ListTable/index.tsx
@@ -20,7 +20,7 @@ export interface ListTableProps {
     //optional
     pluralName?: string;
     singleName?: string;
-    rowActions?: (({item, data, addRow, removeRow}) => JSX.Element) | JSX.Element | JSX.Element[] | Function | null;
+    rowActions?: (({item, data, addRow, removeRow, listTableApi}) => JSX.Element) | JSX.Element | JSX.Element[] | Function | null;
     parameters?: {};
     error?: {} | Boolean;
     isLoading?: Boolean;
@@ -201,6 +201,7 @@ export const ListTable = ({
                         <tbody className={styles.tableContent}>
                             {productRecommendation}
                             <ListTableRows
+                                apiSettings={apiSettings}
                                 columns={visibleColumns}
                                 data={data}
                                 isLoading={isLoading}

--- a/src/Views/Components/ListTable/ListTableRows/index.tsx
+++ b/src/Views/Components/ListTable/ListTableRows/index.tsx
@@ -5,8 +5,9 @@ import {useEffect, useState} from 'react';
 import TableCell from '../TableCell';
 import {BulkActionCheckbox} from '@givewp/components/ListTable/BulkActions/BulkActionCheckbox';
 import InterweaveSSR from '@givewp/components/ListTable/InterweaveSSR';
+import ListTableApi from '@givewp/components/ListTable/api';
 
-export default function ListTableRows({columns, data, isLoading, rowActions, setUpdateErrors, parameters, singleName, columnFilters, includeBulkActionsCheckbox = false, tableId}) {
+export default function ListTableRows({columns, data, isLoading, rowActions, setUpdateErrors, parameters, singleName, columnFilters, includeBulkActionsCheckbox = false, tableId, apiSettings}) {
     const [removed, setRemoved] = useState([]);
     const [added, setAdded] = useState([]);
 
@@ -91,6 +92,7 @@ export default function ListTableRows({columns, data, isLoading, rowActions, set
                                         addRow,
                                         setUpdateErrors,
                                         parameters,
+                                        listTableApi: new ListTableApi(apiSettings),
                                     })}
                                 </div>
                             )}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The donations list table is being shared on the subscription details page, however it was referencing the donation page window object.  This fixes that by abstracting the listTableApi into a prop.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The list table component

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the list tables all load and the subscription details page loads properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

