### PR TITLE
Fix: Resolve Donor Details page conflict between legacy and new views

### DIFF
--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -9,6 +9,7 @@
  * @since       1.0
  */
 
+use Give\Donors\DonorsAdminPage;
 use Give\Donors\Models\Donor;
 use Give\Helpers\IntlTelInput;
 
@@ -111,10 +112,15 @@ function give_get_format_address( $address, $address_args = array() ) {
  *
  * Renders the donors page contents.
  *
+ * @unreleased add early return if showing new details page
  * @since  1.0
  * @return void
  */
 function give_donors_page() {
+    if (DonorsAdminPage::isShowingNewDetailsPage()) {
+        return;
+    }
+
 	$default_views  = give_donor_views();
 	$requested_view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'donors';
 	if ( array_key_exists( $requested_view, $default_views ) && function_exists( $default_views[ $requested_view ] ) ) {

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -39,7 +39,7 @@ class DonorsAdminPage
         if (self::isShowingDetailsPage()) {
             $donor = Donor::find(absint($_GET['id']));
 
-            if ( ! $donor) {
+            if (! $donor) {
                 wp_die(__('Donor not found', 'give'), 404);
             }
 
@@ -99,6 +99,14 @@ class DonorsAdminPage
     public static function isShowingDetailsPage(): bool
     {
         return isset($_GET['id'], $_GET['page']) && 'give-donors' === $_GET['page'];
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function isShowingNewDetailsPage(): bool
+    {
+        return self::isShowingDetailsPage() && isset($_GET['view']) && $_GET['view'] === 'overview';
     }
 
     /**

--- a/src/Donors/ServiceProvider.php
+++ b/src/Donors/ServiceProvider.php
@@ -25,7 +25,6 @@ use Give_Donor as LegacyDonor;
  */
 class ServiceProvider implements ServiceProviderInterface
 {
-
     /**
      * @inheritDoc
      */
@@ -49,8 +48,8 @@ class ServiceProvider implements ServiceProviderInterface
     public function boot()
     {
         $userId = get_current_user_id();
-        $showLegacy = get_user_meta($userId, '_give_donors_archive_show_legacy', true);
-        // only register new admin page if user hasn't chosen to use the old one
+        $showLegacy = DonorsAdminPage::isShowingNewDetailsPage() ? false : get_user_meta($userId, '_give_donors_archive_show_legacy', true);
+        // only register new admin page if user hasn't chosen to use the old one or is trying to access the new donor details page
         if (empty($showLegacy)) {
             Hooks::addAction('admin_menu', DonorsAdminPage::class, 'registerMenuItem', 30);
         } elseif (DonorsAdminPage::isShowing()) {


### PR DESCRIPTION
## Description

This PR adds support for the new React-based donor details overview page and prevents the legacy PHP page from rendering when the new view is active.

**Changes:**
- Added `isShowingNewDetailsPage()` method to `DonorsAdminPage` class to detect when the new overview page is being shown (when `view=overview` parameter is present)
- Updated `give_donors_page()` function to early return if the new details page is showing, preventing the legacy PHP page from rendering
- Updated `ServiceProvider` to check for the new details page before checking user meta preferences, ensuring the new view takes precedence

This ensures the React-based donor details page renders correctly without interference from the legacy PHP implementation.

## Affects

- **Donor Details Page**: When accessing a donor details page with `view=overview` parameter, the legacy PHP page will no longer render, allowing the React component to handle the display
- **Legacy Compatibility**: Users who prefer the legacy view (via user meta preference) are unaffected when not using the new overview view

## Visuals

_No visual changes - this is a backend routing/logic change that prevents page conflicts._

## Testing Instructions

1. Navigate to a donor details page with the new overview view: `wp-admin/edit.php?post_type=give_forms&page=give-donors&id={donor_id}&view=overview`
2. Verify the React-based donor details page renders correctly without the legacy PHP page interfering
3. Verify legacy donor pages still work when `view=overview` is not present
4. Verify users with legacy preference enabled can still access the legacy view when not using the new overview parameter

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

