### PR TITLE
MCP: Bump @givewp/mcp-server v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/react-fontawesome": "^0.1.12",
                 "@givewp/design-system-foundation": "^1.2.0",
                 "@givewp/form-builder-library": "^1.7.1",
-                "@givewp/mcp-server": "^2.0.1",
+                "@givewp/mcp-server": "^2.0.2",
                 "@hookform/error-message": "^2.0.1",
                 "@hookform/resolvers": "^2.9.10",
                 "@paypal/paypal-js": "^8.2.0",
@@ -2911,9 +2911,9 @@
             }
         },
         "node_modules/@givewp/mcp-server": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@givewp/mcp-server/-/mcp-server-2.0.1.tgz",
-            "integrity": "sha512-Nl7WaCM/CO6eTdWpka+iBVvc6WM925GFdQmIXyVv9TkIwLx1UZ5dufnQslrjHa+9IZh3x35qxzyTrIam7Tnb7w==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@givewp/mcp-server/-/mcp-server-2.0.2.tgz",
+            "integrity": "sha512-djURaw9L5Ol0lbMlt7VBP8Xe7yLMxiHXrkd98ST01S4nzaG+UD8VsZCP6zsa3Sgl+hqVuI4GqGWCv2i78LWy2g==",
             "license": "ISC",
             "dependencies": {
                 "@elementor/angie-sdk": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "@fortawesome/react-fontawesome": "^0.1.12",
         "@givewp/design-system-foundation": "^1.2.0",
         "@givewp/form-builder-library": "^1.7.1",
-        "@givewp/mcp-server": "^2.0.1",
+        "@givewp/mcp-server": "^2.0.2",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^2.9.10",
         "@paypal/paypal-js": "^8.2.0",


### PR DESCRIPTION
### Main Changes

- Updates the MCP Server to [v2.0.2](https://github.com/impress-org/mcp-server/releases/tag/2.0.2), which shortens the server title which Angie 1.0.2 now uses to display in the tools listing.

<img width="367" height="431" alt="image" src="https://github.com/user-attachments/assets/3f68e86a-9b12-48a9-a4b7-d614892798e7" />
