### PR TITLE
Fix: generate campaign cache on campaign merge

### DIFF
--- a/src/Campaigns/Actions/CacheCampaignData.php
+++ b/src/Campaigns/Actions/CacheCampaignData.php
@@ -12,6 +12,7 @@ use Give\Donations\Models\Donation;
  * @uses give_insert_payment hook
  * @uses give_update_payment_status hook
  * @uses give_recurring_add_subscription_payment hook
+ * @uses givewp_campaigns_merged hook
  *
  * Action used to update campaign's stats data
  *
@@ -19,6 +20,7 @@ use Give\Donations\Models\Donation;
 class CacheCampaignData
 {
     /**
+     * @unreleased added dispatch method
      * @since 4.8.0
      */
     public function __invoke(int $donationId): void
@@ -30,9 +32,17 @@ class CacheCampaignData
         }
 
         if ($donation->status->isComplete() || $donation->status->isRenewal()) {
-            as_enqueue_async_action('givewp_cache_campaign_data', [$donation->campaignId], 'givewp_campaigns_cache');
+            $this->dispatch($donation->campaignId);
         }
+    }
 
+    /**
+     * Dispatch the cache campaign data action
+     * @unreleased
+     */
+    public function dispatch(int $campaignId): void
+    {
+        as_enqueue_async_action('givewp_cache_campaign_data', [$campaignId], 'givewp_campaigns_cache');
     }
 
     /**

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -27,6 +27,7 @@ use Give\Campaigns\Migrations\RevenueTable\AddIndexes;
 use Give\Campaigns\Migrations\RevenueTable\AssociateDonationsToCampaign;
 use Give\Campaigns\Migrations\Tables\CreateCampaignFormsTable;
 use Give\Campaigns\Migrations\Tables\CreateCampaignsTable;
+use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\Campaigns\ValueObjects\CampaignPageMetaKeys;
 use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
@@ -254,6 +255,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased added givewp_campaigns_merged hook
      * @since 4.8.0
      */
     private function registerCampaignCache(): void
@@ -268,5 +270,9 @@ class ServiceProvider implements ServiceProviderInterface
         add_action('give_recurring_add_subscription_payment', function (Give_Payment $legacyPayment) {
             give(CacheCampaignData::class)((int)$legacyPayment->ID);
         }, 11, 1);
+
+        add_action('givewp_campaigns_merged', function (Campaign $campaign) {
+            give(CacheCampaignData::class)->dispatch($campaign->id);
+        });
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-3003]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates our campaign cache to be triggered when campaigns have been merged.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Campaign merge

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
ZIP: https://github.com/impress-org/givewp/actions/runs/19299555577

- Create a few campaigns with amount goals and generate donations for each of them
- Merge campaigns into one
- Check the scheduled actions tab to make sure the action for campaign cache has been scheduled
- After the job is complete, check the campaign list table to see the updated goal value of the destination campaign

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-3003]: https://stellarwp.atlassian.net/browse/GIVE-3003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ