### PR TITLE
Fix: Resolve GiftAid and Company field conflict

### DIFF
--- a/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
+++ b/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
@@ -49,7 +49,7 @@ function getJoiRulesForField(field: Field): AnySchema {
 }
 
 /**
- * @unreleased add support for object rules
+ * @unreleased account for custom rules with only excludeUnless property
  * @since 4.13.0 add support for optional false values
  * @since 3.0.0
  */


### PR DESCRIPTION
Resolves [GIVE-2764]

## Description

This PR fixes a validation conflict between the `GiftAid` and `Company` fields. The issue occurred because `GiftAid` has conditional visibility based on the `Company` field (if `Company` is required or not empty, `GiftAid` must not be shown). When a field has conditional visibility rules and the referenced field (`Company`) is present in the form, an `ExcludeUnless` property is automatically added to that field's validation rules.

In `ConvertFieldAPIRulesToJoi.ts`, fields with no rules receive an "any" type. However, because of the `ExcludeUnless` property, the `GiftAid` field was being processed through the rest of the validation function and was incorrectly validated as a string. When the opted-out value was passed (which was not an empty string), it failed the required validation.

To fix this, we've updated the validation logic to check if a field has only the `excludeUnless` property (and no other validation rules). In such cases, the field now returns `Joi.any()` immediately, preventing it from being incorrectly processed through the string validation logic. This ensures that fields like `GiftAid` (which are object/array types) are not validated as strings when they only have conditional visibility rules.

## Affects

- Frontend validation: Updated `ConvertFieldAPIRulesToJoi.ts` to handle fields with only `excludeUnless` rules properly
- GiftAid add-on compatibility: This change enables proper validation for object-type fields like GiftAid that have conditional visibility

## Visuals
No visual changes - this is a backend validation fix.

## Testing Instructions
   - Create a donation form with both Company and GiftAid fields
   - Fill out the donation form without checking the GiftAid checkbox
   - Submit the form - it should submit successfully without validation errors
   - Reload the donation form
   - Verify that when GiftAid is checked, the field data is properly validated on submission

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2764]: https://stellarwp.atlassian.net/browse/GIVE-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ