### PR TITLE
Refactor: tweak public data display logic for REST API V3 endpoints

### DIFF
--- a/src/API/REST/V3/Routes/Donations/ViewModels/DonationViewModel.php
+++ b/src/API/REST/V3/Routes/Donations/ViewModels/DonationViewModel.php
@@ -10,6 +10,7 @@ use Give\EventTickets\Repositories\EventTicketRepository;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Types;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+use Give\Framework\Support\Facades\Str;
 
 /**
  * @since 4.6.0
@@ -79,7 +80,7 @@ class DonationViewModel
             foreach ($sensitiveDataExcluded as $propertyName) {
                 switch ($propertyName) {
                     case 'lastName':
-                        $data[$propertyName] = substr($data[$propertyName], 0, 1);
+                        $data[$propertyName] = Str::substr($data[$propertyName], 0, 1);
                         break;
                     case 'billingAddress':
                         $data[$propertyName] = null;

--- a/src/API/REST/V3/Routes/Donors/ViewModels/DonorViewModel.php
+++ b/src/API/REST/V3/Routes/Donors/ViewModels/DonorViewModel.php
@@ -8,6 +8,7 @@ use Give\DonationForms\Repositories\DonationFormRepository;
 use Give\Donors\Models\Donor;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Types;
+use Give\Framework\Support\Facades\Str;
 
 /**
  * @unreleased Move from Give\Donors\ViewModels to API REST V3 namespace
@@ -81,10 +82,10 @@ class DonorViewModel
             foreach ($sensitiveDataExcluded as $propertyName) {
                 switch ($propertyName) {
                     case 'name':
-                        $data[$propertyName] = $data['firstName'] . ' ' . substr($data['lastName'], 0, 1);
+                        $data[$propertyName] = $data['firstName'] . ' ' . Str::substr($data['lastName'], 0, 1);
                         break;
                     case 'lastName':
-                        $data[$propertyName] = substr($data[$propertyName], 0, 1);
+                        $data[$propertyName] = Str::substr($data[$propertyName], 0, 1);
                         break;
                     case 'additionalEmails':
                     case 'customFields':

--- a/src/Subscriptions/ViewModels/SubscriptionViewModel.php
+++ b/src/Subscriptions/ViewModels/SubscriptionViewModel.php
@@ -5,6 +5,7 @@ namespace Give\Subscriptions\ViewModels;
 use Give\API\REST\V3\Routes\Donors\ValueObjects\DonorAnonymousMode;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+use Give\Framework\Support\Facades\Str;
 use Give\Subscriptions\Models\Subscription;
 
 /**
@@ -76,7 +77,7 @@ class SubscriptionViewModel
             foreach ($sensitiveDataExcluded as $propertyName) {
                 switch ($propertyName) {
                     case 'lastName':
-                        $data[$propertyName] = substr($data[$propertyName], 0, 1);
+                        $data[$propertyName] = Str::substr($data[$propertyName], 0, 1);
                         break;
                     default:
                         $data[$propertyName] = '';

--- a/tests/Unit/API/REST/V3/Routes/Donations/GetDonationRouteTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/GetDonationRouteTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Give\API\REST\V3\Routes\Donations\ValueObjects\DonationRoute;
 use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\Support\Facades\Str;
 use Give\Tests\RestApiTestCase;
 use Give\Tests\TestTraits\HasDefaultWordPressUsers;
 use Give\Tests\TestTraits\RefreshDatabase;
@@ -147,7 +148,7 @@ class GetDonationRouteTest extends RestApiTestCase
         $this->assertNotContains('transactionUrl', $data['gateway']);
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($donation->lastName, 0, 1), $data['lastName']);
+        $this->assertEquals(Str::substr($donation->lastName, 0, 1), $data['lastName']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Donations/GetDonationsRouteTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/GetDonationsRouteTest.php
@@ -11,6 +11,7 @@ use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Donations\ValueObjects\DonationMode;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Donors\Models\Donor;
+use Give\Framework\Support\Facades\Str;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -136,7 +137,7 @@ class GetDonationsRouteTest extends RestApiTestCase
         $this->assertNotContains('transactionUrl', $data[0]['gateway']);
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($donation->lastName, 0, 1), $data[0]['lastName']);
+        $this->assertEquals(Str::substr($donation->lastName, 0, 1), $data[0]['lastName']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetCollectionTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetCollectionTest.php
@@ -11,6 +11,7 @@ use Give\Donations\ValueObjects\DonationMode;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Donors\Models\Donor;
 use Give\Framework\Database\DB;
+use Give\Framework\Support\Facades\Str;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\Tests\RestApiTestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
@@ -177,10 +178,10 @@ class DonorRouteGetCollectionTest extends RestApiTestCase
         $this->assertEmpty(array_intersect_key($data[0], $sensitiveProperties));
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($donor->lastName, 0, 1), $data[0]['lastName']);
+        $this->assertEquals(Str::substr($donor->lastName, 0, 1), $data[0]['lastName']);
 
         // name should return the full name and the first letter of the last name
-        $this->assertEquals($donor->firstName . ' ' . substr($donor->lastName, 0, 1), $data[0]['name']);
+        $this->assertEquals($donor->firstName . ' ' . Str::substr($donor->lastName, 0, 1), $data[0]['name']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetTest.php
@@ -9,6 +9,7 @@ use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Donations\ValueObjects\DonationMode;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Donors\Models\Donor;
+use Give\Framework\Support\Facades\Str;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -296,10 +297,10 @@ class DonorRouteGetTest extends RestApiTestCase
         $this->assertEmpty(array_intersect_key($data, $sensitiveProperties));
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($donor->lastName, 0, 1), $data['lastName']);
+        $this->assertEquals(Str::substr($donor->lastName, 0, 1), $data['lastName']);
 
         // name should return the full name and the first letter of the last name
-        $this->assertEquals($donor->firstName . ' ' . substr($donor->lastName, 0, 1), $data['name']);
+        $this->assertEquals($donor->firstName . ' ' . Str::substr($donor->lastName, 0, 1), $data['name']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemTest.php
@@ -8,6 +8,7 @@ use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Models\DonationForm;
 use Give\Donors\Models\Donor;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
+use Give\Framework\Support\Facades\Str;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -187,7 +188,7 @@ class SubscriptionRouteGetItemTest extends RestApiTestCase
         $this->assertNotContains('subscriptionUrl', $data['gateway']);
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($subscription->donor()->get()->lastName, 0, 1), $data['lastName']);
+        $this->assertEquals(Str::substr($subscription->donor()->get()->lastName, 0, 1), $data['lastName']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemsTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemsTest.php
@@ -9,6 +9,7 @@ use Give\Campaigns\Models\Campaign;
 use Give\Donors\Models\Donor;
 use Give\Framework\Database\DB;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
+use Give\Framework\Support\Facades\Str;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -148,7 +149,7 @@ class SubscriptionRouteGetItemsTest extends RestApiTestCase
         $this->assertNotContains('subscriptionUrl', $data[0]['gateway']);
 
         // lastName should return only the first letter when sensitive data is not included
-        $this->assertEquals(substr($subscription->donor()->get()->lastName, 0, 1), $data[0]['lastName']);
+        $this->assertEquals(Str::substr($subscription->donor()->get()->lastName, 0, 1), $data[0]['lastName']);
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-3022]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR enhances discrete visibility across the Donations, Donors, and Subscriptions REST APIs by improving how certain data is handled when `includeSensitiveData` is `false`. Certain information is now properly redacted or excluded from API responses for non-admin users.

### Donations API
- **Last Name Abbreviation**: `lastName` now returns only the first letter instead of being completely removed
- **Gateway Transaction ID Protection**: Added `gatewayTransactionId` to sensitive data exclusion list
- **Transaction URL Exclusion**: `transactionUrl` is excluded from gateway details when sensitive data is not included

### Donors API
- **Last Name Abbreviation**: `lastName` now returns only the first letter
- **Name Field Update**: `name` field now uses `firstName + ' ' + first letter of lastName` format

### Subscriptions API
- **Last Name Abbreviation**: `lastName` now returns only the first letter
- **Subscription URL Exclusion**: `subscriptionUrl` is excluded from gateway details when sensitive data is not included

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `src/API/REST/V3/Routes/Donations/ViewModels/DonationViewModel.php`
- `src/API/REST/V3/Routes/Donors/ViewModels/DonorViewModel.php`
- `src/Subscriptions/ViewModels/SubscriptionViewModel.php`
- `tests/Unit/API/REST/V3/Routes/Donations/GetDonationRouteTest.php`
- `tests/Unit/API/REST/V3/Routes/Donations/GetDonationsRouteTest.php`
- `tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetCollectionTest.php`
- `tests/Unit/API/REST/V3/Routes/Donors/DonorRouteGetTest.php`
- `tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemTest.php`
- `tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemsTest.php`

### Breaking Changes

⚠️ **None** - This is a visibility enhancement. The API behavior only changes when `includeSensitiveData` is not set or `false`, which is the default for non-admin users.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

### For Devs

Run the unit tests to verify all changes:

```bash
composer test -- --filter testGetDonorShouldNotIncludeSensitiveData
composer test -- --filter testGetDonorsShouldNotIncludeSensitiveData

composer test -- --filter testGetDonationShouldNotIncludeSensitiveData
composer test -- --filter testGetDonationsShouldNotIncludeSensitiveData

composer test -- --filter testGetSubscriptionShouldNotIncludeSensitiveData
composer test -- --filter testGetSubscriptionsShouldNotIncludeSensitiveData
```

**Expected Results:**
- ✅ `lastName` returns only first letter when `includeSensitiveData=false`
- ✅ Gateway URLs (`transactionUrl`, `subscriptionUrl`) are excluded when sensitive data is not included
- ✅ Sensitive IDs (`gatewayTransactionId`, `gatewaySubscriptionId`) are excluded when sensitive data is not included
- ✅ All existing functionality remains intact for admin users with `includeSensitiveData=true`

### For QA

Make sure all admin screens for Donors, Donations, and Subscriptions keep displaying all information.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-3022]: https://stellarwp.atlassian.net/browse/GIVE-3022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ